### PR TITLE
Fix parse errors in non-interpolating sigil heredocs (e.g. ~S""")

### DIFF
--- a/src/org/elixir_lang/ElixirFlexLexer.java
+++ b/src/org/elixir_lang/ElixirFlexLexer.java
@@ -1850,9 +1850,16 @@ public class ElixirFlexLexer implements FlexLexer {
             }
             // fall through
           case 271: break;
-          case 82:
-            { pushAndBegin(ESCAPE_SEQUENCE);
-                     return ElixirTypes.ESCAPE;
+            case 82: {
+                // Hotfix: non-interpolating sigil heredocs (e.g. ~S""") should not enter ESCAPE_SEQUENCE
+                // This breaks in [regex.ex](https://github.com/elixir-lang/elixir/blob/v1.16/lib/elixir/lib/regex.ex#L50) in Elixir 1.16+,
+                // causing completion, highlighting, etc, to not work, throwing error.
+                if (isInterpolating()) {
+                    pushAndBegin(ESCAPE_SEQUENCE);
+                    return ElixirTypes.ESCAPE;
+                } else {
+                    return ElixirTypes.FRAGMENT;
+                }
             }
             // fall through
           case 272: break;
@@ -2375,8 +2382,14 @@ public class ElixirFlexLexer implements FlexLexer {
             // lookahead expression with fixed base length
             zzMarkedPos = Character.offsetByCodePoints
                 (zzBufferL/*, zzStartRead, zzEndRead - zzStartRead*/, zzStartRead, 1);
-            { yybegin(GROUP_HEREDOC_LINE_ESCAPED_EOL);
-                     return ElixirTypes.ESCAPE;
+          {
+              // Hotfix: non-interpolating sigil heredocs (e.g. ~S""") should not enter ESCAPE_SEQUENCE
+              if (isInterpolating()) {
+                  yybegin(GROUP_HEREDOC_LINE_ESCAPED_EOL);
+                  return ElixirTypes.ESCAPE;
+              } else {
+                  return ElixirTypes.FRAGMENT;
+              }
             }
             // fall through
           case 338: break;

--- a/tests/org/elixir_lang/elixir_flex_lexer/group_heredoc_line_body/LiteralSigilHeredocTest.java
+++ b/tests/org/elixir_lang/elixir_flex_lexer/group_heredoc_line_body/LiteralSigilHeredocTest.java
@@ -1,0 +1,53 @@
+package org.elixir_lang.elixir_flex_lexer.group_heredoc_line_body;
+
+import com.intellij.psi.tree.IElementType;
+import org.elixir_lang.ElixirFlexLexer;
+import org.elixir_lang.elixir_flex_lexer.TokenTest;
+import org.elixir_lang.psi.ElixirTypes;
+import org.jetbrains.annotations.NotNull;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Tests that non-interpolating sigil heredocs ({@code ~S"""}) treat escape sequences and interpolation starts as
+ * literal {@code FRAGMENT} tokens instead of entering {@code ESCAPE_SEQUENCE} or {@code INTERPOLATION} states.
+ *
+ * @see InterpolationTest for the interpolating counterpart
+ */
+@RunWith(Parameterized.class)
+public class LiteralSigilHeredocTest extends TokenTest {
+
+    public LiteralSigilHeredocTest(CharSequence charSequence, IElementType tokenType, int lexicalState) {
+        super(charSequence, tokenType, lexicalState);
+    }
+
+    @Parameterized.Parameters(
+            name = "\"{0}\" parses as {1} token and advances to state {2}"
+    )
+    public static Collection<Object[]> generateData() {
+        return Arrays.asList(
+                new Object[][]{
+                        { "#{", ElixirTypes.FRAGMENT, ElixirFlexLexer.GROUP_HEREDOC_LINE_BODY },
+                        { "\\", ElixirTypes.FRAGMENT, ElixirFlexLexer.GROUP_HEREDOC_LINE_BODY }
+                }
+        );
+    }
+
+    @Override
+    protected void start(@NotNull CharSequence charSequence) {
+        // ~S""" is a non-interpolating sigil heredoc
+        CharSequence fullCharSequence = "~S\"\"\"\n" + charSequence;
+        super.start(fullCharSequence);
+        // consume '~'
+        lexer.advance();
+        // consume 'S'
+        lexer.advance();
+        // consume '"""'
+        lexer.advance();
+        // consume '\n'
+        lexer.advance();
+    }
+}


### PR DESCRIPTION
Noticed a problem where `Regex.` wouldn't autocomplete in Elixir 1.16+, as the documentation changed in [regex.ex](https://github.com/elixir-lang/elixir/blob/v1.16/lib/elixir/lib/regex.ex#L50) to have this line:

```ex
* `\x{hhh..}` - Character with hex code hhh..
```

Opening regex.ex showed:
<img width="1338" height="847" alt="broken" src="https://github.com/user-attachments/assets/3bc622c1-721d-49aa-bb23-5e768e7351a6" />

I've hotfixed ElixirFlexLexer.java, which has been done in the past, with the goal to upgrade to support Elixir 1.19+ ASAP.

It now renders nicely:

<img width="975" height="575" alt="fixed" src="https://github.com/user-attachments/assets/20a481df-48d3-4d0b-8ab4-761584d26e9c" />

And autocomplete works again:

<img width="709" height="456" alt="fixed_ac" src="https://github.com/user-attachments/assets/011258f0-c4d3-4f80-b985-bba22942553f" />


## tl;dr

1. Hotfixed the generated `ElixirFlexLexer.java` to check `isInterpolating()` before entering escape sequence processing in `GROUP_HEREDOC_LINE_BODY` state
  1a. Case 82 (`{ESCAPE}` rule): returns `FRAGMENT` when not interpolating
  1b. Case 148 (`{ESCAPE} / {EOL}` lookahead rule): returns `FRAGMENT` when not interpolating
2. Added `LiteralSigilHeredocTest` covering non-interpolating sigil heredoc lexing to hopefully

## Breakdown of actual issue

Non-interpolating sigil heredocs like `~S"""` were incorrectly processing escape sequences. When the lexer encountered `\` inside `GROUP_HEREDOC_LINE_BODY`, it unconditionally entered `ESCAPE_SEQUENCE` state, even though `~S` sigils should treat all content as literal text.

This caused content like `\x{hhh..}` (found in Elixir 1.16+ stdlib `regex.ex` `@moduledoc`) to be tokenized as:
```
\  -> ESCAPE
x  -> HEXADECIMAL_WHOLE_NUMBER_BASE
{  -> OPENING_CURLY
h  -> BAD_CHARACTER (not a valid hex digit)
...
}  -> CLOSING_CURLY
```

... instead of all `FRAGMENT` tokens. The parser then produced `PsiErrorElement` and `DummyBlock` nodes, breaking completion, highlighting, and doc rendering for any file containing these patterns.

The `GROUP` (non-heredoc) state already had the `isInterpolating()` guard for its `{ESCAPE}` rules -- `GROUP_HEREDOC_LINE_BODY` was missing it.

---


Once I figure out if this breaks everything else, I'll merge it.