### PR TITLE
fix(ci): default setup-env to the minimum supported platform (2025.3.6)

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -12,9 +12,9 @@ inputs:
     required: false
     default: '24.3.4.6'
   idea-version:
-    description: 'IntelliJ IDEA version to test against. Keep in sync with the matrix in shared-test.yml'
+    description: 'IntelliJ IDEA platform version to build/test against. Defaults to the minimum supported platform (matches pluginSinceBuild) so release/tag builds get it for free; override per-leg to test against a newer platform (see the matrix in shared-test.yml).'
     required: false
-    default: '2026.2'  # should match first version in shared-test.yml
+    default: '2025.3.6'
   java-version:
     description: 'JBR major version to install. Must match the Java level of idea-version: 25 for 2026.2+ (build 262), 21 for earlier.'
     required: false

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -201,7 +201,6 @@ jobs:
         with:
           setup-elixir: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          idea-version: '2026.1.4'
           free-docker-images: false
           skip-searchable-options: 'true'
 

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -20,11 +20,16 @@ on:
         required: false
         type: string
         default: '24.3.4.6'
-      upload-reports:
+      upload-test-reports:
         description: 'Upload test reports as artifacts'
         required: false
         type: boolean
         default: false
+      upload-verifier-reports:
+        description: 'Upload test reports as artifacts'
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -171,7 +176,7 @@ jobs:
       - name: Upload Test Reports (on failure or when requested)
         id: upload-test-reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ always() && (failure() || inputs.upload-reports) }}
+        if: ${{ always() && (failure() || inputs.upload-test-reports) }}
         with:
           name: test-reports-${{ matrix.os }}-${{ matrix.idea-version }}
           path: |
@@ -250,7 +255,7 @@ jobs:
       - name: Upload Verify Reports
         id: upload-verify-reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ always() && inputs.upload-reports }}
+        if: ${{ always() && inputs.upload-verifier-reports }}
         with:
           name: verify-plugin-reports
           path: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -368,16 +368,18 @@ intellijPlatform {
     }
 }
 
-// Capture values eagerly so the task action doesn't reference Project objects (config cache safe)
-val verifierReportsDir: File = layout.buildDirectory.dir("reports/pluginVerifier").get().asFile
-val projectDirFile: File = projectDir
-
 val openVerificationReports = tasks.register("openVerificationReports") {
     description = "Opens plugin verification markdown reports in the IDE"
     group = "verification"
 
     // Always run when triggered (no up-to-date checking)
     outputs.upToDateWhen { false }
+
+    // Locals (not top-level script properties): the doLast action must capture plain File values -
+    // a top-level val is a field on the script object, and capturing it drags the whole script into
+    // the configuration cache, which cannot serialize script object references.
+    val verifierReportsDir: File = layout.buildDirectory.dir("reports/pluginVerifier").get().asFile
+    val projectDirFile: File = projectDir
 
     doLast {
         val mdFiles = verifierReportsDir.listFiles()


### PR DESCRIPTION
setup-env's idea-version default tracked the newest test-matrix leg (bumped to 2026.2 in 2d93e5c60f), which release.yml/tag.yml silently inherited since they never overrode it - compiling the release build against the 2026.2 SDK instead of the declared minimum (pluginSinceBuild=253).

That let the build reference platform classes only present in 2026.2 (e.g. SdkEnvironment.eelDescriptor resolving to EelPathDescriptorKt), which don't exist on 2025.3/2026.1 and throw NoSuchClassError at runtime there.

Default to the minimum supported platform instead, so any caller that doesn't override it (the release/tag builds) gets a build that matches pluginSinceBuild for free. Drops the now-redundant explicit pins from release.yml, tag.yml, and shared-test.yml's build-plugin job -- the test job's per-leg matrix override is the only place idea-version still varies.