### PR TITLE
More fixes for CI multi-matrix Elixir/OTP coverage

### DIFF
--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -31,7 +31,12 @@
     "  Check OTP support against https://elixir.hexdocs.pm/compatibility-and-deprecations.html, which",
     "    is patch-aware: 1.14 is '23 - 25 (and Erlang/OTP 26 from v1.14.5)'. Do NOT use otp_versions",
     "    from elixir-lang.github.com's _data/elixir-versions.yml to decide the range - it is per-MINOR",
-    "    and misses OTP support added in a patch. Within the range prefer that file's recommended_otp."
+    "    and misses OTP support added in a patch. Within the range prefer that file's recommended_otp.",
+    "  A pair may also exist to cover an OTP major no other pair covers - ~75% of the swept BEAM surface",
+    "    is Erlang and the chunk formats track OTP, not Elixir - so the same Elixir may appear twice with",
+    "    different OTPs. Read by OTP major the pairs below are {24, 25, 26, 27, 28}. Prefer the cleanest",
+    "    in-window Elixir for such a leg so it isolates the OTP surface instead of inheriting a quoting",
+    "    backlog: 1.13.4 is 0-fail, 1.18.4 fails 291 but is the newest Elixir whose quoter still builds."
   ],
   "idea": {
     "minimumSupported": { "version": "2025.3.6", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
@@ -43,11 +48,13 @@
   "beam": {
     "baseline": { "elixir": "1.13.4", "otp": "24.3.4.6" },
     "additional": [
+      { "elixir": "1.13.4", "otp": "25.3.2.21" },
       { "elixir": "1.14.5", "otp": "26.2.5.21", "continue-on-error": true },
       { "elixir": "1.15.8", "otp": "26.2.5.21", "continue-on-error": true },
       { "elixir": "1.16.3", "otp": "26.2.5.21", "continue-on-error": true },
       { "elixir": "1.17.3", "otp": "27.1.2", "continue-on-error": true },
       { "elixir": "1.18.4", "otp": "27.3.4", "continue-on-error": true },
+      { "elixir": "1.18.4", "otp": "28.4", "continue-on-error": true },
       { "elixir": "1.19.5", "otp": "28.1", "continue-on-error": true },
       { "elixir": "1.20.2", "otp": "28.4", "continue-on-error": true }
     ]

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
         default: false
       upload-verifier-reports:
-        description: 'Upload test reports as artifacts'
+        description: 'Upload each verification leg''s reports as an artifact, even when it passes.'
         required: false
         type: boolean
         default: true
@@ -431,6 +431,6 @@ jobs:
     uses: ./.github/workflows/shared-verify.yml
     with:
       matrix: ${{ needs.test-matrix.outputs.verify }}
-      # inputs is empty for pull_request events, so this is false there, matching what the inline
-      # verification did before: reports upload only for workflow_call runs that ask for them.
+      # Empty for pull_request, so false there. Failing legs still upload: shared-verify.yml ORs in
+      # `failure()`.
       upload-verifier-reports: ${{ inputs.upload-verifier-reports || false }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -145,18 +145,40 @@ jobs:
       # the cache silently covers nothing.
       - name: Resolve quoter cache slug
         id: quoter-slug
+        env:
+          ELIXIR_VERSION: ${{ matrix.beam.elixir }}
+          OTP_VERSION: ${{ matrix.beam.otp }}
         run: |
           ref=$(grep -E '^quoterRef=' gradle.properties | head -1 | cut -d= -f2-)
           ref="${ref:-v2.1.0}"
-          echo "slug=${ref//\//-}" >> "$GITHUB_OUTPUT"
+          slug="${ref//\//-}"
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+          # Non-word characters collapse to "-" in sdk.pathToken, so do the same here - every OTP in
+          # ci-versions.json is already path-safe, but a future one that is not must not make the
+          # workflow and the build disagree about the directory name.
+          pair="elixir-$(printf %s "$ELIXIR_VERSION" | tr -c 'A-Za-z0-9._-' '-')"
+          pair="$pair-otp-$(printf %s "$OTP_VERSION" | tr -c 'A-Za-z0-9._-' '-')"
+          # Emitted once and consumed by BOTH cache steps, because they have to agree exactly.
+          # actions/cache identifies an entry by (key, version), and the version is a sha256 of the
+          # literal `path:` lines joined by "|" - the raw pattern strings, not the files they expand
+          # to (toolkit packages/cache: restoreCache and saveCacheV2 both hash the `paths` argument,
+          # saveCacheV1 hashes it in reserveCache). Two different lists therefore address two
+          # different entries under one key: restore looks up a version save never wrote, so it
+          # misses on every run, rebuilds the quoter from Hex, and then save collides with the entry
+          # some earlier run left under that key and reports "Unable to reserve cache".
+          {
+            echo "paths<<CACHE_PATHS_EOF"
+            echo "cache/${pair}-intellij_elixir-${slug}"
+            echo '!cache/**/tmp/pipe/**'
+            echo '!cache/**/distillery/priv'
+            echo "CACHE_PATHS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Restore Elixir cache
         id: restore-elixir-cache
         uses: actions/cache/restore@v6
         with:
-          path: |
-            cache/elixir-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}/_build
-            cache/elixir-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}/deps
+          path: ${{ steps.quoter-slug.outputs.paths }}
           key: elixir-${{ runner.os }}-${{ runner.arch }}-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-quoter-${{ hashFiles('gradle.properties') }}
           restore-keys: |
             elixir-${{ runner.os }}-${{ runner.arch }}-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-
@@ -183,15 +205,14 @@ jobs:
 
       # Save the quoter build (_build/deps) now that releaseQuoter has produced it - setup-env only
       # restores this cache; it cannot save it (those dirs do not exist until this step runs).
+      # `path` must stay the shared output, never a list written out here - see Resolve quoter cache
+      # slug for what diverging from Restore costs.
       - name: Save Elixir cache
         id: save-elixir-cache
         if: always() && steps.build-quoter.outcome == 'success' && steps.restore-elixir-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
-          path: |
-            cache/elixir-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}
-            !cache/**/tmp/pipe/**
-            !cache/**/distillery/priv
+          path: ${{ steps.quoter-slug.outputs.paths }}
           key: ${{ steps.restore-elixir-cache.outputs.cache-primary-key }}
 
       # An Elixir the declaration marks unsupported may fail at any phase above, not only here -

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -140,8 +140,9 @@ jobs:
 
       # Restore the quoter build cache (deps + _build) so the Build quoter step goes incremental. This
       # and its Save counterpart live here, not in setup-env, so the whole cache lifecycle sits next to
-      # the quoter build. The dir is namespaced by the gradle.properties quoterRef slug (slashes ->
-      # dashes), matching build.gradle.kts quoterRefSlug.
+      # the quoter build. The dir must name what build.gradle.kts writes - the Elixir/OTP pair (sdk
+      # .pairToken) plus the gradle.properties quoterRef slug (slashes -> dashes, quoterRefSlug) - or
+      # the cache silently covers nothing.
       - name: Resolve quoter cache slug
         id: quoter-slug
         run: |
@@ -154,8 +155,8 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: |
-            cache/elixir-${{ matrix.beam.elixir }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}/_build
-            cache/elixir-${{ matrix.beam.elixir }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}/deps
+            cache/elixir-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}/_build
+            cache/elixir-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}/deps
           key: elixir-${{ runner.os }}-${{ runner.arch }}-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-quoter-${{ hashFiles('gradle.properties') }}
           restore-keys: |
             elixir-${{ runner.os }}-${{ runner.arch }}-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-
