### PR TITLE
Fix Highlighting for Decompiled Beam Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
     version is listed with its release date, so upgrading after skipping a few releases shows what you
     missed rather than one undifferentiated list.
 
+### Bug Fixes
+- [#3901](https://github.com/KronicDeth/intellij-elixir/pull/3901) - [@sh41](https://github.com/sh41)
+  - **Semantic syntax highlighting now appears in decompiled `.beam` files.** Function names, types and
+    the rest were being coloured by the annotators and then discarded before they reached the editor, so
+    decompiled code showed only the plain lexer colours. v24.0.0 announced this as working; it was not.
+  - **Opening a decompiled `.beam` file no longer reports "PsiFile's context does not match the context
+    of the editor",** which reached users as an IDE error report.
+
 ### Build / CI
 - [@sh41](https://github.com/sh41)
   - `CHANGELOG.md` is now in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and is the

--- a/src/org/elixir_lang/annotator/Highlighter.kt
+++ b/src/org/elixir_lang/annotator/Highlighter.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.annotator
 
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType
 import com.intellij.lang.ASTNode
 import com.intellij.lang.annotation.AnnotationBuilder
 import com.intellij.lang.annotation.AnnotationHolder
@@ -10,6 +11,15 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
+/**
+ * Applies semantic syntax colouring on behalf of the annotators.
+ *
+ * **Severity must stay [HighlightInfoType.SYMBOL_TYPE_SEVERITY].** `HighlightInfoFilterImpl.accept` silently
+ * discards any [com.intellij.codeInsight.daemon.impl.HighlightInfo] on a file whose `getOriginalFile()` is a
+ * [com.intellij.psi.PsiCompiledFile] unless the severity is exactly that, so
+ * [HighlightSeverity.INFORMATION] means no highlighting at all in decompiled `.beam` files, with nothing
+ * logged.
+ */
 object Highlighter {
     fun highlight(annotationHolder: AnnotationHolder, textAttributesKey: TextAttributesKey) {
         highlight(annotationHolder, textAttributesKey) { it }
@@ -31,21 +41,33 @@ object Highlighter {
         highlight(annotationHolder, textAttributes) { it.range(textRange) }
     }
 
+    /**
+     * Resolves [textAttributesKey] eagerly rather than calling `AnnotationBuilder.textAttributes(key)`,
+     * which looks more idiomatic but does not keep the key: `forcedTextAttributesKey` on the resulting
+     * [com.intellij.codeInsight.daemon.impl.HighlightInfo] stays `null` either way. Tests therefore have to
+     * compare resolved [TextAttributes] - see `BeamHighlightingTest`.
+     */
     private fun highlight(annotationHolder: AnnotationHolder, textAttributesKey: TextAttributesKey, build: (builder: AnnotationBuilder) -> AnnotationBuilder) {
         highlight(annotationHolder, EditorColorsManager.getInstance().globalScheme.getAttributes(textAttributesKey), build)
     }
 
+    /** For callers that merge attributes and so have no single key to name. */
     private fun highlight(annotationHolder: AnnotationHolder, textAttributes: TextAttributes, build: (builder: AnnotationBuilder) -> AnnotationBuilder) {
-        build(
-                annotationHolder
-                        .newSilentAnnotation(HighlightSeverity.INFORMATION)
-                        .enforcedTextAttributes(TextAttributes.ERASE_MARKER)
-        ).create()
+        eraseUnderlyingHighlighting(annotationHolder, build)
 
         build(
                 annotationHolder
-                        .newSilentAnnotation(HighlightSeverity.INFORMATION)
+                        .newSilentAnnotation(HighlightInfoType.SYMBOL_TYPE_SEVERITY)
                         .enforcedTextAttributes(textAttributes)
+        ).create()
+    }
+
+    /** Wipes the lexer's colouring first, so the semantic attributes replace it rather than blend with it. */
+    private fun eraseUnderlyingHighlighting(annotationHolder: AnnotationHolder, build: (builder: AnnotationBuilder) -> AnnotationBuilder) {
+        build(
+                annotationHolder
+                        .newSilentAnnotation(HighlightInfoType.SYMBOL_TYPE_SEVERITY)
+                        .enforcedTextAttributes(TextAttributes.ERASE_MARKER)
         ).create()
     }
 }

--- a/src/org/elixir_lang/beam/psi/BeamFileImpl.kt
+++ b/src/org/elixir_lang/beam/psi/BeamFileImpl.kt
@@ -1,6 +1,9 @@
 package org.elixir_lang.beam.psi
 
 import com.ericsson.otp.erlang.OtpErlangDecodeException
+import com.intellij.codeInsight.multiverse.CodeInsightContextManager
+import com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl
+import com.intellij.codeInsight.multiverse.isSharedSourceSupportEnabled
 import com.intellij.lang.FileASTNode
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
@@ -63,14 +66,17 @@ class BeamFileImpl private constructor(
     override fun getDecompiledPsiFile(): PsiFile = mirror as PsiFile
 
     /**
-     * Returns the mirror previously built by [getMirror] without triggering decompilation.
+     * The mirror [getMirror] already built, without triggering decompilation.
      *
-     * The highlighting daemon ([com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerImpl.queuePassesCreation] via
-     * [com.intellij.codeInsight.daemon.impl.TextEditorBackgroundHighlighter.getCachedFileToHighlight]) submits a
-     * `PsiCompiledFile` for semantic highlighting by swapping it for this cached mirror. If this returned the
-     * inherited default of `null`, the daemon would bail out of scheduling passes on every attempt and no annotator
-     * (semantic) highlighting would ever run over the decompiled `.beam` text, even though [getMirror] had built a
-     * full AST. Mirrors [com.intellij.psi.impl.compiled.ClsFileImpl.getCachedMirror].
+     * **Must stay overridden.** `DaemonCodeAnalyzerImpl.queuePassesCreation` swaps a `PsiCompiledFile` for
+     * this before scheduling highlighting passes. The inherited default returns `null`, which costs more
+     * than the highlighting: the daemon then falls back to `renewFile()`, which builds the mirror, returns
+     * non-null, and so triggers a restart - which asks for the cached mirror again. Measured on an idle
+     * editor with one decompiled file open, that loops every ~300 ms indefinitely.
+     *
+     * `@ApiStatus.Internal` with no public equivalent, and `getMirror()` is not a stand-in - the cached and
+     * building calls are what separate the EDT path from the background one -
+     * [IJPL-252078](https://youtrack.jetbrains.com/issue/IJPL-252078).
      */
     override fun getCachedMirror(): PsiFile? = mirrorFileElement?.psi as PsiFile?
 
@@ -419,8 +425,15 @@ class BeamFileImpl private constructor(
                         ElixirLanguage,
                         mirrorText,
                         false,
-                        false
+                        false,
+                        // noSizeLimit, as ClsFileImpl.getMirror does. PsiFileFactoryImpl discards the language
+                        // passed here (`language = viewProvider.getBaseLanguage()`), and calcBaseLanguage
+                        // answers PlainTextLanguage for text over `idea.max.intellisense.filesize`, which
+                        // makes setMirror below throw InvalidMirrorException. No fixture decompiles large
+                        // enough to cover it.
+                        true
                     )
+                    propagateCodeInsightContextTo(mirror)
                     mirrorTreeElement = SourceTreeToPsiMap.psiToTreeNotNull(mirror)
                     try {
                         val finalMirrorTreeElement = mirrorTreeElement
@@ -439,6 +452,36 @@ class BeamFileImpl private constructor(
             }
         }
         return mirrorTreeElement!!.psi
+    }
+
+    /**
+     * Copies this file's [com.intellij.codeInsight.multiverse.CodeInsightContext] onto [mirror]'s view
+     * provider, as [com.intellij.psi.impl.compiled.ClsFileImpl.getMirror] does.
+     *
+     * The platform never does this itself - a [PsiFileFactory]-built mirror always reports `DefaultContext` -
+     * so without it the daemon logs `PsiFile's context does not match the context of the editor` on every
+     * decompiled `.beam`, which reaches users as an error report. Shared-source support is on by default, so
+     * this is the normal path.
+     *
+     * Only the setter needs the `@ApiStatus.Internal` `CodeInsightContextManagerImpl`; the service, reading a
+     * context and [isSharedSourceSupportEnabled] are all public on `CodeInsightContextManager`, so they go
+     * through that. The cast is what `CodeInsightContextManagerImpl.getInstanceImpl` does internally, against
+     * the single registered implementation, and using it directly keeps the plugin verifier's internal-API
+     * findings to the two that are unavoidable - naming the type, and the call - instead of five. The whole
+     * core-api `codeInsight.multiverse` package is `@ApiStatus.Experimental` regardless -
+     * [IJPL-252078](https://youtrack.jetbrains.com/issue/IJPL-252078).
+     */
+    @Suppress("UnstableApiUsage")
+    private fun propagateCodeInsightContextTo(mirror: PsiFile) {
+        val project = manager.project
+
+        if (isSharedSourceSupportEnabled(project)) {
+            val contextManager = CodeInsightContextManager.getInstance(project)
+            // Read before the cast: a smart-cast `contextManager` would bind this to the impl instead.
+            val context = contextManager.getCodeInsightContext(viewProvider)
+
+            (contextManager as CodeInsightContextManagerImpl).setCodeInsightContext(mirror.viewProvider, context)
+        }
     }
 
     override fun setMirror(element: TreeElement) {

--- a/tests/org/elixir_lang/annotator/BeamHighlightingTest.kt
+++ b/tests/org/elixir_lang/annotator/BeamHighlightingTest.kt
@@ -1,0 +1,81 @@
+package org.elixir_lang.annotator
+
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import org.elixir_lang.beam.BeamLibraryTestCase
+import org.elixir_lang.ElixirFileType
+import org.elixir_lang.ElixirSyntaxHighlighter
+
+/**
+ * Semantic (annotator) highlighting over decompiled `.beam` files - see [Highlighter] for why the severity
+ * matters.
+ *
+ * The three tests are a set and must stay together: [testSourceElixirFileGetsSemanticHighlighting] shows the
+ * harness can see annotator output at all, and
+ * [testDecompiledTextGetsSemanticHighlightingAsPlainElixirSource] shows the decompiler's output is
+ * highlightable. If either goes red, [testDecompiledBeamFunctionNameGetsSemanticHighlighting] proves nothing.
+ */
+class BeamHighlightingTest : BeamLibraryTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/type"
+
+    fun testSourceElixirFileGetsSemanticHighlighting() {
+        myFixture.configureByFiles("beam_qualified_type_goto.ex")
+
+        // Forced attributes specifically, not just any info: injected fragments and inspections would satisfy
+        // a bare isNotEmpty() without any annotator having run.
+        assertTrue(
+            "The harness must produce annotator HighlightInfos for ordinary Elixir source",
+            myFixture.doHighlighting().any { it.forcedTextAttributes != null }
+        )
+    }
+
+    /** Highlights the *identical* decompiled text as ordinary source, leaving compiled-file handling as the
+     * only difference from [testDecompiledBeamFunctionNameGetsSemanticHighlighting]. */
+    fun testDecompiledTextGetsSemanticHighlightingAsPlainElixirSource() {
+        openBeam("queue.beam")
+        val decompiledText = myFixture.editor.document.text
+
+        myFixture.configureByText(ElixirFileType.INSTANCE, decompiledText)
+
+        assertConsFunctionNameIsHighlighted("the same text as a plain .ex source file")
+    }
+
+    fun testDecompiledBeamFunctionNameGetsSemanticHighlighting() {
+        openBeam("queue.beam")
+
+        assertConsFunctionNameIsHighlighted("the decompiled queue.beam")
+    }
+
+    /**
+     * Shared so the decompiled and plain-source cases differ *only* in what was configured. Offsets come from
+     * the live document because the fixture `.beam` decompiles to a different length than an SDK one.
+     *
+     * Compares resolved attributes rather than the [ElixirSyntaxHighlighter.FUNCTION_DECLARATION] key because
+     * the key is not observable on an annotator's `HighlightInfo` (see [Highlighter]). Known weakness: another
+     * annotator emitting attributes that resolve identically over an overlapping range would satisfy this.
+     */
+    private fun assertConsFunctionNameIsHighlighted(what: String) {
+        val clause = "def cons(x, q)"
+        val clauseIndex = myFixture.editor.document.text.indexOf(clause)
+        assertTrue("Clause '$clause' not found in $what", clauseIndex >= 0)
+
+        val nameStart = clauseIndex + "def ".length
+        val nameEnd = nameStart + "cons".length
+
+        val expected = EditorColorsManager
+            .getInstance()
+            .globalScheme
+            .getAttributes(ElixirSyntaxHighlighter.FUNCTION_DECLARATION)
+
+        val covering = myFixture
+            .doHighlighting()
+            .filter { it.startOffset <= nameStart && it.endOffset >= nameEnd }
+
+        assertTrue(
+            "The `cons` function name in $what should carry " +
+                "${ElixirSyntaxHighlighter.FUNCTION_DECLARATION.externalName} attributes; " +
+                "${covering.size} HighlightInfo(s) cover $nameStart..$nameEnd: " +
+                covering.joinToString(" ; ") { "${it.startOffset}..${it.endOffset} ${it.forcedTextAttributes}" },
+            covering.any { it.forcedTextAttributes == expected }
+        )
+    }
+}

--- a/tests/org/elixir_lang/beam/BeamLibraryFixture.kt
+++ b/tests/org/elixir_lang/beam/BeamLibraryFixture.kt
@@ -1,0 +1,73 @@
+package org.elixir_lang.beam
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Registers and removes project libraries holding `.beam` fixtures.
+ *
+ * [BeamLibraryTestCase] covers the common case - one `ebin/` directory as a CLASSES root - and should be
+ * preferred. This exists for suites that cannot use it: those extending a different base class, and those
+ * whose fixture layout is the point of the test (a SOURCES root alongside the CLASSES root, so that
+ * source-over-decompiled resolution can be exercised; or a root that is not named `ebin`).
+ */
+object BeamLibraryFixture {
+    /**
+     * Creates [libraryName] with [classesRoots] and [sourcesRoots] and adds it as a module dependency.
+     *
+     * Both root lists are attached in a single write action, because a library committed without its roots is
+     * briefly visible to the project model and can be indexed empty.
+     */
+    fun addLibrary(
+        project: Project,
+        module: Module,
+        libraryName: String,
+        classesRoots: List<VirtualFile>,
+        sourcesRoots: List<VirtualFile> = emptyList(),
+    ) {
+        WriteAction.run<Throwable> {
+            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+            val tableModel = libraryTable.modifiableModel
+            val library = tableModel.createLibrary(libraryName)
+
+            library.modifiableModel.let { libraryModel ->
+                classesRoots.forEach { libraryModel.addRoot(it, OrderRootType.CLASSES) }
+                sourcesRoots.forEach { libraryModel.addRoot(it, OrderRootType.SOURCES) }
+                libraryModel.commit()
+            }
+
+            tableModel.commit()
+
+            ModuleRootModificationUtil.addDependency(module, library)
+        }
+    }
+
+    /**
+     * Removes [libraryName] and the module's dependency on it.
+     *
+     * The order matters: the order entry has to go before the library, or the module keeps an entry pointing
+     * at a disposed library.
+     */
+    fun removeLibrary(project: Project, module: Module, libraryName: String) {
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            model.orderEntries
+                .filter { it.presentableName == libraryName }
+                .forEach { model.removeOrderEntry(it) }
+        }
+
+        WriteAction.run<Throwable> {
+            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+            libraryTable.getLibraryByName(libraryName)?.let { library ->
+                libraryTable.modifiableModel.let { model ->
+                    model.removeLibrary(library)
+                    model.commit()
+                }
+            }
+        }
+    }
+}

--- a/tests/org/elixir_lang/beam/BeamLibraryTestCase.kt
+++ b/tests/org/elixir_lang/beam/BeamLibraryTestCase.kt
@@ -1,0 +1,74 @@
+package org.elixir_lang.beam
+
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.PlatformTestCase
+import java.io.File
+
+/**
+ * Base for tests that need `.beam` fixtures resolvable as library classes.
+ *
+ * Registers `<testDataPath>/ebin` as a CLASSES root of a project library in [setUp] and removes it in
+ * [tearDown], so subclasses only supply their own `getTestDataPath()`. The library membership matters: a
+ * `.beam` outside a library root is not treated as compiled library code, so decompilation, navigation and
+ * highlighting all behave differently from the real IDE.
+ */
+abstract class BeamLibraryTestCase : PlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        addBeamLibrary()
+    }
+
+    @Throws(Exception::class)
+    override fun tearDown() {
+        runAll(
+            { removeBeamLibrary() },
+            { super.tearDown() },
+        )
+    }
+
+    /**
+     * Opens the decompiled view of [beamName] from this test's `ebin` fixture directory.
+     *
+     * Every caller currently passes `queue.beam`, so the IDE reports [beamName] as always the same value.
+     * Do not inline it: subclasses ship different fixtures - `BeamModuleGotoDeclarationTest` has only
+     * `Elixir.Code.beam`, and the type suites also carry `erlang.beam`.
+     */
+    protected fun openBeam(beamName: String) {
+        val beamIo = File(File(testDataPath, EBIN).absoluteFile, beamName)
+        val beamVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(beamIo)
+        assertNotNull("Could not find decompiled $beamName in VFS", beamVf)
+        myFixture.configureFromExistingVirtualFile(beamVf!!)
+    }
+
+    /** [openBeam], then puts the caret on the last character of [anchor] within the decompiled text. */
+    protected fun openBeamAndMoveCaretTo(beamName: String, anchor: String) {
+        openBeam(beamName)
+
+        val anchorIndex = myFixture.editor.document.text.indexOf(anchor)
+        assertTrue("Anchor '$anchor' not found in decompiled $beamName", anchorIndex >= 0)
+        myFixture.editor.caretModel.moveToOffset(anchorIndex + anchor.length - 1)
+    }
+
+    private fun addBeamLibrary() {
+        val ebinDir = File(testDataPath, EBIN).absoluteFile
+        assertTrue("$EBIN/ fixture directory not found at ${ebinDir.absolutePath}", ebinDir.isDirectory)
+
+        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, ebinDir.path)
+
+        val ebinVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebinDir)
+        assertNotNull("Could not find $EBIN/ fixture directory in VFS", ebinVf)
+
+        BeamLibraryFixture.addLibrary(project, myFixture.module, BEAM_LIBRARY_NAME, listOf(ebinVf!!))
+    }
+
+    private fun removeBeamLibrary() {
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, BEAM_LIBRARY_NAME)
+    }
+
+    private companion object {
+        private const val EBIN = "ebin"
+        private const val BEAM_LIBRARY_NAME = "beam-fixture-lib"
+    }
+}

