### PR TITLE
fix(build): keep running the test suite when the quoter will not build

### DIFF
--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -56,7 +56,7 @@
       { "elixir": "1.18.4", "otp": "27.3.4", "continue-on-error": true },
       { "elixir": "1.18.4", "otp": "28.4", "continue-on-error": true },
       { "elixir": "1.19.5", "otp": "28.1", "continue-on-error": true },
-      { "elixir": "1.20.2", "otp": "28.4", "continue-on-error": true }
+      { "elixir": "1.20.2", "otp": "29.0", "continue-on-error": true }
     ]
   }
 }

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -416,7 +416,7 @@ jobs:
 
               const icon = leg.status.informational ? '⚠️' : '❌';
               // The text carries the reason, so it does not repeat the count: "tests failed" with 291 in the ❌
-              // column, against "failed at quoter build" where the counts are partial and the number is
+              // column, against "failed at compile" where the counts are partial and the number is
               // meaningless.
               return { icon, text: failedAt === 'tests' ? 'tests failed' : `failed at ${safe(failedAt, 40)}` };
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 
 ### Build / CI
 
+- [@sh41](https://github.com/sh41)
+  - **A quoter that fails to build no longer stops the whole test suite.** `releaseQuoter` records
+    whether it produced a daemon and succeeds either way, so the tests that need no quoter still run.
+    The ones that need it fail immediately, naming the Elixir/OTP pair and the recorded reason - they
+    fail rather than skip, so the counts still say what was not asserted. A recorded failure is never
+    up to date, so the next build retries it, and `mix release` output is logged in full when it fails.
+  - `-PquoterRequired=true` stops the build at `releaseQuoter` instead, for anyone debugging the
+    quoter itself.
+
 ## [24.0.1] - 2026-08-09
 
 ### Enhancements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,7 +299,7 @@ For example, to launch the latest RubyMine EAP:
 
 | Task | Source root | What it covers | Quoter daemon | Network on a cold cache |
 |---|---|---|---|---|
-| `test` | `tests/` | the whole JUnit suite, parser tests included | **yes** | **yes** |
+| `test` | `tests/` | the whole JUnit suite, parser tests included | **yes** (soft) | **yes** |
 | `:jps-builder:test` | `jps-builder/tests/` | the JPS build process | no | no |
 | `check` | - | both of the above | yes | yes |
 | `testUI` | `testUI/kotlin` | IDE UI tests; needs a built plugin | no | no |
@@ -314,6 +314,20 @@ For example, to launch the latest RubyMine EAP:
 (`org.elixir_lang.parser_definition.*`) quote source through it and compare the result against the
 plugin's own quoting. Gradle stops the daemon at the end of the build. On a warm cache this costs
 about a second; the first run in a fresh clone downloads and builds the quoter.
+
+The quoter is a **soft** requirement, because it may not build for every Elixir/OTP pair the pipeline
+tests against. `releaseQuoter` records whether it produced a daemon and succeeds either way, so only
+the tests that quote through it fail - immediately and by name - and the rest of the suite runs. They
+fail rather than skip so the counts still say what was not asserted. A recorded failure is never up to
+date, so the next build retries the quoter; recovering from an offline run or a killed compile needs
+nothing from you. Dependency fetching (`getQuoterDeps`) is not soft: no network on a cold cache still
+fails the build outright.
+
+To stop at the quoter instead, which is what you want when debugging the quoter itself:
+
+```sh
+./gradlew check -PquoterRequired=true
+```
 
 To build (so you get a .zip file):
 ```sh
@@ -392,8 +406,8 @@ from unsupported to supported:
 
 `continue-on-error` covers the whole leg - toolchain setup, compile, sandbox, quoter build and tests -
 not just the test step, because an unsupported Elixir can fail at any of those and they all mean the
-same thing. `setup-beam` may not publish the pair; the quoter may not compile on it. The annotation on
-a failed informational leg names the phase it died in, so you can tell those apart.
+same thing. `setup-beam` may not publish the pair. The annotation on a failed informational leg names
+the phase it died in, so you can tell those apart.
 
 ##### Reading a leg in the checks list
 
@@ -405,7 +419,7 @@ row in one list maps to the other without translating.
 A leg that stopped **before its tests ran** says so in the name:
 
 ```
-Test Results (1.19.5+28.1, INCOMPLETE - failed at quoter build)
+Test Results (1.19.5+28.1, INCOMPLETE - failed at compile)
 ```
 
 That matters because the check's own title only ever describes the result files it found - a leg that
@@ -425,7 +439,7 @@ split by whether the leg can block a merge. The icons say only that:
 | ❔ | the leg did not report its status, so no claim is made either way |
 
 The status text names the reason: `tests failed` with a count beside it, versus
-`failed at quoter build` where the counts cover only what ran. For *which* tests failed, follow a row
+`failed at compile` where the counts cover only what ran. For *which* tests failed, follow a row
 to its `Test Results (...)` check or read the **Failed tests** summary on the leg's own job - the
 comment deals in counts only.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,6 +172,12 @@ val elixirPath: Directory = cachePath.dir("elixir-$elixirVersion")
 val quoterUnzippedPath: Directory =
     cachePath.dir("${pairToken(elixirVersion, expectedOtpVersion.getOrElse("unresolved"))}-intellij_elixir-$quoterRefSlug")
 val quoterExe: RegularFile = quoterUnzippedPath.file("_build/dev/rel/intellij_elixir/bin/intellij_elixir")
+// Whether the daemon could be built, written by releaseQuoter and read by startQuoter and the test
+// tasks. Beside the release it describes, so it is keyed on the Elixir/OTP pair like the rest of that
+// tree; in the shared cache root it would describe whichever pair built last.
+val quoterAvailabilityFile: RegularFile = quoterUnzippedPath.file("quoter-availability.properties")
+// Opts back in to a hard failure at releaseQuoter, for debugging the quoter itself.
+val quoterRequired: Boolean = providers.gradleProperty("quoterRequired").getOrElse("false").toBoolean()
 val quoterTmpPath: Directory = cachePath.dir("quoter_tmp_$quoterRefSlug")
 // hex/rebar + fetched deps are cached under the project (used by the quoter mix build).
 val mixHomePath: Directory = cachePath.dir("mix_home")
@@ -833,6 +839,8 @@ val releaseQuoter = tasks.register<ReleaseQuoterTask>("releaseQuoter") {
     // Configure the task
     quoterDir.set(quoterUnzippedPath)
     buildDir.set(quoterUnzippedPath.dir("_build"))
+    availabilityFile.set(quoterAvailabilityFile)
+    required.set(quoterRequired)
     sdkProperties.set(sdkPropertiesFile)
     mixHome.set(mixHomeForPair)
     mixArchives.set(mixArchivesForPair)
@@ -860,6 +868,8 @@ val quoterService = gradle.sharedServices.registerIfAbsent("quoter", QuoterServi
 val startQuoter = tasks.register<StartQuoterTask>("startQuoter") {
     description = "Starts the Quoter tool"
     dependsOn(releaseQuoter)
+
+    availabilityFile.set(quoterAvailabilityFile)
 }
 
 registerResolveExternalDependenciesTasksForAllProjects()
@@ -891,9 +901,18 @@ tasks.named<Test>("test") {
     usesService(quoterService)
 
     val sdkProps = sdkPropertiesFile
+    val quoterAvailability = quoterAvailabilityFile.asFile
     doFirst {
-        environment(elixirTestEnvironment(sdkProps.get().asFile))
+        environment(elixirTestEnvironment(sdkProps.get().asFile, quoterAvailability))
     }
+
+    // QUOTER_AVAILABLE reaches the test JVM through that doFirst, so - as with the versions below -
+    // Gradle cannot see it. Undeclared, a run that gains or loses a daemon stays UP-TO-DATE and
+    // reports the other run's results. Optional: `-x releaseQuoter` leaves no marker.
+    inputs.file(quoterAvailability)
+        .withPropertyName("quoterAvailability")
+        .withPathSensitivity(PathSensitivity.NONE)
+        .optional(true)
 
     // The Elixir/OTP versions reach the test JVM as environment variables set in that doFirst, which
     // Gradle cannot see, so they have to be declared or a version switch does not invalidate this task.

--- a/buildSrc/src/main/kotlin/quoter/QuoterAvailability.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterAvailability.kt
@@ -1,0 +1,102 @@
+package quoter
+
+import java.io.File
+
+/**
+ * Whether a Quoter daemon could be built for the Elixir/OTP pair this build targets. Written by
+ * `releaseQuoter`, read by `startQuoter` and the test tasks.
+ *
+ * This marker, not the exit code of `mix release`, is what the build treats as authoritative:
+ * `releaseQuoter` succeeds either way so that a pair whose quoter will not compile still runs the
+ * tests that need no quoter.
+ */
+data class QuoterAvailability(val available: Boolean, val reason: String?) {
+
+    /** Writes the marker, creating its parent directory. */
+    fun writeTo(file: File) {
+        file.parentFile?.mkdirs()
+        val lines = buildList {
+            add("$AVAILABLE_KEY=$available")
+            reason?.takeIf { it.isNotBlank() }?.let { add("$REASON_KEY=${singleLine(it)}") }
+        }
+        file.writeText(lines.joinToString(System.lineSeparator()))
+    }
+
+    companion object {
+        const val AVAILABLE_KEY = "quoter.available"
+        const val REASON_KEY = "quoter.unavailable.reason"
+
+        /** Environment variable carrying [available] to the test JVM. */
+        const val AVAILABLE_ENVIRONMENT_VARIABLE = "QUOTER_AVAILABLE"
+
+        /** Environment variable carrying [reason] to the test JVM; only set when unavailable. */
+        const val REASON_ENVIRONMENT_VARIABLE = "QUOTER_UNAVAILABLE_REASON"
+
+        /** How many trailing output lines of a failed `mix release` are kept as the reason. */
+        private const val REASON_LINES = 5
+
+        /** Bounds the reason: it ends up in an environment block. */
+        private const val REASON_MAX_LENGTH = 500
+
+        val AVAILABLE = QuoterAvailability(available = true, reason = null)
+
+        fun unavailable(reason: String): QuoterAvailability =
+            QuoterAvailability(available = false, reason = reason)
+
+        /**
+         * Reads the marker, or `null` when `releaseQuoter` has not run.
+         *
+         * A file that exists but does not say `available=true` reads as unavailable: mistaking a
+         * working quoter for a missing one costs a clear message, the reverse costs a timeout per
+         * quoting test.
+         */
+        fun readFrom(file: File): QuoterAvailability? {
+            if (!file.isFile) return null
+
+            val properties = file.readLines()
+                .mapNotNull { line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) return@mapNotNull null
+                    val separator = trimmed.indexOf('=')
+                    if (separator <= 0) return@mapNotNull null
+                    trimmed.substring(0, separator).trim() to trimmed.substring(separator + 1).trim()
+                }
+                .toMap()
+
+            return QuoterAvailability(
+                available = properties[AVAILABLE_KEY].toBoolean(),
+                reason = properties[REASON_KEY]?.takeIf { it.isNotBlank() }
+            )
+        }
+
+        /**
+         * The tail of a failed `mix release`, as one line that survives a properties file, an
+         * environment variable and a JUnit XML.
+         *
+         * Elixir frames every diagnostic in box-drawing characters, unconditionally - `format_snippet/6`
+         * in `elixir_errors.erl` offers no plain mode. They are stripped rather than matched on,
+         * because each boundary this string crosses is another chance to render them as mojibake, and
+         * they say nothing. What is left of a row that was only frame - gutter, caret, underline - is
+         * dropped; the `└─ file:line:column: context` row is the diagnostic's only statement of where
+         * it happened, so it survives as its text.
+         */
+        fun summarize(output: String): String =
+            output.lines()
+                .map { line -> line.filterNot { it in FRAME_CHARACTERS }.replace(WHITESPACE, " ").trim() }
+                .filterNot { it.isEmpty() || it.all { character -> character in HIGHLIGHT_CHARACTERS } }
+                .takeLast(REASON_LINES)
+                .joinToString(" | ")
+                .let(::singleLine)
+                .let { if (it.length > REASON_MAX_LENGTH) it.take(REASON_MAX_LENGTH) + "..." else it }
+
+        private val FRAME_CHARACTERS = "│┌├└─".toSet()
+
+        /** What a frame row holds instead of text: the `^` position marker and the `~~~` span. */
+        private val HIGHLIGHT_CHARACTERS = "^~".toSet()
+
+        private val WHITESPACE = Regex("\\s+")
+
+        private fun singleLine(text: String): String =
+            text.replace(Regex("\\s*\\R\\s*"), " | ").trim()
+    }
+}

--- a/buildSrc/src/main/kotlin/quoter/tasks/ReleaseQuoterTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/ReleaseQuoterTask.kt
@@ -4,16 +4,21 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+import quoter.QuoterAvailability
 import sdk.mixEnvironment
 import sdk.mixExecutable
 import sdk.readPropertiesFile
+import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.inject.Inject
 
@@ -21,6 +26,10 @@ import javax.inject.Inject
  * Creates a Mix release for the Quoter project using the Elixir/Erlang SDK resolved by
  * `resolveElixirErlangSdks` (mise/PATH/env aware) - no from-source Elixir build required. The
  * release bundles ERTS from the resolved Erlang, so the daemon is self-contained at runtime.
+ *
+ * A `mix release` that fails is recorded in [availabilityFile] rather than failing the build. Failing
+ * here fails the task graph before JUnit starts, which loses the whole suite to say something about
+ * only the tests that quote. `-PquoterRequired=true` asks for that hard failure anyway.
  */
 abstract class ReleaseQuoterTask : DefaultTask() {
 
@@ -48,11 +57,34 @@ abstract class ReleaseQuoterTask : DefaultTask() {
     @get:OutputDirectory
     abstract val buildDir: DirectoryProperty
 
+    /**
+     * Whether the daemon could be built, and why not when it could not. An output so that it travels
+     * with the `_build` it describes.
+     */
+    @get:OutputFile
+    abstract val availabilityFile: RegularFileProperty
+
+    /** `-PquoterRequired=true`: fail the build rather than record an unbuildable quoter. */
+    @get:Input
+    abstract val required: Property<Boolean>
+
     @get:Inject
     abstract val execOps: ExecOperations
 
     init {
+        // Retry a recorded failure on the next build. Because the task succeeds when `mix release`
+        // does not, Gradle would otherwise record a normal execution and skip it forever, making a
+        // transient cause - a killed compile, a half-fetched dependency - permanent. A missing marker
+        // is likewise not up to date: there is no record to trust.
+        outputs.upToDateWhen {
+            QuoterAvailability.readFrom(availabilityFile.get().asFile)?.available == true
+        }
+
         outputs.cacheIf { true }
+        // An out-of-date task can still be satisfied by a cache hit, which would defeat the check
+        // above wherever the entry was pulled. Reads the previous run's marker, caching state being
+        // resolved before the action runs.
+        outputs.cacheIf { QuoterAvailability.readFrom(availabilityFile.get().asFile)?.available != false }
     }
 
     @TaskAction
@@ -64,10 +96,48 @@ abstract class ReleaseQuoterTask : DefaultTask() {
         val archives = mixArchives.get().asFile
         val mixEnv = mixEnvironment(erlangHome, mixHome.get().asFile, archives)
 
-        execOps.exec {
+        // Captured rather than streamed, because the reason has to outlive this task - the tests that
+        // need the daemon fail later, in another JVM. One buffer for both streams keeps the failure in
+        // position among the warnings; the whole output is logged below either way, so a failure keeps
+        // every line while a routine build keeps its warnings out of the log.
+        val captured = ByteArrayOutputStream()
+        val result = execOps.exec {
             commandLine(mixExe, "release", "--overwrite")
             workingDir(quoterDir.get().asFile)
             environment(mixEnv)
+            standardOutput = captured
+            errorOutput = captured
+            isIgnoreExitValue = true
+        }
+
+        // UTF-8 rather than the platform default: mix emits UTF-8, and the summary strips Elixir's
+        // box-drawing diagnostic frame by character.
+        val output = captured.toString(Charsets.UTF_8)
+        if (result.exitValue == 0) logger.info(output) else logger.lifecycle(output)
+
+        val availability = if (result.exitValue == 0) {
+            QuoterAvailability.AVAILABLE
+        } else {
+            QuoterAvailability.unavailable(
+                "mix release exited ${result.exitValue}: ${QuoterAvailability.summarize(output)}"
+            )
+        }
+        availability.writeTo(availabilityFile.get().asFile)
+
+        if (!availability.available) {
+            val message = "Quoter daemon unavailable for " +
+                "Elixir ${props["elixir.version"].orEmpty()} / OTP ${props["erlang.version"].orEmpty()}: " +
+                availability.reason
+
+            if (required.get()) {
+                throw GradleException(message)
+            }
+
+            logger.lifecycle(
+                "$message\n" +
+                    "Tests that quote through the daemon will fail; the rest of the suite still runs. " +
+                    "Pass -PquoterRequired=true to fail the build here instead."
+            )
         }
     }
 }

--- a/buildSrc/src/main/kotlin/quoter/tasks/StartQuoterTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/StartQuoterTask.kt
@@ -1,9 +1,14 @@
 package quoter.tasks
 
+import quoter.QuoterAvailability
 import quoter.QuoterService
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -15,8 +20,25 @@ abstract class StartQuoterTask : DefaultTask() {
     @get:ServiceReference("quoter")
     abstract val quoterService: Property<QuoterService>
 
+    /**
+     * Marker written by `releaseQuoter`. Read here rather than in [QuoterService], which is a shared
+     * service with its own lifecycle, while this task is where the input already sits.
+     */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val availabilityFile: RegularFileProperty
+
     @TaskAction
     fun start() {
+        val availability = QuoterAvailability.readFrom(availabilityFile.get().asFile)
+
+        // Nothing was built for this pair, so skip the start rather than spend the service's retries
+        // discovering that. Tests that need the daemon fail with this reason; the rest run as usual.
+        if (availability != null && !availability.available) {
+            logger.lifecycle("Quoter daemon not started - ${availability.reason}")
+            return
+        }
+
         quoterService.get().ensureStarted()
     }
 }

--- a/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
+++ b/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
@@ -1,5 +1,6 @@
 package sdk
 
+import quoter.QuoterAvailability
 import java.io.File
 
 /**
@@ -91,16 +92,36 @@ private fun pathToken(version: String?): String =
  * stdlib source/ebin: the resolved Erlang runtime env (so `erl` is on PATH) plus the
  * ELIXIR_LANG_ELIXIR_PATH / ELIXIR_EBIN_DIRECTORY / ELIXIR_VERSION vars pointed at the resolved SDK.
  * Read the properties file produced by `resolveElixirErlangSdks`.
+ *
+ * [quoterAvailabilityFile] is the marker `releaseQuoter` writes, forwarded as
+ * QUOTER_AVAILABLE/QUOTER_UNAVAILABLE_REASON so the tests that quote can fail immediately and by name
+ * rather than each waiting for a daemon that is not there. Taken from the marker rather than a Gradle
+ * property, so a stale run cannot claim a daemon it did not build. Callers whose tests never quote
+ * (jps-builder) omit it and set neither variable.
  */
-fun elixirTestEnvironment(sdkPropertiesFile: File): Map<String, String> {
+fun elixirTestEnvironment(
+    sdkPropertiesFile: File,
+    quoterAvailabilityFile: File? = null
+): Map<String, String> {
     val props = readPropertiesFile(sdkPropertiesFile)
     val elixirHome = File(props["elixir.sdk.path"] ?: error("Missing elixir.sdk.path in ${sdkPropertiesFile.absolutePath}"))
     val erlangHome = File(props["erlang.sdk.path"] ?: error("Missing erlang.sdk.path in ${sdkPropertiesFile.absolutePath}"))
     val version = props["elixir.version"].orEmpty()
     val ebin = File(elixirHome, "lib${File.separator}elixir${File.separator}ebin")
+    val quoterEnvironment = quoterAvailabilityFile?.let(QuoterAvailability::readFrom)?.let { availability ->
+        buildMap {
+            put(QuoterAvailability.AVAILABLE_ENVIRONMENT_VARIABLE, availability.available.toString())
+            if (!availability.available && availability.reason != null) {
+                put(QuoterAvailability.REASON_ENVIRONMENT_VARIABLE, availability.reason)
+            }
+        }
+    }.orEmpty()
+
     return erlangRuntimeEnvironment(erlangHome) + mapOf(
         "ELIXIR_LANG_ELIXIR_PATH" to elixirHome.absolutePath,
         "ELIXIR_EBIN_DIRECTORY" to ebin.absolutePath + File.separator,
         "ELIXIR_VERSION" to version,
-    )
+        // Lets a failure name the whole pair; ELIXIR_VERSION alone would not.
+        "ERLANG_VERSION" to props["erlang.version"].orEmpty(),
+    ) + quoterEnvironment
 }

--- a/tests/org/elixir_lang/intellij_elixir/Quoter.kt
+++ b/tests/org/elixir_lang/intellij_elixir/Quoter.kt
@@ -30,6 +30,14 @@ object Quoter {
 
     private const val ABSENT = "(no term at this path)"
 
+    /**
+     * Set by the build: "false" when no daemon could be built for the Elixir/OTP pair under test.
+     * Anything else, absent included, means carry on and let the call decide.
+     */
+    private const val AVAILABLE_VARIABLE = "QUOTER_AVAILABLE"
+
+    private const val UNAVAILABLE_REASON_VARIABLE = "QUOTER_UNAVAILABLE_REASON"
+
     @JvmStatic
     fun assertError(file: PsiFile) {
         val text = file.text
@@ -46,6 +54,32 @@ object Quoter {
         } catch (e: OtpErlangExit) {
             throw RuntimeException(e)
         }
+    }
+
+    /**
+     * Fails a test needing the reference quoter when the build could not produce one for this
+     * Elixir/OTP pair. Call it from any test whose precondition is a running daemon, not only those
+     * that quote - otherwise the test reports its own symptom and leaves the cause to be guessed.
+     *
+     * A failure and not an `Assume`: skipping would report a clean run for assertions that were never
+     * made, and would let a quoter that stopped building on a supported pair pass unnoticed instead of
+     * turning a required leg red.
+     *
+     * Also the reason it runs before [IntellijElixir.getLocalNode] - otherwise each of these tests
+     * pays an OTP node setup and a timeout only to report that no message arrived.
+     */
+    @JvmStatic
+    fun assertAvailable() {
+        if (System.getenv(AVAILABLE_VARIABLE) != "false") return
+
+        val reason = System.getenv(UNAVAILABLE_REASON_VARIABLE) ?: "no reason recorded"
+        val elixirVersion = System.getenv("ELIXIR_VERSION").orEmpty().ifEmpty { "unknown" }
+        val otpVersion = System.getenv("ERLANG_VERSION").orEmpty().ifEmpty { "unknown" }
+
+        throw AssertionError(
+            "Quoter daemon unavailable for Elixir $elixirVersion / OTP $otpVersion: $reason\n" +
+                "This test needs the reference quoter; the rest of the suite does not."
+        )
     }
 
     @Contract("null -> fail")
@@ -285,6 +319,8 @@ object Quoter {
     }
 
     fun quote(code: String): OtpErlangTuple? {
+        assertAvailable()
+
         val otpNode = IntellijElixir.getLocalNode()
         val otpMbox = otpNode.createMbox()
         val request: OtpErlangObject = elixirString(code)

--- a/tests/org/elixir_lang/quoter/PipeLocationTest.kt
+++ b/tests/org/elixir_lang/quoter/PipeLocationTest.kt
@@ -2,6 +2,7 @@ package org.elixir_lang.quoter
 
 import com.intellij.util.system.OS
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.intellij_elixir.Quoter
 import java.io.File
 
 /**
@@ -40,6 +41,11 @@ class PipeLocationTest : PlatformTestCase() {
         if (OS.CURRENT == OS.Windows) {
             return
         }
+
+        // Only the daemon creates these pipes, so with no daemon this asserts nothing. Report that
+        // rather than "No quoter_tmp_* directory found", which names the symptom and leaves the cause
+        // to be guessed. After the Windows return, because there is no daemon to need there either.
+        Quoter.assertAvailable()
 
         val projectRoot = File(System.getProperty("user.dir"))
         val cacheDir = File(projectRoot, "cache")


### PR DESCRIPTION
The reference quoter does not build on every Elixir/OTP pair the pipeline tests against, and until now
that took the whole suite with it. `test` depends on `startQuoter` depends on `releaseQuoter`, so a
failed `mix release` fails the task graph **before JUnit starts** — no test class is ever loaded, and no
test-level mechanism can rescue one. On the affected legs the only tests to survive were the six in
`:jps-builder:test`, which is how a leg where ~6 500 tests never started could publish a check reading
`All 6 tests pass`.

Only the tests that quote through the daemon actually need it. `SdkBeamParseTest` and
`SdkDecompileParseableTest` read the resolved SDK and decompile; they were being lost to a dependency
they never had.

This makes a missing quoter a property of the environment, reported per test, rather than a build error.

## What changed

| | |
|---|---|
| `releaseQuoter` | runs `mix release` with `isIgnoreExitValue`, records `quoter.available` (plus a one-line reason) in a marker beside the release, and succeeds either way |
| `startQuoter` | reads the marker and skips a daemon it cannot start |
| `elixirTestEnvironment` | forwards the marker as `QUOTER_AVAILABLE` / `QUOTER_UNAVAILABLE_REASON` |
| `Quoter.quote` | fails immediately with the recorded reason when the daemon is absent |

`-PquoterRequired=true` restores the previous behaviour — a hard failure at `releaseQuoter` — which is
what you want when debugging the quoter itself: one build error instead of ~1 900 test failures saying
the same thing.

## Three decisions worth reviewing

**The quoting tests fail; they do not skip.** A skip would report a clean run for ~1 900 assertions that
were never made — the same misreading as a green check on a leg whose tests never started, which this
repo has already been bitten by once. Failing also preserves the merge gate: if the quoter breaks on a
*supported* pair, those tests go red on a required leg rather than quietly disappearing.

**A recorded failure is never up to date.** Because the task now succeeds when `mix release` does not,
Gradle would otherwise record a normal execution and report `UP-TO-DATE` forever, turning a transient
cause — a killed compile, a half-fetched dependency, an offline moment — into a permanent one until
something unrelated changed `mix.exs`, the lockfile or the SDK. `outputs.upToDateWhen` re-runs the
release whenever the marker says it failed; a success still goes `UP-TO-DATE`. There is a matching
`cacheIf` guard, because an out-of-date task can still be satisfied by a cache hit.

**Dependency fetching is not soft.** `getQuoterDeps` still fails the build outright, so a cold cache with
no network stops there rather than reporting a missing quoter.

## What this changes about CI reporting

This is the part most likely to be missed, because it moves a leg from one failure phase to another and
the reporting is phase-aware.

The OTP-28+ legs will stop reporting `INCOMPLETE - failed at quoter build`. They now reach their tests,
so `tests_ran` becomes `true`, the check name loses the marker, and the aggregate counts jump by roughly
6 500 per leg. That is the intended outcome — the marker exists to stop a 6-test leg reading as a pass,
and once a leg genuinely runs its tests there is nothing to disclaim. Both legs remain informational, so
the required-leg line is unaffected.

`failed at quoter build` remains a reachable stage (`mix deps.get` can still fail, and
`-PquoterRequired=true` reinstates the hard failure); it just stops meaning "this Elixir cannot host the
quoter". `CONTRIBUTING.md` and a comment in `test-results.yml` are updated accordingly.

One-off cost: the new `@OutputFile` invalidates every existing `cache/` tree once, so the first build on
any machine re-runs `mix release` a single time (~4 s warm).

## Verification

Measured locally on Windows, against the committed `KronicDeth/intellij_elixir@v2.1.0` quoter:

- **Baseline 1.13.4 / 24.3.4.6** — `check` green, 6 563 tests, 0 failures. `releaseQuoter` `UP-TO-DATE`
  on re-run; an A → B → A pair switch still re-executes in seconds without re-downloading hex.
- **1.19.5 / 28.1** — `releaseQuoter` succeeds with `quoter.available=false` and the `artificery`
  compile error recorded. `check` then executes **6 653 tests where 6 ran before**; 1 957 fail fast on
  the missing daemon and 9 are real. `SdkBeamParseTest` passes 1 756/1 756 and `SdkDecompileParseableTest`
  2/2 — the OTP-28.1 sweeps, which had never run on that leg at all.
- **Merge gate** — with the marker forced to unavailable on the baseline pair, the build goes red and the
  quoting tests fail while everything else still passes.
- **Retry** — a recorded failure re-executes on the next build; a success stays `UP-TO-DATE`.
- **`-PquoterRequired=true`** — hard failure at `releaseQuoter`, as before.

Not a fix for the quoter itself — [`intellij_elixir#11`](https://github.com/KronicDeth/intellij_elixir/pull/11)
is the repair. This stops an unbuildable quoter costing the tests that never needed one; the two can land
in either order.