@@ -188,7 +189,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: |
-            cache/elixir-${{ matrix.beam.elixir }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}
+            cache/elixir-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-intellij_elixir-${{ steps.quoter-slug.outputs.slug }}
             !cache/**/tmp/pipe/**
             !cache/**/distillery/priv
           key: ${{ steps.restore-elixir-cache.outputs.cache-primary-key }}

--- a/.github/workflows/shared-verify.yml
+++ b/.github/workflows/shared-verify.yml
@@ -294,10 +294,15 @@ jobs:
 
       # One invocation per job, so the action's fixed verification_result.log name needs no
       # per-product copy - the artifact name carries the product and version instead.
+      #
+      # `inputs.upload-verifier-reports` is always false on `pull_request`: the `inputs` context is
+      # empty for that trigger, and a `workflow_call` default applies only when the workflow is called.
+      # `failure()` is what uploads there, and it works only while `Verify Plugin` has no
+      # `continue-on-error`.
       - name: Upload Verify Reports
         id: upload-verify-reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ always() && inputs.upload-verifier-reports && steps.verify.outputs.verification-output-log-filename != '' }}
+        if: ${{ (failure() || inputs.upload-verifier-reports) && steps.verify.outputs.verification-output-log-filename != '' }}
         with:
           name: verify-plugin-reports-${{ matrix.product }}-${{ matrix.version }}
           path: |

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -540,6 +540,85 @@ jobs:
             if (noResults.length) headline.push(`**${noResults.length} produced no results**`);
             body.push(headline.join(' · '), '');
 
