### PR TITLE
Consolidate internal API usage of `JpsProjectLoadingManager`

### DIFF
--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import com.intellij.workspaceModel.ide.JpsProjectLoadingManager
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.JdkOrderEntry
@@ -60,6 +59,7 @@ import org.elixir_lang.tool_manager.ToolManagerSettings
 import org.elixir_lang.tool_manager.ToolManagerSettingsListener
 import org.elixir_lang.tool_manager.ToolManagerVersions
 import org.elixir_lang.util.WriteActions
+import org.elixir_lang.util.awaitJpsProjectLoaded
 import java.util.concurrent.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -186,35 +186,12 @@ class ElixirEditorBasedSdkWidget(
     )
 
     init {
-        // Trigger the initial notification scan only after the JPS project model sync completes.
-        //
-        // At startup the platform loads the workspace model from a cache, then runs the
-        // `DelayedProjectSynchronizer` project activity which reads the actual .iml and
-        // jdk.table.xml files from disk and applies them to the workspace model.  This sync
-        // takes several seconds (WSL projects: 5–13 s).  Any SDK assignment we commit before
-        // the sync completes is overwritten when the sync applies the persisted .iml state.
-        //
-        // `JpsProjectLoadingManager.jpsProjectLoaded` fires immediately if the JPS model is
-        // already loaded, or after `DelayedProjectSynchronizer` finishes otherwise.  This
-        // guarantees the workspace model is stable (reflects the on-disk .iml) before we show
-        // the notification or let the user click an action.
-        //
-        // `JpsProjectLoadingManager` is @ApiStatus.Internal + @Deprecated in favour of
-        // `WorkspaceModelInternal.awaitSynchronizationWithJpsModel`.  We cannot use the
-        // replacement because it is both @ApiStatus.Experimental *and* absent from the 2025.3
-        // platform (verified: not present in tag idea/253.28294.334).  Since pluginSinceBuild
-        // is 253, using it directly would throw NoSuchMethodError on 2025.3.
-        // JpsProjectLoadingManager works across all supported versions (253 through 261+)
-        // and is the documented mechanism for this use case ("add a missing SDK").
-        // The Python plugin (PySdkFromEnvironmentVariableConfigurator) uses it for the same
-        // purpose.
-        @Suppress("UnstableApiUsage", "DEPRECATION")
+        // Trigger the initial notification scan only after the JPS project model sync completes: any SDK
+        // assignment committed before the sync applies the on-disk .iml state would be overwritten, so we must
+        // wait until the workspace model is stable before showing a notification or letting the user act on it.
+        // See `awaitJpsProjectLoaded` for why this uses the deprecated/internal API and the migration tickets.
         scope.launch {
-            suspendCancellableCoroutine { cont ->
-                JpsProjectLoadingManager.getInstance(project).jpsProjectLoaded {
-                    cont.resumeWith(Result.success(Unit))
-                }
-            }
+            awaitJpsProjectLoaded(project)
             notificationScanRequests.tryEmit(Unit)
         }
 

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerService.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerService.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.util.Disposer
-import com.intellij.workspaceModel.ide.JpsProjectLoadingManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.cancel
@@ -15,9 +14,9 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.elixir_lang.util.ElixirCoroutineService
+import org.elixir_lang.util.awaitJpsProjectLoaded
 import com.intellij.util.messages.Topic
 import java.nio.file.Path
 import kotlin.time.Duration.Companion.milliseconds
@@ -93,15 +92,11 @@ internal class ToolManagerSdkCheckerService(private val project: Project) : Disp
             }
         })
 
-        // Wait for JPS project model sync before the initial scan so that module content roots
-        // and SDK assignments reflect the on-disk state rather than the workspace-model cache.
-        @Suppress("UnstableApiUsage", "DEPRECATION")
+        // Wait for JPS project model sync before the initial scan so that module content roots and SDK
+        // assignments reflect the on-disk state rather than the workspace-model cache.
+        // See [awaitJpsProjectLoaded] for why this uses the deprecated/internal API and the migration tickets.
         scope.launch {
-            suspendCancellableCoroutine<Unit> { cont ->
-                JpsProjectLoadingManager.getInstance(project).jpsProjectLoaded {
-                    cont.resumeWith(Result.success(Unit))
-                }
-            }
+            awaitJpsProjectLoaded(project)
             LOG.debug("JPS model loaded, emitting initial scan request for '${project.name}'")
             scanRequests.tryEmit(Unit)
         }

