### PR TITLE
fix(ci): stop the Test Results checks failing on test failures

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -87,6 +87,13 @@ jobs:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/event-file/event.json
           event_name: ${{ github.event.workflow_run.event }}
+          # Failing tests must not turn this check red: the Test workflow is the gate, and it already
+          # decides what blocks a merge (an informational leg such as Elixir 1.19 deliberately fails
+          # tests without failing the workflow). These checks exist to report numbers, not to judge.
+          # "errors" rather than "nothing" keeps one canary: Gradle records every test failure as
+          # <failure>, so this only goes red when the reporting itself breaks - unparseable result
+          # files, or a suite that could not run - which would otherwise silently undercount.
+          fail_on: errors
           # artifact names double as check names, matching what shared-test.yml
           # published inline before this workflow existed
           check_name: ${{ matrix.artifact }}
@@ -147,3 +154,6 @@ jobs:
           comment_mode: always
           files: 'artifacts/test-results/**/*.xml'
           report_suite_logs: error
+          # See the per-cell publish job above: report the numbers, leave the pass/fail verdict to
+          # the Test workflow.
+          fail_on: errors


### PR DESCRIPTION
The Test workflow decides what blocks a merge, and it deliberately tolerates the informational Elixir 1.19 leg: those tests run and report but cannot fail the workflow. The published Test Results checks took the same failures as their own verdict, so a leg that cannot fail the build still turned a pull request's merge box red.

Pass fail_on: errors to the publisher on both the per-cell and the aggregate step, so those checks report counts and annotations without passing judgement. "errors" rather than "nothing" keeps one canary: Gradle records every test failure as <failure> and never <error> here, so the checks still go red when the reporting itself breaks - an unparseable result file, or a suite that could not run - which is exactly the failure mode that recently dropped 133 failures from a report without anything looking wrong.

Separate from the change that motivated it because it cannot work from a pull request: a workflow_run workflow always executes the copy on the default branch, so this only takes effect once it is on main.