+            // Required legs are the only ones that can block a merge, so their verdict goes first - ahead of
+            // every other number here, all of which span both kinds of leg. On a matrix like this one the
+            // informational legs contribute ALL of the failures, so a pull request whose required legs are
+            // entirely green still led with "291 failed" and "1,251 failing runs", and the one figure that
+            // has to be zero for the pipeline to pass appeared nowhere. Computed from the same per-leg
+            // digests the tables below use, so the two cannot disagree.
+            const required = groups[0].rows;
+            const requiredIncomplete = required.filter(
+              (leg) => !leg.hasResults || leg.status.tests_ran === false,
+            );
+            // A required leg that published results but whose check carries no usable digest contributes an
+            // unknown number of failures, so the total is a floor, not the answer. Said, not hidden.
+            const requiredUncounted = required.filter((leg) => leg.hasResults && !leg.counts);
+            const requiredFailingLegs = required.filter(
+              (leg) => leg.counts && leg.counts.tests_fail + leg.counts.tests_error > 0,
+            );
+            // Summed across legs, so this counts runs rather than distinct tests - the same distinction the
+            // note under the aggregate table draws. A leg's digest cannot say which of its failures another
+            // leg also hit, and the number that matters here is zero either way.
+            const requiredFailingRuns = required.reduce(
+              (total, leg) => total + (leg.counts ? leg.counts.tests_fail + leg.counts.tests_error : 0),
+              0,
+            );
+
+            // The whole verdict is one bold span, so the clauses inside it carry no emphasis of their own:
+            // nesting `**` inside `**` does not reliably render as bold in GitHub-flavoured markdown.
+            const gate = [];
+            if (requiredFailingRuns) {
+              gate.push(
+                `${count(requiredFailingRuns)} failing test ${requiredFailingRuns === 1 ? 'run' : 'runs'}` +
+                  ` across ${requiredFailingLegs.length} of ${required.length}` +
+                  ` ${required.length === 1 ? 'leg' : 'legs'}`,
+              );
+            }
+            if (requiredIncomplete.length) {
+              gate.push(
+                requiredIncomplete.length === 1
+                  ? '1 leg did not run its tests'
+                  : `${requiredIncomplete.length} legs did not run their tests`,
+              );
+            }
+
+            if (!required.length) {
+              body.push(
+                '❔ **No leg reported itself as required**, so nothing here says whether this commit can' +
+                  ' merge.',
+                '',
+              );
+            } else if (gate.length) {
+              // A red gate stays red whatever the missing legs would have added; the caveat sits outside the
+              // verdict because it qualifies the number rather than the judgement.
+              const verdict = `❌ **Required legs: ${gate.join('; ')}.**`;
+              body.push(
+                requiredUncounted.length
+                  ? `${verdict} ${requiredUncounted.length} required` +
+                      ` ${requiredUncounted.length === 1 ? 'leg' : 'legs'} published no counts, so that is a` +
+                      ' lower bound.'
+                  : verdict,
+                '',
+              );
+            } else if (requiredUncounted.length) {
+              // Never ✅ here. A tick beside "and some of them did not report" is the same lie as a tick on a
+              // leg that never compiled: the gate is unknown, so it says unknown.
+              const counted = required.length - requiredUncounted.length;
+              body.push(
+                counted === 0
+                  ? '❔ **No required leg reported counts**, so whether anything blocks a merge is unknown.'
+                  : `❔ **Required legs: 0 failing tests among the ${counted} that reported counts**, but` +
+                      ` ${requiredUncounted.length} published none - so whether anything blocks a merge is` +
+                      ' unknown.',
+                '',
+              );
+            } else {
+              body.push(
+                `✅ **Required legs: 0 failing tests**, all ${required.length} ran to completion.`,
+                '',
+              );
+            }
+
             const timed = rows.filter((leg) => Number.isFinite(leg.seconds)).map((leg) => leg.seconds);
 
             if (aggregate && aggregate.stats) {
@@ -550,26 +629,57 @@ jobs:
               const runnerTime = timed.length ? timed.reduce((total, seconds) => total + seconds, 0) : undefined;
               const failures = stats.tests_fail + stats.tests_error;
               const failingRuns = stats.runs_fail + stats.runs_error;
+              // stats.runs_succ rather than a subtraction, so passing runs stay the action's arithmetic like
+              // every other figure here. The fallback only covers the field being absent from a future schema.
+              const passingRuns = Number.isFinite(stats.runs_succ)
+                ? stats.runs_succ
+                : stats.runs - failingRuns - stats.runs_skip;
+
+              // The action's `tests` is the union of distinct (class, test name) pairs over EVERY leg's XMLs,
+              // and on this matrix that roughly doubles the real figure: `org.elixir_lang.beam.SdkBeamParseTest`
+              // names each case after a `.beam` path in the resolved SDK, and the Erlang half of those - about
+              // 1 400 of ~1 700 - carries the OTP application version in the path (`erlang/kernel-8.3.2.2/...`),
+              // so every OTP bump renames nearly all of them. Measured on run 31156815241: 4 897 ordinary tests
+              // identical on every leg, 8 016 distinct sweep cases across the matrix, 12 913 together against
+              // 6 560-6 659 that any single leg actually ran. Nobody can act on that union, so it is not shown;
+              // each leg's own count comes from the per-leg digests already decoded above.
+              // Legs that never got to their tests are excluded - their 6 would otherwise be the bottom of the
+              // range. If nothing reported a status, every leg counts and the ❔ note below says the totals are
+              // of unknown completeness.
+              const anyStatus = rows.some((leg) => leg.status);
+              const legTests = rows
+                .filter((leg) => leg.counts && (!anyStatus || (leg.status && leg.status.tests_ran === true)))
+                .map((leg) => leg.counts.tests);
+              const perLeg = legTests.length
+                ? Math.min(...legTests) === Math.max(...legTests)
+                  ? count(legTests[0])
+                  : `${count(Math.min(...legTests))} - ${count(Math.max(...legTests))}`
+                : '-';
+              // Named exactly for what was measured, so the row does not quietly speak for the legs it skipped.
+              const perLegLabel =
+                legTests.length && legTests.length < rows.length ? 'tests per completed leg' : 'tests per leg';
 
               body.push(
                 '| | count |',
                 '|---|---:|',
-                `| tests | ${count(stats.tests)} |`,
-                `| ✅ passed | ${count(stats.tests_succ)} |`,
-                `| ❌ failed | ${failures ? `**${count(failures)}**` : count(failures)} |`,
-                `| 💤 skipped | ${count(stats.tests_skip)} |`,
+                `| ${perLegLabel} | ${perLeg} |`,
                 `| runs | ${count(stats.runs)} |`,
+                `| ✅ passing runs | ${count(passingRuns)} |`,
                 `| ❌ failing runs | ${failingRuns ? `**${count(failingRuns)}**` : count(failingRuns)} |`,
+                `| 💤 skipped runs | ${count(stats.runs_skip)} |`,
+                `| ❌ distinct tests failing somewhere | ${failures ? `**${count(failures)}**` : count(failures)} |`,
                 `| result files | ${count(stats.files)} |`,
                 `| wall clock (longest leg) | ${duration(wallClock)} |`,
                 `| runner time (all legs) | ${duration(runnerTime)} |`,
                 '',
-                // The action's own check title says "291 fail" while its body says "960 ❌", and both are right.
-                // Which one answers "how bad is this" depends on the matrix, so name both rather than picking.
-                '`tests` counts distinct test cases; `runs` counts executions, so a test present in every leg is' +
-                  ' one test and as many runs as there are legs. **`failing runs` is the number to read** for a' +
-                  ' matrix whose job is per-version validation; `failed` is how many distinct tests fail' +
-                  ' *somewhere*.',
+                // The action's own check title says "291 fail" while its body says "1,251 ❌", and both are
+                // right. Which one answers "how bad is this" depends on the matrix, so name both rather than
+                // picking - but say which is which, because "291" reads like a per-leg number and is not one.
+                '`runs` counts executions across the whole matrix, so a test present in every leg is one test' +
+                  ' and as many runs as there are legs - **that is the figure to read** for a matrix whose job' +
+                  ' is per-version validation. `distinct tests failing somewhere` collapses it back: a test that' +
+                  ' fails on four legs counts once. Every row spans required and informational legs alike; only' +
+                  ' the required-leg line above decides whether this commit can merge.',
                 '',
               );
 
@@ -592,7 +702,8 @@ jobs:
               if (unknown.length) {
                 body.push(
                   `❔ ${unknown.length} ${unknown.length === 1 ? 'leg' : 'legs'} did not report a status, so` +
-                    ' whether their totals are complete is unknown.',
+                    ' whether their totals are complete is unknown - and, since nothing says whether they are' +
+                    ' required, they are not in the required-leg line either.',
                   '',
                 );
               }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
     variables, which Gradle could not see, so `mise use erlang@X elixir@Y` followed by `check` reported
     the *previous* pair's results - the task was up to date, and the build cache would even restore
     those results after a `cleanTest`. Both test tasks now declare the versions as inputs.
+  - CI restores the Elixir quoter cache again - it never had. `actions/cache` identifies an entry by key
+    *and* by a version hashed from the literal `path:` lines, and the restore and save steps listed
+    different paths, so they addressed different entries under one key. Every leg missed, rebuilt its
+    quoter dependencies from Hex, then failed to save against the entry an earlier run had left there -
+    reported as `Unable to reserve cache`, which reads as a harmless race between legs. Both steps now
+    take the path list from one place.
 
 ## [24.0.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@
     variables, which Gradle could not see, so `mise use erlang@X elixir@Y` followed by `check` reported
     the *previous* pair's results - the task was up to date, and the build cache would even restore
     those results after a `cleanTest`. Both test tasks now declare the versions as inputs.
+  - A transient 5xx from JetBrains' artifact CDN no longer loses a whole test leg. Gradle already treats
+    repository server errors as retryable, but its default budget is three attempts over about three
+    seconds; `gradle.properties` now allows eight from a 3-second doubling backoff, roughly six minutes,
+    for every build - CI and local alike.
   - CI restores the Elixir quoter cache again - it never had. `actions/cache` identifies an entry by key
     *and* by a version hashed from the literal `path:` lines, and the restore and save steps listed
     different paths, so they addressed different entries under one key. Every leg missed, rebuilt its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@
     quoter dependencies from Hex, then failed to save against the entry an earlier run had left there -
     reported as `Unable to reserve cache`, which reads as a harmless race between legs. Both steps now
     take the path list from one place.
+  - The test results comment now leads with failures on the **required** legs, the only figure that
+    decides whether a pull request can merge, and reports `tests per leg` in place of a cross-leg
+    union that read 12,913 for a run in which no leg ran more than 6,659.
 
 ## [24.0.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
     leg is required and any later change that breaks it fails the pipeline. OTP 28 stays informational:
     its 291 failures are all pre-existing Elixir-keyed quoting cases, with no OTP-28 decompiler
     failures.
+  - Switching Elixir/OTP versions now re-runs the tests. The versions reach the test JVM as environment
+    variables, which Gradle could not see, so `mise use erlang@X elixir@Y` followed by `check` reported
+    the *previous* pair's results - the task was up to date, and the build cache would even restore
+    those results after a `cleanTest`. Both test tasks now declare the versions as inputs.
 
 ## [24.0.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
     requests. Previously the upload was gated on an input that is always empty for `pull_request`, so
     the reports were unobtainable on exactly the runs that needed them and the evidence had to be dug
     out of a raw job log. Green runs still upload nothing unless a caller asks.
+  - Everything scoped to an Elixir/OTP pair is now keyed on the pair: `MIX_HOME` joins `MIX_ARCHIVES`,
+    and the quoter's `_build`/`deps` join both. Two OTPs for one Elixir previously shared a build tree
+    and overwrote each other, and switching versions re-downloaded hex and rebar. The first build per
+    pair after this change reinstalls and rebuilds once.
 
 ## [24.0.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@
     and the quoter's `_build`/`deps` join both. Two OTPs for one Elixir previously shared a build tree
     and overwrote each other, and switching versions re-downloaded hex and rebar. The first build per
     pair after this change reinstalls and rebuilds once.
+  - CI now covers OTP 25, and runs a decompiler sweep against OTP 28 for the first time. Two
+    `beam.additional` pairs were added, `1.13.4 / 25.3.2.21` and `1.18.4 / 28.4`, chosen to cover OTP
+    majors rather than Elixir minors: most of the decompiled surface is Erlang and the BEAM chunk formats
+    track OTP. **OTP 25 is now a supported pair** - measured locally at 6 560 tests, 0 failures, so its
+    leg is required and any later change that breaks it fails the pipeline. OTP 28 stays informational:
+    its 291 failures are all pre-existing Elixir-keyed quoting cases, with no OTP-28 decompiler
+    failures.
 
 ## [24.0.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
     is genuinely nothing to record.
   - The Tag Release workflow validates the tag shape against the `prerelease` input, that a release is
     cut from `main`, that the tag is new and increases, and that it matches `pluginVersion`.
+  - Plugin verifier reports are now uploaded whenever a verification leg fails, including on pull
+    requests. Previously the upload was gated on an input that is always empty for `pull_request`, so
+    the reports were unobtainable on exactly the runs that needed them and the evidence had to be dug
+    out of a raw job log. Green runs still upload nothing unless a caller asks.
 
 ## [24.0.0] - 2026-08-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,12 +137,12 @@ Gradle will handle all dependency management, including fetching the Intellij ID
 **The tests need Elixir and Erlang. The build does not compile them from source** - it *resolves* an
 already-installed pair. The `resolveElixirErlangSdks` task looks in this order and stops at the first hit:
 
-| # | Erlang | Elixir |
-|---|---|---|
-| 1 | `ERLANG_SDK_HOME` env var | `ELIXIR_SDK_HOME` env var |
-| 2 | `erl` on `PATH` | `elixir` on `PATH` |
-| 3 | `mise install erlang@<expected>` | `mise install elixir@<expected>` |
-| 4 | - | download + `make` from source (last resort, slow) |
+| # | Erlang                           | Elixir                                            |
+|---|----------------------------------|---------------------------------------------------|
+| 1 | `ERLANG_SDK_HOME` env var        | `ELIXIR_SDK_HOME` env var                         |
+| 2 | `erl` on `PATH`                  | `elixir` on `PATH`                                |
+| 3 | `mise install erlang@<expected>` | `mise install elixir@<expected>`                  |
+| 4 | -                                | download + `make` from source (last resort, slow) |
 
 It then exports `ELIXIR_LANG_ELIXIR_PATH`, `ELIXIR_EBIN_DIRECTORY`, `ELIXIR_VERSION`, `ERLANG_SDK_HOME`
 and a `PATH` prefix to every test task, so you never set those by hand.
@@ -363,7 +363,13 @@ resolved versions - so a bad declaration is diagnosable locally rather than from
 | | Elixir | OTP | Status |
 |---|---|---|---|
 | `beam.baseline` | 1.13.4 | 24.3.4.6 | **supported** - must be green |
-| `beam.additional` | every minor above the baseline | see the file | unsupported - informational |
+| `beam.additional` | later minors, plus pairs covering an OTP major no other leg covers | see the file | **supported** when the entry has no `continue-on-error`, otherwise informational |
+
+`beam.additional` is not one-entry-per-Elixir-minor: a pair may exist to cover an **OTP major** no other
+pair covers, because most of the decompiled surface is Erlang and the BEAM chunk formats track OTP
+rather than Elixir. So the same Elixir can appear twice with different OTPs - `1.13.4` currently does.
+For such a leg, prefer the cleanest in-window Elixir so it isolates the OTP surface instead of
+inheriting a quoting backlog.
 
 Check which OTP an Elixir supports against the
 [compatibility table](https://elixir.hexdocs.pm/compatibility-and-deprecations.html) - it accounts for
@@ -375,7 +381,8 @@ decide the range: it is per-minor and misses patch-level additions.
 
 ##### Widening Elixir support
 
-`beam.additional` is a ratchet. Each entry moves one Elixir version from unsupported to supported:
+`beam.additional` is a ratchet. Each entry moves one pair - an Elixir version, an OTP major, or both -
+from unsupported to supported:
 
 1. **Add the pair** with `"continue-on-error": true`. That declares it **unsupported**, and its leg is
    expected to be red. Adding a version is safe at any time - it cannot block a merge.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,8 @@ import sdk.ElixirErlangSdkArgumentProvider
 import sdk.MiseCurrentVersionValueSource
 import sdk.ErlangAvailabilityCheckAction
 import sdk.ResolveElixirErlangSdksTask
+import sdk.mixPairDir
+import sdk.pairToken
 import sdk.versionWithoutBuildTag
 import sdk.elixirTestEnvironment
 import versioning.ChangelogSettings
@@ -95,9 +97,11 @@ val expectedOtpVersion: Provider<String> =
 val expectedVersionSource: String =
     if (providers.gradleProperty("elixirVersion").isPresent) "-PelixirVersion/-PotpVersion" else "mise"
 
-// Names the per-version cache directories below, so a quoter built under one Elixir is never reused
-// for another. The -otp-N build tag is stripped: mise reports "1.13.4-otp-24" where CI passes
-// "1.13.4", and they are the same Elixir - keeping the tag would give the two a cache tree each.
+// The Elixir half of the cache directory names below (the quoter tree pairs this with the OTP version;
+// see quoterUnzippedPath), so a quoter built under one Elixir is never reused for another. The -otp-N
+// build tag is stripped: mise reports "1.13.4-otp-24" where CI passes "1.13.4", and they are the same
+// Elixir - keeping the tag would give the two a cache tree each. Note that tag is not the OTP version:
+// it records which OTP that Elixir release was built for, and the pair keying uses the real one.
 // Only "unresolved" when neither properties nor mise answered; resolveElixirErlangSdks then fails
 // with instructions before anything writes to that path.
 val elixirVersion: String = versionWithoutBuildTag(expectedElixirVersion.getOrElse("unresolved"))
@@ -160,16 +164,33 @@ val javaVersionStr: String = if (platformBuildNumber >= 262) "25" else libs.vers
 // Setup Paths
 val cachePath: Directory = layout.projectDirectory.dir("cache")
 val elixirPath: Directory = cachePath.dir("elixir-$elixirVersion")
-val quoterUnzippedPath: Directory = cachePath.dir("elixir-$elixirVersion-intellij_elixir-$quoterRefSlug")
+// Keyed on the Elixir/OTP PAIR, via the same rule as MIX_HOME/MIX_ARCHIVES below. `_build` and `deps`
+// hold BEAM code and a distillery release, so the reason MIX_ARCHIVES is pair-keyed - the loader
+// rejects a chunk layout built by a different OTP - applies here unchanged. Keyed on Elixir alone,
+// 1.13.4/24.3.4.6 and 1.13.4/25.3.2.21 shared one tree and overwrote each other's build, while their
+// hex/rebar sat in correctly separated pair directories.
+val quoterUnzippedPath: Directory =
+    cachePath.dir("${pairToken(elixirVersion, expectedOtpVersion.getOrElse("unresolved"))}-intellij_elixir-$quoterRefSlug")
 val quoterExe: RegularFile = quoterUnzippedPath.file("_build/dev/rel/intellij_elixir/bin/intellij_elixir")
 val quoterTmpPath: Directory = cachePath.dir("quoter_tmp_$quoterRefSlug")
-// hex/rebar + fetched deps are cached under the project (used by the quoter mix build). Both are
-// declared outputs of getQuoterDeps, so the build cache restores them with `deps` and an up-to-date
-// task skips the `mix local.hex`/`local.rebar` network round-trips. mixArchivesPath is the ROOT: mix
-// installs archives flat, so getQuoterDeps namespaces a subdirectory per Elixir/OTP pair (see
-// sdk.mixArchivesDir) to stop one pair's hex being loaded by another.
+// hex/rebar + fetched deps are cached under the project (used by the quoter mix build).
 val mixHomePath: Directory = cachePath.dir("mix_home")
 val mixArchivesPath: Directory = cachePath.dir("mix_archives")
+
+// MIX_HOME and MIX_ARCHIVES for the pair this build targets. getQuoterDeps declares both as outputs, so
+// each must be the PAIR directory and never the shared root: with a root declared, a sibling pair's
+// install changed this task's output snapshot, so the other pair's entry could not be restored and a
+// version switch reinstalled hex and rebar over the network. Pair-keying also makes anything present
+// provably this pair's, which is what lets the task skip an install it already has.
+//
+// Keyed on the *expected* versions so the paths are known at configuration time - safe because
+// resolveElixirErlangSdks rejects any SDK whose actual version is not isCompatibleVersion with the
+// expected one. Both quoter tasks are wired from these two values, so a declared output and the
+// directory mix actually writes cannot drift apart.
+val mixHomeForPair: File =
+    mixPairDir(mixHomePath.asFile, elixirVersion, expectedOtpVersion.getOrElse("unresolved"))
+val mixArchivesForPair: File =
+    mixPairDir(mixArchivesPath.asFile, elixirVersion, expectedOtpVersion.getOrElse("unresolved"))
 
 // EXPORT FOR SUBPROJECTS (Required for jps-builder to access this path)
 extra["elixirPath"] = elixirPath.asFile.absolutePath
@@ -790,8 +811,8 @@ val getQuoterDeps = tasks.register<GetQuoterDepsTask>("getQuoterDeps") {
     quoterDir.set(quoterUnzippedPath)
     depsDir.set(quoterUnzippedPath.dir("deps"))
     sdkProperties.set(sdkPropertiesFile)
-    mixHome.set(mixHomePath)
-    mixArchivesRoot.set(mixArchivesPath)
+    mixHome.set(mixHomeForPair)
+    mixArchives.set(mixArchivesForPair)
 
     // INPUTS: mix.exs and mix.lock define requirements
     inputs.file(quoterUnzippedPath.file("mix.exs"))
@@ -810,8 +831,8 @@ val releaseQuoter = tasks.register<ReleaseQuoterTask>("releaseQuoter") {
     quoterDir.set(quoterUnzippedPath)
     buildDir.set(quoterUnzippedPath.dir("_build"))
     sdkProperties.set(sdkPropertiesFile)
-    mixHome.set(mixHomePath)
-    mixArchivesRoot.set(mixArchivesPath)
+    mixHome.set(mixHomeForPair)
+    mixArchives.set(mixArchivesForPair)
 
     // INPUTS: mix.exs, lockfile, source code, and dependencies
     inputs.files(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -194,6 +194,9 @@ val mixArchivesForPair: File =
 
 // EXPORT FOR SUBPROJECTS (Required for jps-builder to access this path)
 extra["elixirPath"] = elixirPath.asFile.absolutePath
+// Declared as test-task inputs in both projects - see the root `test` task for why.
+extra["expectedElixirVersion"] = expectedElixirVersion.getOrElse("unresolved")
+extra["expectedOtpVersion"] = expectedOtpVersion.getOrElse("unresolved")
 
 // Version suffix logic:
 // - "default" channel = no suffix (release build)
@@ -891,6 +894,15 @@ tasks.named<Test>("test") {
     doFirst {
         environment(elixirTestEnvironment(sdkProps.get().asFile))
     }
+
+    // The Elixir/OTP versions reach the test JVM as environment variables set in that doFirst, which
+    // Gradle cannot see, so they have to be declared or a version switch does not invalidate this task.
+    // Without them `mise use erlang@X elixir@Y && gradlew check` reports the *previous* pair's results:
+    // the task is UP-TO-DATE, and because the cache key is equally blind the build cache restores those
+    // results even after a cleanTest. Measured before this was added - a 1.18.4/OTP-28 run "passed" in
+    // 28 s with 1.13.4/OTP-25's results.
+    inputs.property("elixirVersion", expectedElixirVersion)
+    inputs.property("otpVersion", expectedOtpVersion)
 
     // The parsing tests are JUnit 3 (com.intellij.testFramework.ParsingTestCase -> TestCase),
     // discovered by the JUnit 4 runner.

--- a/buildSrc/src/main/kotlin/quoter/tasks/GetQuoterDepsTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/GetQuoterDepsTask.kt
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import sdk.mixArchivesDir
 import sdk.mixEnvironment
 import sdk.mixExecutable
 import sdk.readPropertiesFile
@@ -40,7 +39,12 @@ abstract class GetQuoterDepsTask : DefaultTask() {
     abstract val quoterDir: DirectoryProperty
 
     /**
-     * MIX_HOME and the MIX_ARCHIVES root are OUTPUTS, not internal state: `mix local.rebar` and
+     * MIX_HOME for this build's Elixir/OTP pair, wired from `build.gradle.kts`. Per-pair rather than
+     * shared: mix's own `<MIX_HOME>/elixir/1-15/` namespacing is not universal (1.13 writes `rebar3` to
+     * the root), and while this is a declared output a shared directory meant another pair's install
+     * changed this task's output snapshot.
+     *
+     * MIX_HOME and MIX_ARCHIVES are OUTPUTS, not internal state: `mix local.rebar` and
      * `mix local.hex` populate them, and `releaseQuoter`'s `mix release` cannot run without them.
      * Declaring them has two effects that the previous `@Internal` did not:
      *
@@ -53,9 +57,14 @@ abstract class GetQuoterDepsTask : DefaultTask() {
     @get:OutputDirectory
     abstract val mixHome: DirectoryProperty
 
-    /** Root holding one [mixArchivesDir] per Elixir/OTP pair - not MIX_ARCHIVES itself. */
+    /**
+     * MIX_ARCHIVES itself - the directory for the Elixir/OTP pair this build targets, wired from
+     * `build.gradle.kts`. Declaring the enclosing root here instead meant a sibling pair's directory
+     * changed this task's output snapshot, so the other pair's cache entry could not be restored and a
+     * version switch re-downloaded hex.
+     */
     @get:OutputDirectory
-    abstract val mixArchivesRoot: DirectoryProperty
+    abstract val mixArchives: DirectoryProperty
 
     @get:OutputDirectory
     abstract val depsDir: DirectoryProperty
@@ -75,11 +84,7 @@ abstract class GetQuoterDepsTask : DefaultTask() {
         val erlangHome = File(props["erlang.sdk.path"] ?: throw GradleException("Missing erlang.sdk.path"))
         val mixExe = mixExecutable(elixirHome)
         val home = mixHome.get().asFile.apply { mkdirs() }
-        val archives = mixArchivesDir(
-            mixArchivesRoot.get().asFile,
-            props["elixir.version"],
-            props["erlang.version"]
-        ).apply { mkdirs() }
+        val archives = mixArchives.get().asFile.apply { mkdirs() }
         val mixEnv = mixEnvironment(erlangHome, home, archives)
         val dir = quoterDir.get().asFile
 
@@ -92,8 +97,31 @@ abstract class GetQuoterDepsTask : DefaultTask() {
         }
 
         // hex + rebar are required to fetch dependencies.
-        mix("local.rebar", "--force")
-        mix("local.hex", "--force")
+        //
+        // `--force` suppresses the overwrite prompt, not the download, so the only way to avoid the
+        // network round-trip is not to call it. This task cannot be made up-to-date or cacheable across
+        // a version switch - `deps` sits inside unzipQuoter's declared output directory, which disables
+        // caching, and up-to-date history holds one entry per task - so it re-executes whenever the
+        // targeted pair changes, and skipping the reinstall is what keeps that cheap.
+        //
+        // Presence is a sound signal only because both directories are keyed on the Elixir/OTP pair:
+        // anything in them was installed by this task for this pair. Neither is searched at a fixed
+        // depth - mix puts `hex-<version>` directly in MIX_ARCHIVES, but `rebar3` either in MIX_HOME's
+        // root (Elixir 1.13) or under `elixir/<minor>/` (later), so the layout is not predicted.
+        val installedHex = archives.listFiles()?.firstOrNull { it.name.startsWith("hex-") }
+        if (installedHex == null) {
+            mix("local.hex", "--force")
+        } else {
+            logger.info("Reusing ${installedHex.name} in ${archives.name}; skipping mix local.hex")
+        }
+
+        val installedRebar = home.walkTopDown().firstOrNull { it.isFile && it.name.startsWith("rebar3") }
+        if (installedRebar == null) {
+            mix("local.rebar", "--force")
+        } else {
+            logger.info("Reusing ${installedRebar.name} in ${home.name}; skipping mix local.rebar")
+        }
+
         mix("deps.get")
     }
 }

--- a/buildSrc/src/main/kotlin/quoter/tasks/ReleaseQuoterTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/ReleaseQuoterTask.kt
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
-import sdk.mixArchivesDir
 import sdk.mixEnvironment
 import sdk.mixExecutable
 import sdk.readPropertiesFile
@@ -42,9 +41,9 @@ abstract class ReleaseQuoterTask : DefaultTask() {
     @get:Internal
     abstract val mixHome: DirectoryProperty
 
-    /** Root holding one [mixArchivesDir] per Elixir/OTP pair - not MIX_ARCHIVES itself. */
+    /** MIX_ARCHIVES for this build's Elixir/OTP pair; populated by `getQuoterDeps`, read here. */
     @get:Internal
-    abstract val mixArchivesRoot: DirectoryProperty
+    abstract val mixArchives: DirectoryProperty
 
     @get:OutputDirectory
     abstract val buildDir: DirectoryProperty
@@ -62,11 +61,7 @@ abstract class ReleaseQuoterTask : DefaultTask() {
         val elixirHome = File(props["elixir.sdk.path"] ?: throw GradleException("Missing elixir.sdk.path"))
         val erlangHome = File(props["erlang.sdk.path"] ?: throw GradleException("Missing erlang.sdk.path"))
         val mixExe = mixExecutable(elixirHome)
-        val archives = mixArchivesDir(
-            mixArchivesRoot.get().asFile,
-            props["elixir.version"],
-            props["erlang.version"]
-        )
+        val archives = mixArchives.get().asFile
         val mixEnv = mixEnvironment(erlangHome, mixHome.get().asFile, archives)
 
         execOps.exec {

--- a/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
+++ b/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
@@ -41,7 +41,7 @@ fun erlangRuntimeEnvironment(erlangHome: File): Map<String, String> {
  * Full environment for `mix` commands: the Erlang runtime environment plus MIX_HOME/MIX_ARCHIVES so
  * hex/rebar and fetched dependencies are cached under the project rather than the user's home.
  *
- * Pass [mixArchives] the per-version directory from [mixArchivesDir], not the shared root.
+ * Pass both the per-pair directories from [mixPairDir], never a shared root - see that function.
  */
 fun mixEnvironment(erlangHome: File, mixHome: File, mixArchives: File): Map<String, String> =
     erlangRuntimeEnvironment(erlangHome) + mapOf(
@@ -50,20 +50,37 @@ fun mixEnvironment(erlangHome: File, mixHome: File, mixArchives: File): Map<Stri
     )
 
 /**
- * MIX_ARCHIVES directory for one Elixir/OTP pair, under the shared [root].
+ * Directory for one Elixir/OTP pair under a shared [root]. Used for both MIX_ARCHIVES and MIX_HOME.
  *
- * Mix namespaces MIX_HOME by Elixir version itself (`<MIX_HOME>/elixir/1-15/`), but installs archives
- * flat into MIX_ARCHIVES (`hex-2.5.1/`). A single shared archives directory therefore hands a hex
- * compiled by one Elixir/OTP to another, which fails to load:
+ * Mix installs archives flat into MIX_ARCHIVES (`hex-2.5.1/`), so a single shared archives directory
+ * hands a hex compiled by one Elixir/OTP to another, which fails to load:
  *
  *     Error loading module 'Elixir.Hex': corrupt atom table
  *
- * Namespacing by both versions keeps each pair's hex separate. OTP is part of the key because the
- * archive is BEAM code: an Elixir release ships per-OTP builds, and the loader rejects a chunk layout
- * from a different OTP.
+ * OTP is part of the key because the archive is BEAM code: an Elixir release ships per-OTP builds, and
+ * the loader rejects a chunk layout from a different OTP.
+ *
+ * MIX_HOME is keyed the same way even though mix namespaces it internally by Elixir version
+ * (`<MIX_HOME>/elixir/1-15/`), for two reasons. That namespacing is not universal - Elixir 1.13 writes
+ * `rebar3` to the root - so the pairs are not reliably isolated from each other. And a shared MIX_HOME
+ * is declared as an output of `getQuoterDeps`, so one pair's install changed another pair's output
+ * snapshot. Keying it makes each pair's contents provably its own, which is what lets the task skip a
+ * reinstall it already has.
  */
-fun mixArchivesDir(root: File, elixirVersion: String?, erlangVersion: String?): File =
-    File(root, "elixir-${pathToken(elixirVersion)}-otp-${pathToken(erlangVersion)}")
+fun mixPairDir(root: File, elixirVersion: String?, erlangVersion: String?): File =
+    File(root, pairToken(elixirVersion, erlangVersion))
+
+/**
+ * `elixir-<elixir>-otp-<otp>` - the one naming rule for anything scoped to a single Elixir/OTP pair.
+ *
+ * Shared with the quoter build directory rather than being private to [mixPairDir]: the reason given
+ * above for keying MIX_ARCHIVES on OTP - the content is BEAM code, and the loader rejects a chunk
+ * layout from a different OTP - applies just as much to the quoter's own `_build` and `deps`. Both
+ * therefore derive their directory name here, so a pair's build tree and the hex/rebar that produced
+ * it cannot end up scoped differently.
+ */
+fun pairToken(elixirVersion: String?, erlangVersion: String?): String =
+    "elixir-${pathToken(elixirVersion)}-otp-${pathToken(erlangVersion)}"
 
 /** Reduce a version string to something safe to use as a single path segment. */
 private fun pathToken(version: String?): String =

--- a/gradle.properties
+++ b/gradle.properties
@@ -132,6 +132,22 @@ org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes=\
 org.gradle.jvmargs=-Xmx4096m
 kotlin.daemon.jvmargs=-Xmx4906m
 
+# --- Dependency download retries ---
+# Widens a budget Gradle already applies to repository 5xx; it does not switch retrying on. Four
+# properties because two layers implement it independently: max.tentatives
+# (ErrorHandlingModuleComponentRepository) and max.attempts (NetworkOperationBackOffAndRetry). Both
+# read with Integer.getInteger, hence systemProp - a bare org.gradle.internal.* line is ignored.
+#
+# The value is ATTEMPTS, not retries, and the backoff doubles: total wait is
+# 3000*(2^(attempts-1) - 1) ms, so an unrecoverable download costs ~6.4 min per Gradle invocation.
+# Check that against the test legs' timeout-minutes if you raise either.
+#
+# Editing this file re-primes the Elixir quoter cache: hashFiles('gradle.properties') is in its key.
+systemProp.org.gradle.internal.repository.max.tentatives=8
+systemProp.org.gradle.internal.repository.initial.backoff=3000
+systemProp.org.gradle.internal.network.retry.max.attempts=8
+systemProp.org.gradle.internal.network.retry.initial.backOff=3000
+
 # @todo Once this has been tested to be stable with the intellij-elixir codebase, enable.
 # Others have it on without issues, so I'm not overly worried - just want to confirm stability.
 # Can always just turn it off for CI.

--- a/jps-builder/build.gradle.kts
+++ b/jps-builder/build.gradle.kts
@@ -43,6 +43,12 @@ tasks.test {
         environment(sdk.elixirTestEnvironment(sdkProps.get().asFile))
     }
 
+    // Same reason as the root `test` task: the versions arrive as environment variables set in that
+    // doFirst, so without declaring them a version switch leaves this task UP-TO-DATE (or restores the
+    // previous pair's results from the build cache) and reports the wrong pair's numbers.
+    inputs.property("elixirVersion", rootProject.extra["expectedElixirVersion"])
+    inputs.property("otpVersion", rootProject.extra["expectedOtpVersion"])
+
     include("**/*Test.class")
 
     // Allow the task to succeed when a global --tests filter matches nothing in this subproject


### PR DESCRIPTION
Follow-on fixes for the multi-version Elixir/OTP matrix. Seven independent changes — each commit stands alone and carries its own reasoning.

## Coverage

- **Cover OTP 25 as supported, sweep OTP 28** (`51c0073c`) — read by OTP major the matrix declared {24, 26, 27, 28}, and only {24, 26, 27} ever reached the test phase: both OTP-28 legs died at the quoter build. `1.13.4 / 25.3.2.21` is now **required** (measured locally at 6 560 tests, 0 failures); `1.18.4 / 28.4` stays informational and is the cheapest route to OTP-28 evidence. 13 test legs — 5 required, 8 informational.

## Build correctness

- **Key `MIX_HOME`, `MIX_ARCHIVES` and the quoter build per Elixir/OTP pair** (`c2bafb3c`) — the quoter build directory was keyed on Elixir alone, so `1.13.4/24.3.4.6` and `1.13.4/25.3.2.21` shared one `_build` and overwrote each other, while their hex/rebar sat in correctly separated directories. The content is BEAM code and the loader rejects a chunk layout from a different OTP. CI hid it because a leg is one pair on a fresh runner.
- **Make the Elixir/OTP versions inputs of the test tasks** (`5467362a`) — the versions reached the test JVM through a `doFirst` environment block Gradle could not see, so `mise use erlang@X elixir@Y && gradlew check` reported the *previous* pair's results, and the build cache restored them even after `cleanTest`.

## CI reliability

- **Restore the Elixir quoter cache** (`f87e8a7a`) — it never had been, once. `actions/cache` addresses an entry by key **and** by a version hashed from the literal `path:` lines, and restore and save listed different paths, so they addressed different entries under one key. Every leg missed, rebuilt from Hex, then collided with the entry an earlier run had left there — which surfaces as `Unable to reserve cache` and reads like a benign race between legs.
- **Increase dependency download retries** (`09530f60`) — a 502 from `cache-redirector.jetbrains.com` took a required leg down. Widens an existing budget rather than switching one on: ~3 s of retries becomes ~6 min.
- **Upload verifier reports when a leg fails** (`e4afeff8`) — `inputs.upload-verifier-reports` is always false on `pull_request`, so reports were unobtainable on exactly the runs that needed them.

## Reporting

- **Report failures on the required legs, and tests per leg** (`9579e11a`) — every figure in the test results comment spanned required and informational legs together. On this matrix the informational legs contribute **all** of the failures (`1+89+288+291+291+291 = 1251`, exactly the aggregate), so a pull request whose five required legs were entirely green still led with "291 failed", and the one number that has to be zero for the pipeline to pass appeared nowhere. The same commit replaces the cross-leg `tests` union, which read 12 913 for a run in which no leg ran more than 6 659.

<details>
<summary>What that last one changes in the comment</summary>

Before:

```
Commit `09530f60` · 13 legs · **2 did not complete**

| | count |
|---|---:|
| tests | 12,913 |
| ✅ passed | 12,622 |
| ❌ failed | **291** |
| 💤 skipped | 0 |
| runs | 72,463 |
| ❌ failing runs | **1,251** |
```

After:

```
Commit `09530f60` · 13 legs · **2 did not complete**

✅ **Required legs: 0 failing tests**, all 5 ran to completion.

| | count |
|---|---:|
| tests per completed leg | 6,560 - 6,659 |
| runs | 72,463 |
| ✅ passing runs | 71,212 |
| ❌ failing runs | **1,251** |
| 💤 skipped runs | 0 |
| ❌ distinct tests failing somewhere | **291** |
```

Both leg tables below are unchanged — the per-leg `tests` column was never the misleading figure, since each cell is one leg's own count.

Why 12 913: the action keys a test on `(classname, name)` and unions those keys over every leg's XMLs. `org.elixir_lang.beam.SdkBeamParseTest` names each case after a `.beam` path in the resolved SDK (`parses[erlang/kernel-8.3.2.2/gen_server.beam]`), and the Erlang half — ~1 400 of ~1 700 — carries the OTP application version, so every OTP bump renames nearly all of them. Measured on run 31156815241: 4 897 ordinary tests identical on every leg, 8 016 distinct sweep cases across the matrix.

</details>

---

**Note for reviewers:** `test-results.yml` runs on `workflow_run`, which always executes the copy on the **default branch** — so the last commit has no effect on this pull request's own comment. It starts applying to the first run after merge. It was verified instead against captured artifacts of run `31156815241`: the renderer reproduces the already-posted comment byte for byte before the change, and eight synthetic paths cover the branches that run does not contain (failing required leg, required leg that died, both, no required legs, no status files, all legs complete, missing digest, missing digest on a red gate).