--- a/src/org/elixir_lang/util/JpsProjectModel.kt
+++ b/src/org/elixir_lang/util/JpsProjectModel.kt
@@ -1,0 +1,53 @@
+package org.elixir_lang.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.workspaceModel.ide.JpsProjectLoadingManager
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Suspends until the JPS project model has been synchronized with the on-disk `.iml` / `jdk.table.xml` files,
+ * resuming immediately if the sync already completed.
+ *
+ * At startup the platform first loads the workspace model from a cache, then runs the `DelayedProjectSynchronizer`
+ * project activity which reads the actual `.iml` and `jdk.table.xml` files from disk and applies them to the
+ * workspace model (WSL projects: 5–13 seconds). Any project-model change committed before that sync completes - e.g.
+ * assigning a missing Elixir SDK - is overwritten when the sync applies the persisted state. Callers that read or
+ * mutate authoritative module/SDK configuration from an automated startup activity must await this gate first.
+ *
+ * ## Why the deprecated, internal [JpsProjectLoadingManager]?
+ *
+ * [JpsProjectLoadingManager] is `@ApiStatus.Internal` **and** `@Deprecated` in favour of
+ * `com.intellij.platform.backend.workspace.impl.WorkspaceModelInternal.awaitSynchronizationWithJpsModel`. We do not
+ * migrate, because for a Marketplace plugin the replacement is no better:
+ *
+ * - It is `@ApiStatus.Experimental` declared on the `@ApiStatus.Internal WorkspaceModelInternal` interface, so it is
+ *   itself an internal API - switching would relocate the plugin-verifier internal-API violation, not remove it.
+ * - It requires a `(workspaceModel as WorkspaceModelInternal)` cast (the platform confirms the cast is safe, but it
+ *   is still internal surface).
+ * - It is absent from our minimum supported build 253 (verified against tag `idea/253.28294.334`); calling it there
+ *   throws `NoSuchMethodError`.
+ *
+ * [JpsProjectLoadingManager] works across the whole supported range (253 → 261+) and is the mechanism the platform
+ * itself endorses for the "automated startup activity that may change project configuration" case - which is exactly
+ * this one (see the IJPL-249625 discussion). The JetBrains PyCharm plugin uses it for the same purpose.
+ *
+ * ## Migration - this is the single place to change
+ *
+ * Watch these tickets; when a public, cast-free API ships and our `sinceBuild` is past the build that first carries
+ * it, replace the body here (all call sites update automatically):
+ *
+ * - **IJPL-249625** (open) - make `awaitSynchronizationWithJpsModel` a cast-free, official public API.
+ *   https://youtrack.jetbrains.com/issue/IJPL-249625
+ *   The comment thread carries the platform's rationale (Lucy Kornilova) that this gate is needed only for startup
+ *   activities that change project configuration - i.e. this use case - and confirms the replacement stays internal.
+ * - **IJPL-241069** (open) - "Remove JpsProjectLoadingManager". https://youtrack.jetbrains.com/issue/IJPL-241069
+ * - **IJPL-240839** (fixed) - introduced the (internal) replacement. https://youtrack.jetbrains.com/issue/IJPL-240839
+ */
+@Suppress("UnstableApiUsage", "DEPRECATION")
+suspend fun awaitJpsProjectLoaded(project: Project) {
+    suspendCancellableCoroutine { cont ->
+        JpsProjectLoadingManager.getInstance(project).jpsProjectLoaded {
+            cont.resumeWith(Result.success(Unit))
+        }
+    }
+}


### PR DESCRIPTION
Use only in one place and add comments that link to the  youtrack issues tracking it

 - **IJPL-249625** (open) - make `awaitSynchronizationWithJpsModel` a cast-free, official public API.
https://youtrack.jetbrains.com/issue/IJPL-249625
  The comment thread carries the platform's rationale (Lucy Kornilova) that this gate is needed only for startup
  activities that change project configuration - i.e. this use case - and confirms the replacement stays internal.
- **IJPL-241069** (open) - "Remove JpsProjectLoadingManager". https://youtrack.jetbrains.com/issue/IJPL-241069
- **IJPL-240839** (fixed) - introduced the (internal) replacement. https://youtrack.jetbrains.com/issue/IJPL-240839