--- a/tests/org/elixir_lang/code_insight/completion/contributor/BeamCallDefinitionClauseTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/BeamCallDefinitionClauseTest.kt
@@ -4,14 +4,13 @@ import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementPresentation
 import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.LibraryOrderEntry
-import com.intellij.openapi.roots.libraries.Library
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.common.runAll
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryFixture
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import java.io.File
 
@@ -87,16 +86,8 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
         // Include test name to guarantee uniqueness within a shared light project.
         val libraryName = "beam-$name"
 
-        val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-        val library = WriteAction.computeAndWait<Library, RuntimeException> {
-            val lib = libraryTable.createLibrary(libraryName)
-            val model = lib.modifiableModel
-            model.addRoot(ebinVirtualDir!!, OrderRootType.CLASSES)
-            model.commit()
-            lib
-        }
+        BeamLibraryFixture.addLibrary(project, myFixture.module, libraryName, listOf(ebinVirtualDir!!))
 
-        ModuleRootModificationUtil.addDependency(myFixture.module, library)
         return libraryName
     }
 
@@ -121,17 +112,14 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
         // Include test name to guarantee uniqueness within a shared light project.
         val libraryName = "beam-source-$name"
 
-        val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-        val library = WriteAction.computeAndWait<Library, RuntimeException> {
-            val lib = libraryTable.createLibrary(libraryName)
-            val model = lib.modifiableModel
-            model.addRoot(ebinVirtualDir!!, OrderRootType.CLASSES)
-            model.addRoot(libVirtualDir!!, OrderRootType.SOURCES)
-            model.commit()
-            lib
-        }
+        BeamLibraryFixture.addLibrary(
+            project,
+            myFixture.module,
+            libraryName,
+            listOf(ebinVirtualDir!!),
+            listOf(libVirtualDir!!),
+        )
 
