### PR TITLE
fix(sdk): register Elixir SDKs added through the SDK dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
     missed rather than one undifferentiated list.
 
 ### Bug Fixes
+- [@sh41](https://github.com/sh41)
+  - **Adding an Elixir SDK registers it again.** [#3888](https://github.com/KronicDeth/intellij-elixir/issues/3888) -
+    the SDK list stayed empty and "Elixir Facet SDK is not defined" persisted, because setting up the
+    SDK's paths read the SDK table without a read lock and the resulting error aborted registration
+    before the SDK reached the list.
+  - **A newly added Elixir SDK is paired with the Erlang SDK you picked,** rather than whichever one
+    happened to be registered first. The chosen SDK is not committed until the dialog is applied, and
+    the pairing was resolved without consulting the dialog's uncommitted SDKs.
+  - **The "Configure from mise" action no longer goes missing from the SDK banner.** The startup scan
+    request could be dropped before its collector was listening, leaving the project with no tool
+    manager scan at all.
 - [#3901](https://github.com/KronicDeth/intellij-elixir/pull/3901) - [@sh41](https://github.com/sh41)
   - **Semantic syntax highlighting now appears in decompiled `.beam` files.** Function names, types and
     the rest were being coloured by the annotators and then discarded before they reached the editor, so

--- a/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.trace
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkModel
 import com.intellij.openapi.projectRoots.SdkModificator
 import com.intellij.openapi.ui.Messages
 import kotlinx.coroutines.runBlocking
@@ -38,16 +39,18 @@ object ElixirInternalErlangSdkSetup {
      *
      * Resolution order:
      * 1. Explicit SDK stored in UserData (set by the wizard when creating Erlang + Elixir together)
-     * 2. Already-linked SDK from existing SdkAdditionalData
+     * 2. Already-linked SDK from existing SdkAdditionalData, looked up in [sdkModel] before
+     *    ProjectJdkTable so a dependency chosen in the same dialog resolves before it is committed
      * 3. Any registered Erlang SDK in ProjectJdkTable
      * 4. Prompt the user to pick a mise-installed Erlang SDK (mise Elixir SDKs only)
      */
     internal fun configureInternalErlangSdk(
         elixirSdk: Sdk,
         elixirSdkModificator: SdkModificator,
+        sdkModel: SdkModel? = null,
     ): Sdk? {
         val existingAdditionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
-        val existingErlangSdk = existingAdditionalData?.let { data -> ReadActions.compute { data.getErlangSdk() } }
+        val existingErlangSdk = existingAdditionalData?.let { data -> ReadActions.compute { data.getErlangSdk(sdkModel) } }
         val explicitErlangSdk = elixirSdk.getUserData(ERLANG_SDK_KEY)
 
         LOG.trace { "[${elixirSdk.name}] configureInternalErlangSdk: explicitErlangSdk=${explicitErlangSdk?.name}, existingErlangSdk=${existingErlangSdk?.name}" }

--- a/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirInternalErlangSdkSetup.kt
@@ -17,6 +17,7 @@ import org.elixir_lang.sdk.SdkRegistrar
 import org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.erlang_dependent.Type.Companion.ERLANG_SDK_KEY
+import org.elixir_lang.util.ReadActions
 import org.elixir_lang.util.WriteActions
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
 
@@ -46,14 +47,14 @@ object ElixirInternalErlangSdkSetup {
         elixirSdkModificator: SdkModificator,
     ): Sdk? {
         val existingAdditionalData = elixirSdk.sdkAdditionalData as? SdkAdditionalData
-        val existingErlangSdk = existingAdditionalData?.getErlangSdk()
+        val existingErlangSdk = existingAdditionalData?.let { data -> ReadActions.compute { data.getErlangSdk() } }
         val explicitErlangSdk = elixirSdk.getUserData(ERLANG_SDK_KEY)
 
         LOG.trace { "[${elixirSdk.name}] configureInternalErlangSdk: explicitErlangSdk=${explicitErlangSdk?.name}, existingErlangSdk=${existingErlangSdk?.name}" }
 
         val erlangSdk = explicitErlangSdk
             ?: existingErlangSdk
-            ?: ErlangSdkResolver.findAnyRegistered()?.also { LOG.trace { "[${elixirSdk.name}] Resolution: found via findAnyRegistered: '${it.name}'" } }
+            ?: ReadActions.compute { ErlangSdkResolver.findAnyRegistered() }?.also { LOG.trace { "[${elixirSdk.name}] Resolution: found via findAnyRegistered: '${it.name}'" } }
             ?: promptForMiseErlangSdk(elixirSdk)?.also { LOG.trace { "[${elixirSdk.name}] Resolution: found via promptForMiseErlangSdk: '${it.name}'" } }
 
         if (erlangSdk != null) {

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.debug
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkModel
 import com.intellij.openapi.projectRoots.SdkModificator
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VfsUtil
@@ -17,7 +18,7 @@ import java.nio.file.Paths
 object ElixirSdkPathConfigurator {
     private val LOG = Logger.getInstance(ElixirSdkPathConfigurator::class.java)
 
-    fun configure(sdk: Sdk) {
+    fun configure(sdk: Sdk, sdkModel: SdkModel? = null) {
         LOG.info("Configuring SDK paths for ${sdk.name}")
         val sdkModificator = sdk.sdkModificator
 
@@ -30,7 +31,7 @@ object ElixirSdkPathConfigurator {
         // is registered to consume JavadocOrderRootType roots.
         addSourcePaths(sdkModificator)
 
-        val erlangSdk = ElixirInternalErlangSdkSetup.configureInternalErlangSdk(sdk, sdkModificator)
+        val erlangSdk = ElixirInternalErlangSdkSetup.configureInternalErlangSdk(sdk, sdkModificator, sdkModel)
         if (erlangSdk == null) {
             // Only remove SDKs that are not yet in ProjectJdkTable (wizard/new-SDK path).
             // An existing SDK that temporarily can't resolve its Erlang pairing must not be removed -

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkPathConfigurator.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.projectRoots.SdkModificator
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.vfs.VfsUtil
 import org.elixir_lang.sdk.SdkEbinPaths
+import org.elixir_lang.util.ReadActions
 import org.elixir_lang.util.WriteActions
 import java.io.File
 import java.nio.file.Path
@@ -34,7 +35,7 @@ object ElixirSdkPathConfigurator {
             // Only remove SDKs that are not yet in ProjectJdkTable (wizard/new-SDK path).
             // An existing SDK that temporarily can't resolve its Erlang pairing must not be removed -
             // the caller (e.g. SdkRegistrar.registerOrUpdateElixirSdk) owns the SDK's lifecycle.
-            if (ProjectJdkTable.getInstance().findJdk(sdk.name) == null) {
+            if (ReadActions.compute { ProjectJdkTable.getInstance().findJdk(sdk.name) } == null) {
                 LOG.warn("No Erlang SDK found for new Elixir SDK '${sdk.name}'; removing incomplete SDK")
                 WriteActions.runWriteAction { ProjectJdkTable.getInstance().removeJdk(sdk) }
             } else {

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -148,6 +148,11 @@ ELIXIR_SDK_HOME
         ElixirSdkPathConfigurator.configure(sdk)
     }
 
+    override fun setupSdkPaths(sdk: Sdk, sdkModel: SdkModel): Boolean {
+        ElixirSdkPathConfigurator.configure(sdk, sdkModel)
+        return true
+    }
+
     @Deprecated("Deprecated in Java")
     // IntelliJ SDKType still requires this deprecated override.
     @Suppress("DEPRECATION")

--- a/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolver.kt
@@ -36,10 +36,14 @@ interface ErlangSdkResolver {
          * are registered. Used as a fallback when no Erlang SDK has been explicitly paired with an
          * Elixir SDK.
          */
-        fun findAnyRegistered(): Sdk? =
-            ProjectJdkTable.getInstance()
+        @RequiresReadLock
+        fun findAnyRegistered(): Sdk? {
+            ThreadingAssertions.assertReadAccess()
+
+            return ProjectJdkTable.getInstance()
                 .getSdksOfType(org.elixir_lang.sdk.erlang.Type.instance)
                 .firstOrNull { it.homePath != null }
+        }
     }
 }
 

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkAnalyser.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkAnalyser.kt
@@ -66,7 +66,10 @@ internal class ToolManagerSdkAnalyser(private val project: Project) : Disposable
     val latestAnalysisResult: ToolManagerAnalysisResult?
         get() = latestAnalysis
 
+    // replay = 1 so a request emitted before the collector below subscribes is still delivered:
+    // MutableSharedFlow discards tryEmit when it has no subscribers.
     private val analysisRequests = MutableSharedFlow<Unit>(
+        replay = 1,
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )

--- a/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerService.kt
+++ b/src/org/elixir_lang/tool_manager/ToolManagerSdkCheckerService.kt
@@ -47,7 +47,10 @@ internal class ToolManagerSdkCheckerService(private val project: Project) : Disp
         settings = ToolManagerSettings.getInstance(project),
     )
 
+    // replay = 1 so a request emitted before the collector below subscribes is still delivered:
+    // MutableSharedFlow discards tryEmit when it has no subscribers.
     private val scanRequests = MutableSharedFlow<Unit>(
+        replay = 1,
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )

--- a/src/org/elixir_lang/util/ReadActions.kt
+++ b/src/org/elixir_lang/util/ReadActions.kt
@@ -1,0 +1,34 @@
+package org.elixir_lang.util
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
+import java.util.concurrent.Callable
+
+/**
+ * Read-action helper for blocking callers whose thread context varies.
+ *
+ * Mirrors [WriteActions] for the read side: use it for model reads in non-suspending code that can
+ * be reached both from a caller that already holds the read lock (or the EDT, which holds
+ * write-intent) and from a bare pooled thread, such as
+ * [com.intellij.openapi.projectRoots.SdkType.setupSdkPaths].
+ *
+ * Code that always runs in one known context should keep taking the lock explicitly - prefer a
+ * `@RequiresReadLock` contract on the caller where the caller can honour it.
+ */
+object ReadActions {
+    /**
+     * Runs [action] under a read action, or directly when the lock is already held.
+     *
+     * The guard is load-bearing, not an optimisation: when
+     * [com.intellij.openapi.application.NonBlockingReadAction.executeSynchronously] cannot start the
+     * computation immediately it waits in `blockUntilWriteActionIsDone`, which asserts that the
+     * calling thread holds *no* read access. Entering it while already holding the lock - or on the
+     * EDT, where read access is always allowed - would trip that assertion.
+     */
+    fun <T> compute(action: () -> T): T =
+        if (ApplicationManager.getApplication().isReadAccessAllowed) {
+            action()
+        } else {
+            ReadAction.nonBlocking(Callable { action() }).executeSynchronously()
+        }
+}


### PR DESCRIPTION
Fixes #3888.

Adding an Elixir SDK never registered it. The SDK list stayed empty, and the "Elixir Facet SDK is not defined" warning persisted. Reported against `mise` on Linux, but it is not `mise`-specific — it affects every Elixir SDK added through the **+** button.

Two further defects turned up on the same path and are fixed here too.

## 1. `setupSdkPaths` ran without a read lock

`ProjectSdksModel.setupSdk` runs `SdkType.setupSdkPaths` inside `runProcessWithProgressSynchronously` — a pooled thread holding no read lock — and only calls `doAdd` when it returns `true`:

```java
ProgressManager.getInstance().runProcessWithProgressSynchronously(
  () -> { pathSetup.set(sdkType.setupSdkPaths(newJdk, this)); }, ...);
if (!pathSetup.get()) return;
doAdd(newJdk, callback);
```

Resolving the dependent Erlang SDK from there reads the SDK table, so `findErlangSdkByHomePath`'s read-access assertion threw. The exception unwound straight out of `setupSdkPaths`, `pathSetup` stayed `false`, and the SDK was dropped before it ever reached the model — with nothing user-visible to explain it.

`DependentSdkType.supportsCustomCreateUI()` returns `true`, so this path is taken for every Elixir SDK addition.

The three model reads on that path — the linked-SDK resolve, the any-registered fallback, and the `findJdk` existence check — now take a read action, and `findAnyRegistered` gains the `@RequiresReadLock` contract its siblings already carry. The dialog and write-action paths deliberately stay outside the lock, since taking a write action from under a read lock deadlocks.

`ReadActions` mirrors the existing `WriteActions` helper because this path is reached both from that pooled thread and from the settings dialog on the EDT. Its guard is load-bearing rather than an optimisation: `NonBlockingReadAction.executeSynchronously()` waits in `blockUntilWriteActionIsDone`, which asserts the caller holds *no* read access.

## 2. The Erlang SDK pairing ignored the user's choice

The Erlang SDK picked in the Add SDK dialog only reaches `ProjectJdkTable` when the dialog is applied — after `setupSdkPaths` runs. Resolution passed no `SdkModel`, so the lookup by home path missed, the lookup by name missed, and the chain fell through to `findAnyRegistered()`: whichever Erlang SDK happened to be registered first.

The platform hands `setupSdkPaths` an `SdkModel` containing the uncommitted SDKs. The two-argument form is now overridden and the model passed down, so the pairing resolves against what the dialog is actually holding. The single-argument form stays for `SdkRegistrar`, which has no model and whose SDKs are already committed.

## 3. The "Configure from mise" action went missing

Intermittently absent, with no tool-manager scan running at all for the lifetime of the project.

Both tool-manager services emit their first request from a coroutine launched *before* the one that collects it, and `awaitJpsProjectLoaded` returns without suspending when the JPS model is already loaded — so the emit can win the race. A `MutableSharedFlow` with `replay = 0` drops `tryEmit` when it has no subscribers, and `tryEmit` still reports success, so the single startup request vanished silently and nothing re-requested a scan. No scan means no analysis, and every consumer of that analysis has nothing to offer.

`replay = 1` makes delivery independent of which coroutine starts first. `ToolManagerSdkAnalyser` has the identical shape — its message-bus listeners can fire before its collector subscribes — so it gets the same treatment.

## Verification

Diagnosed from sandbox logs and confirmed under the debugger against PhpStorm 2026.1.1. At `ElixirInternalErlangSdkSetup.kt:49`, on the pooled thread: `readAccessAllowed=false`, `edt=false`, additional data already carrying the Erlang home path, and the wizard-supplied SDK already present in user data. Stepping one line further unwound the exception past every plugin frame into `CoreProgressManager.startTask`. For defect 3, the scan pipeline was stepped end to end on a run where the request *was* delivered, confirming every stage downstream of the dropped emit works.

`compileKotlin` clean; 293 tests green across `org.elixir_lang.sdk.*`, `org.elixir_lang.tool_manager.*` and `org.elixir_lang.cli.*`.

Manually verified against the built plugin:

- Adding an Elixir SDK from **Settings → Languages & Frameworks → Elixir → SDKs** registers it.
- The "Configure from mise" action appears and works on the editor banner.
- The "Configure from mise" button appears and works on the **Settings → Elixir** page.

The last two are independent consumers of the same `ToolManagerSdkAnalyser` snapshot (`notification/setup_sdk/Provider` and `facet/Configurable`), so both were blocked by the dropped scan request.