-        ModuleRootModificationUtil.addDependency(myFixture.module, library)
         return libraryName
     }
 

--- a/tests/org/elixir_lang/documentation/ErlangAtomQualifierHoverDocumentationOTP23Test.kt
+++ b/tests/org/elixir_lang/documentation/ErlangAtomQualifierHoverDocumentationOTP23Test.kt
@@ -1,11 +1,8 @@
 package org.elixir_lang.documentation
 
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import org.elixir_lang.beam.BeamLibraryFixture
 import java.io.File
 
 /**
@@ -88,30 +85,11 @@ class ErlangAtomQualifierHoverDocumentationOTP23Test : QuickDocumentationTestCas
         val appDirVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(appDir)
         assertNotNull("Could not find app directory: ${appDir.absolutePath}", appDirVf)
 
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(appDirVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
+        BeamLibraryFixture.addLibrary(project, myFixture.module, LIBRARY_NAME, listOf(appDirVf!!))
     }
 
     private fun removeBeamLibrary() {
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val library = libraryTable.getLibraryByName(LIBRARY_NAME)
-            if (library != null) {
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, LIBRARY_NAME)
     }
 
     override fun getTestDataPath(): String =

--- a/tests/org/elixir_lang/documentation/ErlangAtomQualifierHoverDocumentationTest.kt
+++ b/tests/org/elixir_lang/documentation/ErlangAtomQualifierHoverDocumentationTest.kt
@@ -1,11 +1,8 @@
 package org.elixir_lang.documentation
 
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import org.elixir_lang.beam.BeamLibraryFixture
 import java.io.File
 
 /**
@@ -68,30 +65,11 @@ class ErlangAtomQualifierHoverDocumentationTest : QuickDocumentationTestCase() {
         val beamDirVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(beamDir))
         assertNotNull("Could not find beam test data directory: $beamDir", beamDirVf)
 
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(beamDirVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
+        BeamLibraryFixture.addLibrary(project, myFixture.module, LIBRARY_NAME, listOf(beamDirVf!!))
     }
 
     private fun removeBeamLibrary() {
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val library = libraryTable.getLibraryByName(LIBRARY_NAME)
-            if (library != null) {
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, LIBRARY_NAME)
     }
 
     override fun getTestDataPath(): String =

--- a/tests/org/elixir_lang/inspection/UnresolvableTypeTest.kt
+++ b/tests/org/elixir_lang/inspection/UnresolvableTypeTest.kt
@@ -1,15 +1,8 @@
 package org.elixir_lang.inspection
 
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
-import org.elixir_lang.PlatformTestCase
-import java.io.File
+import org.elixir_lang.beam.BeamLibraryTestCase
 
-class UnresolvableTypeTest : PlatformTestCase() {
+class UnresolvableTypeTest : BeamLibraryTestCase() {
     override fun setUp() {
         super.setUp()
         myFixture.enableInspections(UnresolvableType::class.java)
@@ -94,85 +87,17 @@ class UnresolvableTypeTest : PlatformTestCase() {
     }
 
     /**
-     * A qualified type from a decompiled BEAM module (`:queue.queue()` from the Erlang stdlib)
-     * resolves to a [org.elixir_lang.beam.psi.impl.TypeDefinitionImpl], not a source `@type` [org.elixir_lang.psi.call.Call].
-     * The inspection must recognise it as resolved via [org.elixir_lang.model.psi.type.TypeReference.resolvesToType],
-     * not the source-only [org.elixir_lang.model.psi.type.TypeReference.resolveSymbols], so it is not flagged.
-     */
-    /**
-     * A qualified type from a decompiled BEAM module (`:queue.queue()` from the Erlang stdlib) cannot be
-     * enumerated: only `:erlang` built-in types are materialised as resolvable type definitions, so the
-     * inspection must not claim a decompiled module's types are undefined. Guarded by the "qualifier resolves
-     * to a [org.elixir_lang.beam.psi.impl.ModuleImpl]" check in the inspection.
-     */
-    /**
      * A qualified type from a decompiled BEAM module (`:queue.queue()` from the Erlang stdlib) resolves to a
-     * [org.elixir_lang.beam.psi.impl.TypeDefinitionImpl] built from the beam's type data, so the inspection must
-     * not flag it as undefined.
+     * [org.elixir_lang.beam.psi.impl.TypeDefinitionImpl] built from the beam's type data, not to a source
+     * `@type` [org.elixir_lang.psi.call.Call], so the inspection must treat it as resolved via
+     * [org.elixir_lang.model.psi.type.TypeReference.resolvesToType] rather than the source-only
+     * [org.elixir_lang.model.psi.type.TypeReference.resolveSymbols].
      */
     fun testBeamQualifiedTypeNotFlagged() {
-        addBeamLibrary()
         myFixture.configureByFiles("beam_qualified_type_not_flagged.ex")
         myFixture.checkHighlighting()
     }
 
     override fun getTestDataPath(): String =
         "testData/org/elixir_lang/inspection/unresolvable_type"
-
-    @Throws(Exception::class)
-    override fun tearDown() {
-        try {
-            removeBeamLibrary()
-        } finally {
-            super.tearDown()
-        }
-    }
-
-    private fun addBeamLibrary() {
-        val ebinDir = File(testDataPath, "ebin").absoluteFile
-        assertTrue("ebin/ fixture directory not found at ${ebinDir.absolutePath}", ebinDir.isDirectory)
-
-        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, ebinDir.path)
-
-        val ebinVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebinDir)
-        assertNotNull("Could not find ebin/ fixture directory in VFS", ebinVf)
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(BEAM_LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(ebinVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
-    }
-
-    /**
-     * The light project module is shared across test methods and other suites, so drop the added
-     * library order entry and project library in tearDown to avoid leaking `:queue` into later tests.
-     */
-    private fun removeBeamLibrary() {
-        ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
-            model.orderEntries
-                .filter { it.presentableName == BEAM_LIBRARY_NAME }
-                .forEach { model.removeOrderEntry(it) }
-        }
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            libraryTable.getLibraryByName(BEAM_LIBRARY_NAME)?.let { library ->
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
-    }
-
-    companion object {
-        private const val BEAM_LIBRARY_NAME = "unresolvable-type-beam-lib"
-    }
 }

--- a/tests/org/elixir_lang/model/psi/function/BeamFunctionGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/function/BeamFunctionGotoDeclarationTest.kt
@@ -1,31 +1,23 @@
 package org.elixir_lang.model.psi.function
 
 import com.intellij.ide.impl.HeadlessDataManager
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
-import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryTestCase
 import org.elixir_lang.code_insight.assertGotoDeclarationChosenAtCaret
 import org.elixir_lang.code_insight.assertShowUsagesChosenAtCaret
 import org.elixir_lang.code_insight.gotoDeclarationDestinationAtCaret
 import org.elixir_lang.code_insight.nonDeclarationUsageCountAtCaret
-import java.io.File
 
 /**
  * Behavioural Go To Declaration and Find Usages coverage for functions defined in decompiled BEAM modules, e.g.
  * `:queue.new/0` from the Erlang stdlib. Unlike source `def`s these resolve to `CallDefinitionImpl` decompiled PSI,
  * so they exercise the branch of the call reference that navigates into the `.beam` mirror rather than a source clause.
  */
-class BeamFunctionGotoDeclarationTest : PlatformTestCase() {
+class BeamFunctionGotoDeclarationTest : BeamLibraryTestCase() {
     override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/function"
 
     override fun setUp() {
         super.setUp()
         HeadlessDataManager.fallbackToProductionDataManager(myFixture.testRootDisposable)
-        addBeamLibrary()
     }
 
     fun testCtrlClickOnRemoteBeamFunctionChoosesGotoDeclaration() {
@@ -88,69 +80,5 @@ class BeamFunctionGotoDeclarationTest : PlatformTestCase() {
         myFixture.assertGotoDeclarationChosenAtCaret(
             "Ctrl+Click on the `in_r` call inside the decompiled queue.beam should navigate to its declaration"
         )
-    }
-
-    private fun openBeamAndMoveCaretTo(beamName: String, anchor: String) {
-        val beamIo = File(File(testDataPath, "ebin").absoluteFile, beamName)
-        val beamVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(beamIo)
-        assertNotNull("Could not find decompiled $beamName in VFS", beamVf)
-        myFixture.configureFromExistingVirtualFile(beamVf!!)
-        val text = myFixture.editor.document.text
-        val anchorIndex = text.indexOf(anchor)
-        assertTrue("Anchor '$anchor' not found in decompiled $beamName", anchorIndex >= 0)
-        myFixture.editor.caretModel.moveToOffset(anchorIndex + anchor.length - 1)
-    }
-
-    @Throws(Exception::class)
-    override fun tearDown() {
-        try {
-            removeBeamLibrary()
-        } finally {
-            super.tearDown()
-        }
-    }
-
-    private fun addBeamLibrary() {
-        val ebinDir = File(testDataPath, "ebin").absoluteFile
-        assertTrue("ebin/ fixture directory not found at ${ebinDir.absolutePath}", ebinDir.isDirectory)
-
-        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, ebinDir.path)
-
-        val ebinVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebinDir)
-        assertNotNull("Could not find ebin/ fixture directory in VFS", ebinVf)
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(BEAM_LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(ebinVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
-    }
-
-    private fun removeBeamLibrary() {
-        ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
-            model.orderEntries
-                .filter { it.presentableName == BEAM_LIBRARY_NAME }
-                .forEach { model.removeOrderEntry(it) }
-        }
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            libraryTable.getLibraryByName(BEAM_LIBRARY_NAME)?.let { library ->
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
-    }
-
-    companion object {
-        private const val BEAM_LIBRARY_NAME = "function-goto-beam-lib"
     }
 }

--- a/tests/org/elixir_lang/model/psi/module/BeamModuleGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/module/BeamModuleGotoDeclarationTest.kt
@@ -1,16 +1,9 @@
 package org.elixir_lang.model.psi.module
 
 import com.intellij.ide.impl.HeadlessDataManager
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
-import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryTestCase
 import org.elixir_lang.code_insight.assertGotoDeclarationChosenAtCaret
 import org.elixir_lang.code_insight.gotoDeclarationDestinationAtCaret
-import java.io.File
 
 /**
  * Behavioural Go To Declaration coverage for module aliases that resolve only to a compiled `.beam`
@@ -18,13 +11,12 @@ import java.io.File
  * they exercise the [ModuleReference] branch that routes through `navigationElement` into the decompiled
  * mirror's `defmodule` - without it the beam result is silently dropped and Ctrl+Click does nothing.
  */
-class BeamModuleGotoDeclarationTest : PlatformTestCase() {
+class BeamModuleGotoDeclarationTest : BeamLibraryTestCase() {
     override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/module"
 
     override fun setUp() {
         super.setUp()
         HeadlessDataManager.fallbackToProductionDataManager(myFixture.testRootDisposable)
-        addBeamLibrary()
     }
 
     fun testCtrlClickOnBeamModuleQualifierChoosesGotoDeclaration() {
@@ -54,58 +46,5 @@ class BeamModuleGotoDeclarationTest : PlatformTestCase() {
             "Should land in the decompiled Elixir.Code.beam, not the source file (was ${target!!.containingFile.name})",
             target.containingFile.name.startsWith("Elixir.Code")
         )
-    }
-
-    @Throws(Exception::class)
-    override fun tearDown() {
-        try {
-            removeBeamLibrary()
-        } finally {
-            super.tearDown()
-        }
-    }
-
-    private fun addBeamLibrary() {
-        val ebinDir = File(testDataPath, "ebin").absoluteFile
-        assertTrue("ebin/ fixture directory not found at ${ebinDir.absolutePath}", ebinDir.isDirectory)
-
-        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, ebinDir.path)
-
-        val ebinVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebinDir)
-        assertNotNull("Could not find ebin/ fixture directory in VFS", ebinVf)
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(BEAM_LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(ebinVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
-    }
-
-    private fun removeBeamLibrary() {
-        ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
-            model.orderEntries
-                .filter { it.presentableName == BEAM_LIBRARY_NAME }
-                .forEach { model.removeOrderEntry(it) }
-        }
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            libraryTable.getLibraryByName(BEAM_LIBRARY_NAME)?.let { library ->
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
-    }
-
-    companion object {
-        private const val BEAM_LIBRARY_NAME = "module-goto-beam-lib"
     }
 }

--- a/tests/org/elixir_lang/model/psi/type/BeamTypeGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/type/BeamTypeGotoDeclarationTest.kt
@@ -1,18 +1,8 @@
 package org.elixir_lang.model.psi.type
 
 import com.intellij.ide.impl.HeadlessDataManager
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
-import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
-import org.elixir_lang.PlatformTestCase
-import org.elixir_lang.code_insight.assertGotoDeclarationChosenAtCaret
-import org.elixir_lang.code_insight.assertShowUsagesChosenAtCaret
-import org.elixir_lang.code_insight.gotoDeclarationDestinationAtCaret
-import org.elixir_lang.code_insight.nonDeclarationUsageCountAtCaret
-import org.elixir_lang.code_insight.psiUsagesAtCaret
+import org.elixir_lang.beam.BeamLibraryTestCase
+import org.elixir_lang.code_insight.*
 import java.io.File
 
 /**
@@ -21,13 +11,12 @@ import java.io.File
  * source `@type`s these resolve to `TypeDefinitionImpl` decompiled PSI, so they exercise the branch of
  * the type reference that navigates into the `.beam` mirror rather than a source attribute.
  */
-class BeamTypeGotoDeclarationTest : PlatformTestCase() {
+class BeamTypeGotoDeclarationTest : BeamLibraryTestCase() {
     override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/type"
 
     override fun setUp() {
         super.setUp()
         HeadlessDataManager.fallbackToProductionDataManager(myFixture.testRootDisposable)
-        addBeamLibrary()
     }
 
     fun testCtrlClickOnRemoteBeamTypeChoosesGotoDeclaration() {
@@ -158,14 +147,17 @@ class BeamTypeGotoDeclarationTest : PlatformTestCase() {
         // round-trip) skip, which is why they stay green while the IDE collapses every within-beam usage onto
         // line 1. The adapter short-circuits to line -1 for any file whose `getFileType().isBinary()` is true,
         // so the fix is that the within-beam usages must resolve to a file the usage view treats as text.
-        val rows = com.intellij.openapi.application.ReadAction.compute<List<Pair<Int, String?>>, RuntimeException> {
-            usages.map { u ->
-                val adapter = com.intellij.usages.UsageInfo2UsageAdapter(
-                    com.intellij.usageView.UsageInfo(u.file, u.range, false)
-                )
-                Pair(adapter.line, adapter.usageInfo.virtualFile?.name)
+        // Callable, not a bare lambda: the lambda binds the deprecated Runnable overload and returns Void.
+        val rows = com.intellij.openapi.application.ReadAction.nonBlocking(
+            java.util.concurrent.Callable {
+                usages.map { u ->
+                    val adapter = com.intellij.usages.UsageInfo2UsageAdapter(
+                        com.intellij.usageView.UsageInfo(u.file, u.range, false)
+                    )
+                    Pair(adapter.line, adapter.usageInfo.virtualFile?.name)
+                }
             }
-        }
+        ).executeSynchronously()
         val distinctLines = rows.map { it.first }.distinct().sorted()
         val vfiles = rows.map { it.second }.distinct()
         assertEquals(
@@ -239,69 +231,5 @@ class BeamTypeGotoDeclarationTest : PlatformTestCase() {
             "The `queue` identifier should sit inside the decompiled `@opaque queue(item)` definition",
             generateSequence(target) { it.parent }.any { it.text.startsWith("@opaque queue") }
         )
-    }
-
-    private fun openBeamAndMoveCaretTo(beamName: String, anchor: String) {
-        val beamIo = File(File(testDataPath, "ebin").absoluteFile, beamName)
-        val beamVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(beamIo)
-        assertNotNull("Could not find decompiled $beamName in VFS", beamVf)
-        myFixture.configureFromExistingVirtualFile(beamVf!!)
-        val text = myFixture.editor.document.text
-        val anchorIndex = text.indexOf(anchor)
-        assertTrue("Anchor '$anchor' not found in decompiled $beamName", anchorIndex >= 0)
-        myFixture.editor.caretModel.moveToOffset(anchorIndex + anchor.length - 1)
-    }
-
-    @Throws(Exception::class)
-    override fun tearDown() {
-        try {
-            removeBeamLibrary()
-        } finally {
-            super.tearDown()
-        }
-    }
-
-    private fun addBeamLibrary() {
-        val ebinDir = File(testDataPath, "ebin").absoluteFile
-        assertTrue("ebin/ fixture directory not found at ${ebinDir.absolutePath}", ebinDir.isDirectory)
-
-        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, ebinDir.path)
-
-        val ebinVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebinDir)
-        assertNotNull("Could not find ebin/ fixture directory in VFS", ebinVf)
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(BEAM_LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(ebinVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
-    }
-
-    private fun removeBeamLibrary() {
-        ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
-            model.orderEntries
-                .filter { it.presentableName == BEAM_LIBRARY_NAME }
-                .forEach { model.removeOrderEntry(it) }
-        }
-
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            libraryTable.getLibraryByName(BEAM_LIBRARY_NAME)?.let { library ->
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
-    }
-
-    companion object {
-        private const val BEAM_LIBRARY_NAME = "type-goto-beam-lib"
     }
 }

--- a/tests/org/elixir_lang/psi/scope/call_definition_clause/SpecialFormSourceOverBeamTest.kt
+++ b/tests/org/elixir_lang/psi/scope/call_definition_clause/SpecialFormSourceOverBeamTest.kt
@@ -5,12 +5,11 @@ import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.roots.LibraryOrderEntry
 import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.common.runAll
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryFixture
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import java.io.File
 
@@ -91,18 +90,14 @@ class SpecialFormSourceOverBeamTest : PlatformTestCase() {
             null
         }
 
-        val libraryName = "special-forms-$name"
-        val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-        val library = WriteAction.computeAndWait<Library, RuntimeException> {
-            val lib = libraryTable.createLibrary(libraryName)
-            val model = lib.modifiableModel
-            model.addRoot(ebinVirtualDir!!, OrderRootType.CLASSES)
-            libVirtualDir?.let { model.addRoot(it, OrderRootType.SOURCES) }
-            model.commit()
-            lib
-        }
-
-        ModuleRootModificationUtil.addDependency(myFixture.module, library)
+        // Library name carries the test name: the light project is shared, so a fixed name would collide.
+        BeamLibraryFixture.addLibrary(
+            project,
+            myFixture.module,
+            "special-forms-$name",
+            listOf(ebinVirtualDir!!),
+            listOfNotNull(libVirtualDir),
+        )
     }
 
     private fun specialFormElementsAtCaret(): List<LookupElement> {

--- a/tests/org/elixir_lang/reference/callable/ErlangAtomQualifierTest.kt
+++ b/tests/org/elixir_lang/reference/callable/ErlangAtomQualifierTest.kt
@@ -1,13 +1,10 @@
 package org.elixir_lang.reference.callable
 
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.psi.PsiPolyVariantReference
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryFixture
 import java.io.File
 
 /**
@@ -124,30 +121,11 @@ class ErlangAtomQualifierTest : PlatformTestCase() {
         val beamDirVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(beamDir))
         assertNotNull("Could not find beam test data directory: $beamDir", beamDirVf)
 
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary("erlang_test_lib")
-            val libModel = library.modifiableModel
-            libModel.addRoot(beamDirVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
+        BeamLibraryFixture.addLibrary(project, myFixture.module, "erlang_test_lib", listOf(beamDirVf!!))
     }
 
     private fun removeBeamLibrary() {
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val library = libraryTable.getLibraryByName("erlang_test_lib")
-            if (library != null) {
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, "erlang_test_lib")
     }
 
     override fun getTestDataPath(): String =

--- a/tests/org/elixir_lang/reference/mfa_tuple/ErlangMfaTupleReferenceTest.kt
+++ b/tests/org/elixir_lang/reference/mfa_tuple/ErlangMfaTupleReferenceTest.kt
@@ -1,14 +1,11 @@
 package org.elixir_lang.reference.mfa_tuple
 
 import com.intellij.model.psi.PsiSymbolReferenceService
-import com.intellij.openapi.application.WriteAction
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.roots.OrderRootType
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryFixture
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.model.psi.atom.AtomReference
 import org.elixir_lang.psi.ElixirAtom
@@ -113,30 +110,11 @@ class ErlangMfaTupleReferenceTest : PlatformTestCase() {
         val beamDirVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(beamDir))
         assertNotNull("Could not find beam test data directory: $beamDir", beamDirVf)
 
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val model = libraryTable.modifiableModel
-            val library = model.createLibrary(LIBRARY_NAME)
-            val libModel = library.modifiableModel
-            libModel.addRoot(beamDirVf!!, OrderRootType.CLASSES)
-            libModel.commit()
-            model.commit()
-
-            ModuleRootModificationUtil.addDependency(myFixture.module, library)
-        }
+        BeamLibraryFixture.addLibrary(project, myFixture.module, LIBRARY_NAME, listOf(beamDirVf!!))
     }
 
     private fun removeBeamLibrary() {
-        WriteAction.run<Throwable> {
-            val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-            val library = libraryTable.getLibraryByName(LIBRARY_NAME)
-            if (library != null) {
-                libraryTable.modifiableModel.let { model ->
-                    model.removeLibrary(library)
-                    model.commit()
-                }
-            }
-        }
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, LIBRARY_NAME)
     }
 
     override fun getTestDataPath(): String = "testData/org/elixir_lang/reference/mfa_tuple"


### PR DESCRIPTION
Before:
<img width="1186" height="1953" alt="image" src="https://github.com/user-attachments/assets/e628f6e1-aca9-4890-81ac-0d94b6a25c6c" />


Fixed:
<img width="1189" height="1966" alt="image" src="https://github.com/user-attachments/assets/568abb48-ef5d-4f69-871d-f6cb3c008ee1" />

For this to work an `@Api.Internal` override is required. For completeness, this is what the rendering looks like without the override: 
<img width="1193" height="1993" alt="image" src="https://github.com/user-attachments/assets/8ede2f2f-cef1-4f55-8a2b-039349965248" />

