### PR TITLE
fix(quoting): make the quoted form follow the project's Elixir version

### DIFF
--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -36,7 +36,7 @@
     "    is Erlang and the chunk formats track OTP, not Elixir - so the same Elixir may appear twice with",
     "    different OTPs. Read by OTP major the pairs below are {24, 25, 26, 27, 28}. Prefer the cleanest",
     "    in-window Elixir for such a leg so it isolates the OTP surface instead of inheriting a quoting",
-    "    backlog: 1.13.4 is 0-fail, 1.18.4 fails 291 but is the newest Elixir whose quoter still builds."
+    "    backlog."
   ],
   "idea": {
     "minimumSupported": { "version": "2025.3.6", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
@@ -54,8 +54,7 @@
       { "elixir": "1.16.3", "otp": "26.2.5.21", "continue-on-error": true },
       { "elixir": "1.17.3", "otp": "27.1.2", "continue-on-error": true },
       { "elixir": "1.18.4", "otp": "27.3.4", "continue-on-error": true },
-      { "elixir": "1.18.4", "otp": "28.4", "continue-on-error": true },
-      { "elixir": "1.19.5", "otp": "28.1", "continue-on-error": true },
+      { "elixir": "1.19.5", "otp": "28.4", "continue-on-error": true },
       { "elixir": "1.20.2", "otp": "29.0", "continue-on-error": true }
     ]
   }

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -140,45 +140,32 @@ jobs:
 
       # Restore the quoter build cache (deps + _build) so the Build quoter step goes incremental. This
       # and its Save counterpart live here, not in setup-env, so the whole cache lifecycle sits next to
-      # the quoter build. The dir must name what build.gradle.kts writes - the Elixir/OTP pair (sdk
-      # .pairToken) plus the gradle.properties quoterRef slug (slashes -> dashes, quoterRefSlug) - or
-      # the cache silently covers nothing.
-      - name: Resolve quoter cache slug
-        id: quoter-slug
-        env:
-          ELIXIR_VERSION: ${{ matrix.beam.elixir }}
-          OTP_VERSION: ${{ matrix.beam.otp }}
-        run: |
-          ref=$(grep -E '^quoterRef=' gradle.properties | head -1 | cut -d= -f2-)
-          ref="${ref:-v2.1.0}"
-          slug="${ref//\//-}"
-          echo "slug=$slug" >> "$GITHUB_OUTPUT"
-          # Non-word characters collapse to "-" in sdk.pathToken, so do the same here - every OTP in
-          # ci-versions.json is already path-safe, but a future one that is not must not make the
-          # workflow and the build disagree about the directory name.
-          pair="elixir-$(printf %s "$ELIXIR_VERSION" | tr -c 'A-Za-z0-9._-' '-')"
-          pair="$pair-otp-$(printf %s "$OTP_VERSION" | tr -c 'A-Za-z0-9._-' '-')"
-          # Emitted once and consumed by BOTH cache steps, because they have to agree exactly.
-          # actions/cache identifies an entry by (key, version), and the version is a sha256 of the
-          # literal `path:` lines joined by "|" - the raw pattern strings, not the files they expand
-          # to (toolkit packages/cache: restoreCache and saveCacheV2 both hash the `paths` argument,
-          # saveCacheV1 hashes it in reserveCache). Two different lists therefore address two
-          # different entries under one key: restore looks up a version save never wrote, so it
-          # misses on every run, rebuilds the quoter from Hex, and then save collides with the entry
-          # some earlier run left under that key and reports "Unable to reserve cache".
-          {
-            echo "paths<<CACHE_PATHS_EOF"
-            echo "cache/${pair}-intellij_elixir-${slug}"
-            echo '!cache/**/tmp/pipe/**'
-            echo '!cache/**/distillery/priv'
-            echo "CACHE_PATHS_EOF"
-          } >> "$GITHUB_OUTPUT"
+      # the quoter build.
+      #
+      # The patterns come from the build rather than being derived here. Deriving them meant grepping
+      # quoterRef out of gradle.properties and rebuilding the Elixir/OTP pair token in bash - second
+      # implementations of rules owned by build.gradle.kts and sdk.pairToken, and a cache naming a
+      # directory nothing writes covers nothing, silently. The grep was also blind to -PquoterRef and
+      # ORG_GRADLE_PROJECT_quoterRef. GRADLE_FLAGS is required: configuration resolves the expected
+      # Elixir/OTP versions, and the runners have no mise.
+      #
+      # Emitted once and consumed by BOTH cache steps, because they have to agree exactly.
+      # actions/cache identifies an entry by (key, version), and the version is a sha256 of the
+      # literal `path:` lines joined by "|" - the raw pattern strings, not the files they expand
+      # to (toolkit packages/cache: restoreCache and saveCacheV2 both hash the `paths` argument,
+      # saveCacheV1 hashes it in reserveCache). Two different lists therefore address two
+      # different entries under one key: restore looks up a version save never wrote, so it
+      # misses on every run, rebuilds the quoter from Hex, and then save collides with the entry
+      # some earlier run left under that key and reports "Unable to reserve cache".
+      - name: Resolve quoter cache paths
+        id: quoter-cache
+        run: ./gradlew $GRADLE_FLAGS -q quoterCachePaths --github-output="$GITHUB_OUTPUT"
 
       - name: Restore Elixir cache
         id: restore-elixir-cache
         uses: actions/cache/restore@v6
         with:
-          path: ${{ steps.quoter-slug.outputs.paths }}
+          path: ${{ steps.quoter-cache.outputs.paths }}
           key: elixir-${{ runner.os }}-${{ runner.arch }}-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-quoter-${{ hashFiles('gradle.properties') }}
           restore-keys: |
             elixir-${{ runner.os }}-${{ runner.arch }}-${{ matrix.beam.elixir }}-otp-${{ matrix.beam.otp }}-
@@ -212,7 +199,7 @@ jobs:
         if: always() && steps.build-quoter.outcome == 'success' && steps.restore-elixir-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
-          path: ${{ steps.quoter-slug.outputs.paths }}
+          path: ${{ steps.quoter-cache.outputs.paths }}
           key: ${{ steps.restore-elixir-cache.outputs.cache-primary-key }}
 
       # An Elixir the declaration marks unsupported may fail at any phase above, not only here -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
     up to date, so the next build retries it, and `mix release` output is logged in full when it fails.
   - `-PquoterRequired=true` stops the build at `releaseQuoter` instead, for anyone debugging the
     quoter itself.
+  - **The quoter is built with an explicit `MIX_ENV=prod`, and its release path derives from the same
+    value.** `mix release` has no preferred environment, so an unset `MIX_ENV` built under `:dev`,
+    compiling dev/test-only dependencies the daemon never uses; with the path hard-coded to
+    `_build/dev`, an ambient `MIX_ENV` could leave the marker claiming a daemon `startQuoter` could not
+    find. `deps.get` fetches `--only` that environment too, taking the cold-cache download for the
+    pinned quoter from eleven packages to two. An exported `MIX_ENV` still overrides all of it.
 
 ## [24.0.1] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
     up to date, so the next build retries it, and `mix release` output is logged in full when it fails.
   - `-PquoterRequired=true` stops the build at `releaseQuoter` instead, for anyone debugging the
     quoter itself.
+  - **CI asks the build for the quoter cache paths instead of re-deriving them.** The workflow grepped
+    `quoterRef` out of `gradle.properties` and rebuilt the Elixir/OTP pair token in bash - second
+    implementations of rules owned by `build.gradle.kts` and `sdk.pairToken`, blind to `-PquoterRef`
+    and `ORG_GRADLE_PROJECT_quoterRef`, and silent when they disagreed, since a cache entry naming a
+    directory nothing writes misses on every restore and then collides on save. A `quoterCachePaths`
+    task reports them instead, and `--github-output="$GITHUB_OUTPUT"` reduces the step to one line.
   - **The quoter is built with an explicit `MIX_ENV=prod`, and its release path derives from the same
     value.** `mix release` has no preferred environment, so an unset `MIX_ENV` built under `:dev`,
     compiling dev/test-only dependencies the daemon never uses; with the path hard-coded to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
     and `ORG_GRADLE_PROJECT_quoterRef`, and silent when they disagreed, since a cache entry naming a
     directory nothing writes misses on every restore and then collides on save. A `quoterCachePaths`
     task reports them instead, and `--github-output="$GITHUB_OUTPUT"` reduces the step to one line.
+  - **The quoter is pinned to a commit SHA of `sh41/intellij_elixir` instead of the `v2.1.0` tag.**
+    v2.1.0 predates `mix release` and still uses `use Mix.Config` and `Supervisor.Spec`, so it warned
+    on every Elixir the pipeline tests. Same quoter, modernised build, unchanged quoted forms.
   - **The quoter is built with an explicit `MIX_ENV=prod`, and its release path derives from the same
     value.** `mix release` has no preferred environment, so an unset `MIX_ENV` built under `:dev`,
     compiling dev/test-only dependencies the daemon never uses; with the path hard-coded to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,6 @@
 
 ### Enhancements
 
-- [@sh41](https://github.com/sh41)
-  - **Quoting now follows the Elixir version behind the file instead of emitting one shape for every
-    version.** Elixir's quoted form changes between releases, so a single answer was wrong everywhere
-    but one version, and each fix for a newer Elixir was a regression on an older one. A quoting
-    dialect is now resolved from the module's Elixir SDK and cached per file, and the five known
-    divergences are gated on the release that changed them: `from_brackets` on a bracketed
-    expression (1.15.0), `from_interpolation` (1.16.0), `from_brackets` on every other bracket form
-    (1.16.2), and `...` as a nullary call rather than a variable (1.17.0). Files with no module or no
-    Elixir SDK take the newest dialect.
-  - **A solitary `not` or `!` is no longer wrapped in `__block__` outside parentheses on Elixir
-    1.15 and later.** 1.15.0 moved that wrapper from every block position into parenthesised
-    expressions only, so `( -> ! one )`, `a not in b` and `"#{!x}"` were each quoted with a spurious
-    block. Inside parentheses it is still wrapped, and `unquote_splicing` is unchanged.
-
 ### Bug Fixes
 
 ### Threading / Platform Hygiene
@@ -27,6 +13,17 @@
 ### Build / CI
 
 - [@sh41](https://github.com/sh41)
+  - **Quoting now follows the Elixir version behind the file instead of emitting one shape for every
+    version.** Elixir's quoted form changes between releases, so a single answer was wrong everywhere
+    but one version, and each fix for a newer Elixir was a regression on an older one. A quoting
+    dialect is resolved from the module's Elixir SDK and cached per file, and six divergences are gated
+    on the release that changed them: `from_brackets` on a bracketed expression and the `__block__`
+    wrapper around a solitary `not`/`!` (1.15.0), `from_interpolation` (1.16.0), `from_brackets` on
+    every other bracket form (1.16.2), and both `...` as a nullary call and `one +(two)` as the call
+    `one(+two)` (1.17.0). Files with no module or no Elixir SDK take the newest dialect. Nothing in
+    production reads the quoted form - its consumers read atoms and arities - so this is test
+    correctness across the nine Elixir/OTP pairs CI covers, not behaviour anyone can observe in the
+    IDE.
   - **A quoter that fails to build no longer stops the whole test suite.** `releaseQuoter` records
     whether it produced a daemon and succeeds either way, so the tests that need no quoter still run.
     The ones that need it fail immediately, naming the Elixir/OTP pair and the recorded reason - they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ### Enhancements
 
+- [@sh41](https://github.com/sh41)
+  - **Quoting now follows the Elixir version behind the file instead of emitting one shape for every
+    version.** Elixir's quoted form changes between releases, so a single answer was wrong everywhere
+    but one version, and each fix for a newer Elixir was a regression on an older one. A quoting
+    dialect is now resolved from the module's Elixir SDK and cached per file, and the five known
+    divergences are gated on the release that changed them: `from_brackets` on a bracketed
+    expression (1.15.0), `from_interpolation` (1.16.0), `from_brackets` on every other bracket form
+    (1.16.2), and `...` as a nullary call rather than a variable (1.17.0). Files with no module or no
+    Elixir SDK take the newest dialect.
+  - **A solitary `not` or `!` is no longer wrapped in `__block__` outside parentheses on Elixir
+    1.15 and later.** 1.15.0 moved that wrapper from every block position into parenthesised
+    expressions only, so `( -> ! one )`, `a not in b` and `"#{!x}"` were each quoted with a spurious
+    block. Inside parentheses it is still wrapped, and `unquote_splicing` is unchanged.
+
 ### Bug Fixes
 
 ### Threading / Platform Hygiene

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,6 +329,14 @@ To stop at the quoter instead, which is what you want when debugging the quoter 
 ./gradlew check -PquoterRequired=true
 ```
 
+The quoter is built with `MIX_ENV=prod`, so its release lands in
+`cache/<pair>-intellij_elixir-<ref>/_build/prod/rel/intellij_elixir`. The environment is set by the
+build rather than left to `mix release`, which has no preferred environment and assembles under `:dev`
+when `MIX_ENV` is unset - compiling the quoter's dev/test-only dependencies, none of which the daemon
+needs at runtime. Exporting `MIX_ENV` overrides this, and the path the build looks in follows the
+same value, so the two cannot disagree. If you switch it, expect one extra `releaseQuoter` run; the
+`_build` subtree for the previous environment is left behind and can be deleted.
+
 To build (so you get a .zip file):
 ```sh
 ./gradlew buildPlugin        # the zip, no tests - prefer this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,8 @@ into a from-source Elixir build that takes many minutes. See
 [Working with a different Elixir/OTP version](#working-with-a-different-elixirotp-version).
 
 Building the quoter (see [Test tasks](#test-tasks)) additionally needs network access on a cold cache -
-it downloads `KronicDeth/intellij_elixir` and runs `mix local.hex` / `mix local.rebar` / `mix deps.get`.
+it downloads the `quoterRepo`/`quoterRef` pinned in `gradle.properties` and runs `mix local.hex` /
+`mix local.rebar` / `mix deps.get`.
 
 **NOTE:** Tests that need an Elixir SDK fail rather than skip when it is missing, so run them through
 Gradle. Running one from the IDE's JUnit runner works only if you supply the environment variables

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ import sdk.ErlangAvailabilityCheckAction
 import sdk.ResolveElixirErlangSdksTask
 import sdk.mixPairDir
 import sdk.pairToken
+import sdk.quoterReleaseExecutablePath
+import sdk.resolveMixEnv
 import sdk.versionWithoutBuildTag
 import sdk.elixirTestEnvironment
 import versioning.ChangelogSettings
@@ -171,7 +173,12 @@ val elixirPath: Directory = cachePath.dir("elixir-$elixirVersion")
 // hex/rebar sat in correctly separated pair directories.
 val quoterUnzippedPath: Directory =
     cachePath.dir("${pairToken(elixirVersion, expectedOtpVersion.getOrElse("unresolved"))}-intellij_elixir-$quoterRefSlug")
-val quoterExe: RegularFile = quoterUnzippedPath.file("_build/dev/rel/intellij_elixir/bin/intellij_elixir")
+// MIX_ENV for both quoter mix tasks AND the launcher path below - one value, so the directory the build
+// looks in is the one mix wrote. Read through `providers` rather than System.getenv so the
+// configuration cache treats it as an input and re-resolves when it changes. Defaults to prod; see
+// sdk.resolveMixEnv for why the build pins this instead of taking mix's default.
+val quoterMixEnv: String = resolveMixEnv(providers.environmentVariable("MIX_ENV").orNull)
+val quoterExe: RegularFile = quoterUnzippedPath.file(quoterReleaseExecutablePath(quoterMixEnv))
 // Whether the daemon could be built, written by releaseQuoter and read by startQuoter and the test
 // tasks. Beside the release it describes, so it is keyed on the Elixir/OTP pair like the rest of that
 // tree; in the shared cache root it would describe whichever pair built last.
@@ -822,6 +829,7 @@ val getQuoterDeps = tasks.register<GetQuoterDepsTask>("getQuoterDeps") {
     sdkProperties.set(sdkPropertiesFile)
     mixHome.set(mixHomeForPair)
     mixArchives.set(mixArchivesForPair)
+    mixEnv.set(quoterMixEnv)
 
     // INPUTS: mix.exs and mix.lock define requirements
     inputs.file(quoterUnzippedPath.file("mix.exs"))
@@ -844,6 +852,7 @@ val releaseQuoter = tasks.register<ReleaseQuoterTask>("releaseQuoter") {
     sdkProperties.set(sdkPropertiesFile)
     mixHome.set(mixHomeForPair)
     mixArchives.set(mixArchivesForPair)
+    mixEnv.set(quoterMixEnv)
 
     // INPUTS: mix.exs, lockfile, source code, and dependencies
     inputs.files(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import quoter.QuoterService
 import quoter.tasks.GetQuoterDepsTask
+import quoter.tasks.QuoterCachePathsTask
 import quoter.tasks.ReleaseQuoterTask
 import quoter.tasks.StartQuoterTask
 import sdk.ElixirErlangSdkArgumentProvider
@@ -112,8 +113,7 @@ val quoterRepo = providers.gradleProperty("quoterRepo").getOrElse("KronicDeth/in
 val quoterRef = providers.gradleProperty("quoterRef").getOrElse("v2.1.0")
 // Cache namespace for the quoter, derived from the ref ('/' is illegal in a path segment). Keeps
 // each repo/ref's downloaded zip, build dir, and daemon tmp dir separate, so switching source
-// never reuses another's artifacts. CI computes the identical slug in its "Resolve quoter cache slug"
-// step in .github/workflows/shared-test.yml (quoterRef with '/' -> '-').
+// never reuses another's artifacts.
 val quoterRefSlug = quoterRef.replace('/', '-')
 
 // Publish channel: "default" for release, "canary" for pre-release
@@ -874,6 +874,25 @@ val quoterService = gradle.sharedServices.registerIfAbsent("quoter", QuoterServi
     }
 }
 
+// Consumed by CI, which must name the directory this build writes rather than re-derive it - see the
+// task's own documentation. Repo-relative and forward-slashed: the same value feeds the Windows legs,
+// and actions/cache exclusion patterns are forward-slashed regardless of runner.
+tasks.register<QuoterCachePathsTask>("quoterCachePaths") {
+    description = "Reports the actions/cache path patterns for the quoter build tree"
+    outputName.set("paths")
+    patterns.set(
+        listOf(
+            layout.projectDirectory.asFile.toPath()
+                .relativize(quoterUnzippedPath.asFile.toPath())
+                .joinToString("/"),
+            // Sockets, not build output - actions/cache cannot archive them.
+            "!cache/**/tmp/pipe/**",
+            // Only present while quoterRef points at a Distillery-era quoter (v2.1.0 and earlier).
+            "!cache/**/distillery/priv",
+        )
+    )
+}
+
 val startQuoter = tasks.register<StartQuoterTask>("startQuoter") {
     description = "Starts the Quoter tool"
     dependsOn(releaseQuoter)
@@ -1015,5 +1034,3 @@ tasks.register<Test>("testUI") {
 //        setProperty("termsOfServiceAgree", "yes")
 //    }
 //}
-
-

--- a/buildSrc/src/main/kotlin/quoter/tasks/GetQuoterDepsTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/GetQuoterDepsTask.kt
@@ -4,6 +4,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -69,6 +71,17 @@ abstract class GetQuoterDepsTask : DefaultTask() {
     @get:OutputDirectory
     abstract val depsDir: DirectoryProperty
 
+    /**
+     * MIX_ENV for the fetch, from `sdk.resolveMixEnv` - the same value `releaseQuoter` builds under, so
+     * `deps` holds what that release needs and nothing else.
+     *
+     * It reaches `mix deps.get` twice over, and only the second one does anything. `deps.get` ignores
+     * MIX_ENV by design, fetching every dependency in the lock whatever its `only:`, so the environment
+     * has to be named again as `--only <env>`.
+     */
+    @get:Input
+    abstract val mixEnv: Property<String>
+
     @get:Inject
     abstract val execOps: ExecOperations
 
@@ -85,14 +98,18 @@ abstract class GetQuoterDepsTask : DefaultTask() {
         val mixExe = mixExecutable(elixirHome)
         val home = mixHome.get().asFile.apply { mkdirs() }
         val archives = mixArchives.get().asFile.apply { mkdirs() }
-        val mixEnv = mixEnvironment(erlangHome, home, archives)
+        // `--only <env>` can have nothing to fetch - a quoter whose every dependency is dev/test-only
+        // has an empty prod set - and mix then does not create `deps` at all. It is a declared output
+        // here and a declared input of `releaseQuoter`, so create it rather than leave that to mix.
+        depsDir.get().asFile.mkdirs()
+        val environment = mixEnvironment(erlangHome, home, archives, mixEnv.get())
         val dir = quoterDir.get().asFile
 
         fun mix(vararg args: String) {
             execOps.exec {
                 commandLine(listOf(mixExe) + args)
                 workingDir(dir)
-                environment(mixEnv)
+                environment(environment)
             }
         }
 
@@ -122,6 +139,10 @@ abstract class GetQuoterDepsTask : DefaultTask() {
             logger.info("Reusing ${installedRebar.name} in ${home.name}; skipping mix local.rebar")
         }
 
-        mix("deps.get")
+        // `--only` because deps.get is the one mix task that disregards MIX_ENV: unrestricted it fetches
+        // the whole lock, so the quoter's dev/test-only dependencies were downloaded on a cold cache for
+        // a prod release that never compiles them. Never prunes `deps` - mix leaves an already-fetched
+        // dependency alone - so switching environments locally leaves the previous set in place.
+        mix("deps.get", "--only", mixEnv.get())
     }
 }

--- a/buildSrc/src/main/kotlin/quoter/tasks/QuoterCachePathsTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/QuoterCachePathsTask.kt
@@ -1,0 +1,87 @@
+package quoter.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+
+/**
+ * Reports the `actions/cache` path patterns covering the quoter's build tree, for the "Resolve quoter
+ * cache paths" step in `.github/workflows/shared-test.yml`.
+ *
+ * The workflow used to derive these itself: grep `quoterRef` out of `gradle.properties`, slugify it, and
+ * rebuild the Elixir/OTP pair token in bash. Both were second implementations of rules that live in
+ * `build.gradle.kts` and `sdk.pairToken`, free to drift from them, and drifting was silent - a cache
+ * entry naming a directory nothing writes misses on every restore and then collides on save. The grep
+ * could not see `-PquoterRef`, `ORG_GRADLE_PROJECT_quoterRef` or `~/.gradle/gradle.properties` either,
+ * each of which changes which quoter the build fetches.
+ *
+ * The patterns are always logged, one per line, which is what you want by hand. Given a
+ * `--github-output`, the whole GitHub Actions step output is appended to that file as well, so the
+ * workflow needs a single line and no shell of its own:
+ *
+ *     ./gradlew -q quoterCachePaths --github-output="$GITHUB_OUTPUT"
+ *
+ * Writing GitHub's own output syntax is a coupling this task already has - `actions/cache` glob
+ * patterns, `!` exclusions and all, are no more portable than the envelope around them.
+ *
+ * Deliberately declares no outputs, so it runs every time. `$GITHUB_OUTPUT` is a different file for
+ * every step, and a task Gradle believed was up to date would leave the step's output unset - an empty
+ * `path`, which actions/cache accepts and silently caches nothing under.
+ */
+abstract class QuoterCachePathsTask : DefaultTask() {
+
+    /**
+     * Patterns in `actions/cache` syntax - a leading `!` excludes. Order is significant and must be
+     * byte-identical between the Restore and Save steps: actions/cache identifies an entry by
+     * (key, version), where the version is a sha256 of the literal patterns joined by "|", not of the
+     * files they expand to. Two different lists are therefore two different entries under one key,
+     * which is why both steps read one output rather than each listing the paths.
+     */
+    @get:Input
+    abstract val patterns: ListProperty<String>
+
+    /** Name of the step output the patterns are published as. */
+    @get:Input
+    abstract val outputName: Property<String>
+
+    /**
+     * Where to append the step output, normally `$GITHUB_OUTPUT`. Appended rather than replaced: the
+     * runner reads the file after the step finishes, so truncating it would drop anything an earlier
+     * command in the same step had written.
+     */
+    @get:Optional
+    @get:Input
+    @get:Option(
+        option = "github-output",
+        description = "File to append the GitHub Actions step output to, normally \$GITHUB_OUTPUT."
+    )
+    abstract val githubOutput: Property<String>
+
+    @TaskAction
+    fun report() {
+        val lines = patterns.get()
+        // QUIET, not lifecycle: reporting the patterns is the whole job, and the workflow runs this
+        // with -q, which silences lifecycle. At lifecycle level `gradlew -q quoterCachePaths` - the
+        // obvious way to inspect them by hand - printed nothing at all.
+        logger.quiet(lines.joinToString("\n"))
+
+        val destination = githubOutput.orNull?.takeIf { it.isNotBlank() } ?: return
+        // A heredoc-style block, because the value is multi-line; `name=value` handles one line only.
+        // The delimiter has to appear on no line of the value, which glob patterns never produce.
+        val delimiter = "QUOTER_CACHE_PATHS_EOF"
+        val block = (listOf("${outputName.get()}<<$delimiter") + lines + delimiter)
+            // LF, not the platform separator: the runner parses this file the same way on every OS.
+            .joinToString("\n", postfix = "\n")
+        // UTF-8 and LF are what the runner reads, on Windows runners too - it is also what the bash
+        // `echo` this replaced produced. Stated rather than left to the default because appending to a
+        // file someone else began is where encoding goes wrong: seed the target with PowerShell 5.1's
+        // `>` (UTF-16LE, with a BOM) and every reader honours that BOM and renders this block as
+        // mojibake. Nothing to fix here when that happens - the target is the wrong encoding, not this.
+        File(destination).appendText(block, Charsets.UTF_8)
+    }
+}

--- a/buildSrc/src/main/kotlin/quoter/tasks/ReleaseQuoterTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/ReleaseQuoterTask.kt
@@ -68,6 +68,15 @@ abstract class ReleaseQuoterTask : DefaultTask() {
     @get:Input
     abstract val required: Property<Boolean>
 
+    /**
+     * MIX_ENV for the release, from `sdk.resolveMixEnv`. An @Input, not a constant read here, because it
+     * selects which `_build/<env>` subtree the launcher lands in: a change has to re-run this task, or
+     * [availabilityFile] would keep reporting a daemon built under the previous environment while
+     * `startQuoter` looks for one under the new one.
+     */
+    @get:Input
+    abstract val mixEnv: Property<String>
+
     @get:Inject
     abstract val execOps: ExecOperations
 
@@ -94,7 +103,7 @@ abstract class ReleaseQuoterTask : DefaultTask() {
         val erlangHome = File(props["erlang.sdk.path"] ?: throw GradleException("Missing erlang.sdk.path"))
         val mixExe = mixExecutable(elixirHome)
         val archives = mixArchives.get().asFile
-        val mixEnv = mixEnvironment(erlangHome, mixHome.get().asFile, archives)
+        val environment = mixEnvironment(erlangHome, mixHome.get().asFile, archives, mixEnv.get())
 
         // Captured rather than streamed, because the reason has to outlive this task - the tests that
         // need the daemon fail later, in another JVM. One buffer for both streams keeps the failure in
@@ -104,7 +113,7 @@ abstract class ReleaseQuoterTask : DefaultTask() {
         val result = execOps.exec {
             commandLine(mixExe, "release", "--overwrite")
             workingDir(quoterDir.get().asFile)
-            environment(mixEnv)
+            environment(environment)
             standardOutput = captured
             errorOutput = captured
             isIgnoreExitValue = true

--- a/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
+++ b/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
@@ -38,16 +38,57 @@ fun erlangRuntimeEnvironment(erlangHome: File): Map<String, String> {
     }
 }
 
+/** MIX_ENV the quoter is built under when nothing in the environment asks for another. */
+const val DEFAULT_MIX_ENV = "prod"
+
 /**
- * Full environment for `mix` commands: the Erlang runtime environment plus MIX_HOME/MIX_ARCHIVES so
- * hex/rebar and fetched dependencies are cached under the project rather than the user's home.
+ * The MIX_ENV to build the quoter under, given the ambient value (`null` when unset).
  *
- * Pass both the per-pair directories from [mixPairDir], never a shared root - see that function.
+ * Resolved rather than left to mix, because `mix release` has no preferred environment: with MIX_ENV
+ * unset it assembles under `:dev`, which compiles the quoter's dev/test-only dependencies - credo and
+ * dialyxir, plus whatever else the pinned `quoterRef` declares, hundreds of files - ahead of the
+ * quoter's own three, and emits their warnings. The daemon needs none of them at runtime.
+ *
+ * The value belongs to the build, not to mix's default, for a second reason: it decides a path.
+ * [quoterReleaseExecutablePath] derives the launcher location from the same value that
+ * [mixEnvironment] hands to the child process, so the directory the build looks in cannot drift from
+ * the one mix writes. Before this was pinned, an ambient MIX_ENV was enough to separate them - Gradle's
+ * `environment(Map)` adds to the inherited environment rather than replacing it, so `MIX_ENV=test` in a
+ * shell reached `mix release`, which still exited 0, so the availability marker recorded a daemon that
+ * `startQuoter` then could not find.
+ *
+ * An explicit ambient MIX_ENV still wins, so a contributor can build the quoter in another environment
+ * without editing the build; the path follows it.
  */
-fun mixEnvironment(erlangHome: File, mixHome: File, mixArchives: File): Map<String, String> =
+fun resolveMixEnv(ambient: String?): String =
+    ambient?.trim()?.takeIf { it.isNotEmpty() } ?: DEFAULT_MIX_ENV
+
+/**
+ * Path of the quoter daemon's release launcher relative to the quoter project directory, for the
+ * [mixEnv] the release was assembled under. Derive it from [resolveMixEnv], never hard-code the
+ * environment segment - see that function.
+ */
+fun quoterReleaseExecutablePath(mixEnv: String): String =
+    "_build/$mixEnv/rel/intellij_elixir/bin/intellij_elixir"
+
+/**
+ * Full environment for `mix` commands: the Erlang runtime environment, MIX_HOME/MIX_ARCHIVES so
+ * hex/rebar and fetched dependencies are cached under the project rather than the user's home, and
+ * MIX_ENV so neither the environment the build inherits nor mix's own default decides it.
+ *
+ * Pass both the per-pair directories from [mixPairDir], never a shared root - see that function - and
+ * [mixEnv] from [resolveMixEnv].
+ */
+fun mixEnvironment(
+    erlangHome: File,
+    mixHome: File,
+    mixArchives: File,
+    mixEnv: String
+): Map<String, String> =
     erlangRuntimeEnvironment(erlangHome) + mapOf(
         "MIX_HOME" to mixHome.absolutePath,
         "MIX_ARCHIVES" to mixArchives.absolutePath,
+        "MIX_ENV" to mixEnv,
     )
 
 /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -74,16 +74,23 @@ pluginVerifierChannels=RELEASE,EAP,RC,PREVIEW
 # mise for the effective version. Override per-invocation with -PelixirVersion / -PotpVersion.
 
 # Quoter source (the intellij_elixir project compiled/run to produce reference ASTs).
-# quoterRepo: GitHub <owner>/<repo>. quoterRef: a tag (e.g. v2.1.0) or branch archive ref
-# (e.g. refs/heads/my-branch). Override to test a fork/branch, e.g.:
-#   -PquoterRepo=sh41/intellij_elixir -PquoterRef=refs/heads/fix/elixir-1.13-deprecation-warnings
+# quoterRepo: GitHub <owner>/<repo>. quoterRef: a commit SHA, a tag (e.g. v2.1.0) or a branch archive
+# ref (e.g. refs/heads/my-branch) - anything https://github.com/<repo>/archive/<ref>.zip serves.
+# Override to test a fork/branch, e.g.:
+#   -PquoterRepo=sh41/intellij_elixir -PquoterRef=refs/heads/my-branch
 # The download/build cache is namespaced by a slug of quoterRef (slashes -> dashes), so switching
-# repo/ref fetches and builds into its own cache dir automatically. (A moving branch keeps the same
-# slug, so delete cache/intellij_elixir-<slug>.zip to force a re-fetch after new branch commits.)
-quoterRepo=KronicDeth/intellij_elixir
-quoterRef=v2.1.0
-#quoterRepo=sh41/intellij_elixir
-#quoterRef=refs/heads/fix/elixir-1.13-deprecation-warnings
+# repo/ref fetches and builds into its own cache dir automatically. Prefer a full SHA over a branch
+# ref: a moving branch keeps the same slug, so the cached zip is reused and new commits are never
+# fetched until cache/intellij_elixir-<slug>.zip is deleted by hand.
+#
+# Pinned to sh41's fork rather than a KronicDeth tag because v2.1.0 predates `mix release` - it carries
+# a Distillery rel/config.exs and no `releases:` in mix.exs - and still uses `use Mix.Config` and
+# Supervisor.Spec, so it warns on every Elixir the pipeline tests. This SHA is the same quoter with the
+# build modernised; the quoting behaviour it reports is unchanged.
+quoterRepo=sh41/intellij_elixir
+quoterRef=44b95390967b2b8db51322412b7dcbfc434d0a9b
+#quoterRepo=KronicDeth/intellij_elixir
+#quoterRef=v2.1.0
 
 # Plugins which will run ONLY when running `runIde` tasks, not for testing/release.
 #

--- a/src/org/elixir_lang/psi/impl/AtomableParent.kt
+++ b/src/org/elixir_lang/psi/impl/AtomableParent.kt
@@ -15,7 +15,8 @@ class AtomableParent(val wrapped: Parent) : Parent by wrapped {
         val quotedChildren = QuotableImpl.quote(interpolation.children)
         val interpolationMetadata = QuotableImpl.metadata(interpolation)
 
-        val quotedKernelToStringCall = QuotableImpl.quotedFunctionCall(
+        val quotedKernelToStringCall = QuotableImpl.quotedInterpolationCall(
+                interpolation,
                 Module.prependElixirPrefix(Module.KERNEL),
                 "to_string",
                 interpolationMetadata,

--- a/src/org/elixir_lang/psi/impl/ParentImpl.kt
+++ b/src/org/elixir_lang/psi/impl/ParentImpl.kt
@@ -6,6 +6,7 @@ import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.name.Module
 import org.elixir_lang.psi.impl.QuotableImpl.metadata
 import org.elixir_lang.psi.impl.QuotableImpl.quotedFunctionCall
+import org.elixir_lang.psi.impl.QuotableImpl.quotedInterpolationCall
 import org.jetbrains.annotations.Contract
 import java.nio.charset.Charset
 
@@ -208,7 +209,8 @@ object ParentImpl {
             val quotedChildren = QuotableImpl.quote(interpolation.children)
             val interpolationMetadata = metadata(interpolation)
 
-            quotedFunctionCall(
+            quotedInterpolationCall(
+                interpolation,
                 Module.prependElixirPrefix(Module.KERNEL),
                 "to_string",
                 interpolationMetadata,
@@ -218,7 +220,8 @@ object ParentImpl {
             val quotedChildren = QuotableImpl.quote(interpolation.children)
             val interpolationMetadata = metadata(interpolation)
 
-            val quotedKernelToStringCall = quotedFunctionCall(
+            val quotedKernelToStringCall = quotedInterpolationCall(
+                interpolation,
                 Module.prependElixirPrefix(Module.KERNEL),
                 "to_string",
                 interpolationMetadata,
@@ -246,7 +249,8 @@ object ParentImpl {
         val quotedChildren = QuotableImpl.quote(interpolation.children)
         val interpolationMetadata = metadata(interpolation)
 
-        val quotedKernelToStringCall = quotedFunctionCall(
+        val quotedKernelToStringCall = quotedInterpolationCall(
+            interpolation,
             Module.prependElixirPrefix(Module.KERNEL),
             "to_string",
             interpolationMetadata,

--- a/src/org/elixir_lang/psi/impl/QuotableImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QuotableImpl.kt
@@ -20,6 +20,8 @@ import org.elixir_lang.psi.impl.ParentImpl.addChildTextCodePoints
 import org.elixir_lang.psi.impl.ParentImpl.elixirCharList
 import org.elixir_lang.psi.impl.ParentImpl.elixirString
 import org.elixir_lang.psi.operation.*
+import org.elixir_lang.psi.quoting.QuotingDialect
+import org.elixir_lang.psi.quoting.QuotingDialectResolver.dialectFor
 import org.jetbrains.annotations.Contract
 import java.lang.Double
 import java.lang.Long
@@ -58,7 +60,13 @@ fun ElixirStabBody.quote(metadata: OtpErlangList): OtpErlangObject =
                 }
                 .map { it as Quotable }
                 .map { it.quote() }
-                .let { QuotableImpl.buildBlock(it.toList(), metadata) }
+                .let {
+                    QuotableImpl.buildBlock(
+                        it.toList(),
+                        metadata,
+                        QuotableImpl.rearrangesUnaryOperators(this)
+                    )
+                }
 
 object QuotableImpl {
     private val AMBIGUOUS_OP = OtpErlangAtom("ambiguous_op")
@@ -334,10 +342,11 @@ object QuotableImpl {
         val bracketArguments = atUnqualifiedBracketOperation.bracketArguments
         val quotedBracketArguments = bracketArguments.quote()
 
+        // `@1[:a]` - Elixir's `bracket_at_expr -> at_op_eol access_expr bracket_arg`.
         return quotedFunctionCall(
                 "Elixir.Access",
                 "get",
-                metadata(bracketArguments),
+                bracketIdentifierMetadata(bracketArguments),
                 quotedContainer,
                 quotedBracketArguments
         )
@@ -484,10 +493,11 @@ object QuotableImpl {
         val bracketArguments = atUnqualifiedBracketOperation.bracketArguments
         val quotedBracketArguments = bracketArguments.quote()
 
+        // `@foo[:a]` - Elixir's `bracket_at_expr -> at_op_eol dot_bracket_identifier bracket_arg`.
         return quotedFunctionCall(
                 "Elixir.Access",
                 "get",
-                metadata(bracketArguments),
+                bracketIdentifierMetadata(bracketArguments),
                 quotedContainer,
                 quotedBracketArguments
         )
@@ -551,18 +561,34 @@ object QuotableImpl {
 
         assert(children.size == 2)
 
-        val quotedMatchedExpression = (children[0] as Quotable).quote()
+        val container = children[0]
+        val quotedMatchedExpression = (container as Quotable).quote()
         val bracketArguments = children[1] as Quotable
         val quotedBracketArguments = bracketArguments.quote()
+
+        // Two Elixir productions land here, and they gained `from_brackets` two minors apart:
+        // `bracket_expr -> access_expr bracket_arg` (`[1, 2][0]`) at 1.15.0, and
+        // `bracket_at_expr -> at_op_eol access_expr bracket_arg` (`@Alias[:a]`) at 1.16.2. There is
+        // dedicated PSI for `@1[...]` and `@foo[...]`, but every other `@`-prefixed operand - an
+        // alias, a string, a sigil, a list, `@&1` - reaches this generic operation, so the `@` is
+        // what tells the two apart.
+        val metadata = if (container.isAtPrefixed()) {
+            bracketIdentifierMetadata(bracketArguments)
+        } else {
+            bracketedExpressionMetadata(bracketArguments)
+        }
 
         return quotedFunctionCall(
                 "Elixir.Access",
                 "get",
-                metadata(bracketArguments),
+                metadata,
                 quotedMatchedExpression,
                 quotedBracketArguments
         )
     }
+
+    /** Whether [this] is an `@`-prefix operation, so bracket access on it is Elixir's `bracket_at_expr`. */
+    private fun PsiElement.isAtPrefixed(): Boolean = stripAccessExpression() is AtOperation
 
     @Contract(pure = true)
     @JvmStatic
@@ -784,10 +810,11 @@ object QuotableImpl {
         val bracketArguments = qualifiedBracketOperation.bracketArguments
         val quotedBracketArguments = bracketArguments.quote()
 
+        // `Foo.bar[:a]` - Elixir's `dot_bracket_identifier -> matched_expr dot_op bracket_identifier`.
         return quotedFunctionCall(
                 "Elixir.Access",
                 "get",
-                metadata(bracketArguments),
+                bracketIdentifierMetadata(bracketArguments),
                 quotedContainer,
                 quotedBracketArguments
         )
@@ -890,10 +917,11 @@ object QuotableImpl {
         val bracketArguments = unqualifiedBracketOperation.bracketArguments
         val quotedBracketArguments = bracketArguments.quote()
 
+        // `foo[:a]` - Elixir's `dot_bracket_identifier -> bracket_identifier`.
         return quotedFunctionCall(
                 "Elixir.Access",
                 "get",
-                metadata(bracketArguments),
+                bracketIdentifierMetadata(bracketArguments),
                 quotedContainer,
                 quotedBracketArguments
         )
@@ -967,6 +995,14 @@ object QuotableImpl {
                     callMetadata,
                     *quotedBlockArguments
             )
+        } else if (identifierText == "..." && dialectFor(identifier).quotesEllipsisAsNullaryCall) {
+            // Elixir 1.17.0 gave the parser an `ellipsis_op` production built with
+            // `build_nullary_op`, so `...` - in a `@spec` or on its own - became a call with no
+            // arguments, `{:..., meta, []}`, where before it quoted as a variable, `{:..., meta, nil}`.
+            quoted = quotedFunctionCall(
+                identifierText,
+                callMetadata
+            )
         } else {
             /* @note quotedFunctionCall cannot be used here because in the 3-tuple for function calls, the elements are
               {name, metadata, arguments}, while for an ambiguous call or variable, the elements are
@@ -999,13 +1035,30 @@ object QuotableImpl {
 
     @Contract(pure = true)
     @JvmStatic
-    fun quote(parentheticalStab: ElixirParentheticalStab): OtpErlangObject =
-        parentheticalStab.stab?.quote(emptyMetadata(parentheticalStab)) ?:
-        // @note CANNOT use quotedFunctionCall because it requires metadata and gives nil instead of [] when no
-        //   arguments are given while empty block is quoted as `{__block__, [], []}`
-        OtpErlangTuple(
-                arrayOf(BLOCK, emptyMetadata(parentheticalStab), OtpErlangList())
-        )
+    fun quote(parentheticalStab: ElixirParentheticalStab): OtpErlangObject {
+        val stab = parentheticalStab.stab
+            // @note CANNOT use quotedFunctionCall because it requires metadata and gives nil instead of [] when no
+            //   arguments are given while empty block is quoted as `{__block__, [], []}`
+            ?: return OtpErlangTuple(
+                    arrayOf(BLOCK, emptyMetadata(parentheticalStab), OtpErlangList())
+            )
+
+        val quoted = stab.quote(emptyMetadata(parentheticalStab))
+
+        // Elixir 1.15.0's `build_paren_stab` took over wrapping a solitary `not`/`!`, so from then
+        // on it happens here rather than in every block - and with empty metadata, because that
+        // clause returns before the one that adds the parentheses' own.
+        return if (!rearrangesUnaryOperators(parentheticalStab) && isRearrangedUnary(quoted)) {
+            blockFunctionCall(listOf(quoted), OtpErlangList())
+        } else {
+            quoted
+        }
+    }
+
+    /** A `not` or `!` call, the `?rearrange_uop` operators. */
+    private fun isRearrangedUnary(quoted: OtpErlangObject): Boolean =
+        Macro.isLocalCall(quoted) &&
+                (quoted as OtpErlangTuple).elementAt(0) in REARRANGED_UNARY_OPERATORS
 
     private fun emptyMetadata(parentheticalStab: ElixirParentheticalStab): OtpErlangList = metadata(parentheticalStab)
 
@@ -1369,7 +1422,7 @@ object QuotableImpl {
         )
 
         // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L76-L79
-        return toBlock(quotedChildren)
+        return toBlock(quotedChildren, rearrangesUnaryOperators(file))
     }
 
     @Contract(pure = true)
@@ -1485,7 +1538,9 @@ object QuotableImpl {
     @Contract(pure = true)
     private fun quote(children: Array<Quotable>) =
         // Uses toBlock because this is for inside interpolation, which functions the same as an embedded file
-        children.map(Quotable::quote).let { toBlock(it) }
+        children.map(Quotable::quote).let {
+            toBlock(it, rearrangesUnaryOperators(children.firstOrNull()))
+        }
 
     @JvmStatic
     fun quotedFunctionCall(
@@ -1502,6 +1557,79 @@ object QuotableImpl {
     fun metadata(operator: Operator): OtpErlangList = metadata(operator.operatorTokenNode())
     @JvmStatic
     fun metadata(element: PsiElement): OtpErlangList = metadata(element.node)
+
+    /**
+     * `Access.get/2` metadata for bracket access on an expression - `[1, 2][0]`, Elixir's
+     * `bracket_expr -> access_expr bracket_arg`. Carries `from_brackets` from 1.15.0, two minors
+     * before the other four bracket forms do.
+     */
+    @RequiresReadLock
+    private fun bracketedExpressionMetadata(bracketArguments: PsiElement): OtpErlangList =
+        bracketMetadata(
+            bracketArguments,
+            dialectFor(bracketArguments).emitsFromBracketsOnBracketedExpression
+        )
+
+    /**
+     * `Access.get/2` metadata for the four bracket forms Elixir 1.16.2 brought in line with
+     * [bracketedExpressionMetadata]: `foo[:a]`, `Foo.bar[:a]`, `@foo[:a]` and `@1[:a]`.
+     */
+    @RequiresReadLock
+    private fun bracketIdentifierMetadata(bracketArguments: PsiElement): OtpErlangList =
+        bracketMetadata(
+            bracketArguments,
+            dialectFor(bracketArguments).emitsFromBracketsOnEveryBracketForm
+        )
+
+    /** `from_brackets` leads the keyword list, as `meta_with_from_brackets` prepends it. */
+    private fun bracketMetadata(bracketArguments: PsiElement, fromBrackets: Boolean): OtpErlangList =
+        if (fromBrackets) {
+            OtpErlangList(
+                arrayOf<OtpErlangObject>(
+                    keywordTuple("from_brackets", true),
+                    lineNumberKeywordTuple(bracketArguments.node)
+                )
+            )
+        } else {
+            metadata(bracketArguments)
+        }
+
+    /**
+     * The `Kernel.to_string/1` call that interpolation quotes to, tagged `from_interpolation` from
+     * Elixir 1.16.0 on.
+     *
+     * Only the outer call is tagged; the inner `.` call that names `Kernel.to_string` keeps the
+     * plain metadata, matching `{{:., [line: 1], [Kernel, :to_string]},
+     * [from_interpolation: true, line: 1], [...]}`.
+     */
+    @RequiresReadLock
+    @JvmStatic
+    fun quotedInterpolationCall(
+        interpolation: ElixirInterpolation,
+        module: String,
+        identifier: String,
+        metadata: OtpErlangList,
+        vararg arguments: OtpErlangObject
+    ): OtpErlangTuple {
+        if (!dialectFor(interpolation).emitsFromInterpolation) {
+            return quotedFunctionCall(module, identifier, metadata, *arguments)
+        }
+
+        val quotedQualifiedIdentifier = quotedFunctionCall(
+            ".",
+            metadata,
+            OtpErlangAtom(module),
+            OtpErlangAtom(identifier)
+        )
+
+        return quotedFunctionCall(
+            quotedQualifiedIdentifier,
+            OtpErlangList(
+                arrayOf(keywordTuple("from_interpolation", true), *metadata.elements())
+            ),
+            *arguments
+        )
+    }
 
     @JvmStatic
     fun quotedFunctionCall(
@@ -1770,12 +1898,26 @@ object QuotableImpl {
      * See https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L724-L725
      */
     @Contract(pure = true)
-    private fun toBlock(quotedChildren: List<OtpErlangObject>): OtpErlangObject =
+    private fun toBlock(
+        quotedChildren: List<OtpErlangObject>,
+        rearrangeUnaryOperators: Boolean
+    ): OtpErlangObject =
             when (quotedChildren.size) {
                 0 -> emptyBlock()
-                1 -> buildBlock(quotedChildren, OtpErlangList())
+                1 -> buildBlock(quotedChildren, OtpErlangList(), rearrangeUnaryOperators)
                 else -> blockFunctionCall(quotedChildren, OtpErlangList())
             }
+
+    /**
+     * Whether a solitary `not`/`!` in a block built from [element] takes a `__block__` wrapper.
+     *
+     * Elixir 1.15.0 moved that wrapper out of `build_block` - which a file, a stab body and an
+     * interpolation all go through - and into `build_paren_stab`, so from then on only a
+     * parenthesised single unary expression carries it. `unquote_splicing` is unaffected.
+     */
+    @RequiresReadLock
+    internal fun rearrangesUnaryOperators(element: PsiElement?): Boolean =
+        (element?.let(::dialectFor) ?: QuotingDialect.FALLBACK).wrapsSolitaryUnaryNotInEveryBlock
 
     private fun emptyBlock() =
              otpErlangTuple(
@@ -1797,7 +1939,11 @@ object QuotableImpl {
      * @param quotedChildren
      */
     @Contract(pure = true)
-    internal fun buildBlock(quotedChildren: List<OtpErlangObject>, metadata: OtpErlangList): OtpErlangObject =
+    internal fun buildBlock(
+        quotedChildren: List<OtpErlangObject>,
+        metadata: OtpErlangList,
+        rearrangeUnaryOperators: Boolean
+    ): OtpErlangObject =
             when (quotedChildren.size) {
                 0 -> NIL
                 1 -> {
@@ -1807,7 +1953,15 @@ object QuotableImpl {
                     if (Macro.isLocalCall(quotedChild)) {
                         // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L547
                         when ((quotedChild as OtpErlangTuple).elementAt(0)) {
-                            EXCLAMATION_POINT, NOT, UNQUOTE_SPLICING ->
+                            // `unquote_splicing` wraps in every version; `not` and `!` stopped
+                            // wrapping here in 1.15.0 and wrap only inside parentheses from then on.
+                            EXCLAMATION_POINT, NOT ->
+                                if (rearrangeUnaryOperators) {
+                                    blockFunctionCall(quotedChildren, metadata)
+                                } else {
+                                    quotedChild
+                                }
+                            UNQUOTE_SPLICING ->
                                 blockFunctionCall(quotedChildren, metadata)
                             else ->
                                 quotedChild

--- a/src/org/elixir_lang/psi/impl/QuotableImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QuotableImpl.kt
@@ -98,9 +98,12 @@ object QuotableImpl {
         return OtpErlangTuple(children.map { it as Quotable }.map(Quotable::quote).toTypedArray())
     }
 
+    @RequiresReadLock
     @Contract(pure = true)
     @JvmStatic
     fun quote(infix: Infix): OtpErlangObject {
+        ambiguousDualOperatorCall(infix)?.let { return it }
+
         val quotedLeftOperand = infix.leftOperand()!!.quote()
 
         val operator = infix.operator()
@@ -115,6 +118,63 @@ object QuotableImpl {
                 metadata(operator),
                 quotedLeftOperand,
                 quotedRightOperand
+        )
+    }
+
+    /**
+     * `one +(two)` quoted as the no-parentheses call `one(+two)` - what Elixir does from 1.17.0 - or
+     * `null` when this is not that shape or the dialect predates it, leaving the caller's
+     * binary-operation quoting correct.
+     *
+     * The plugin's lexer implements the pre-1.17.0 rule, so `one +two` already parses as a call and
+     * quotes through [quote] for `UnqualifiedNoParenthesesCall` instead. What arrives here as an
+     * operation is only the set 1.17.0 added - a container, `%` or the opposite sign after the sign -
+     * so this reshapes rather than re-lexes: `{op, [left, right]}` becomes
+     * `{leftIdentifier, [{op, [right]}]}`.
+     *
+     * Reshaping at quote time keeps one parse tree per file, which the shared `.txt` fixtures and the
+     * SDK-less lexer both require. The cost is that the PSI still reads as an operation on a 1.17
+     * project, so anything that walks the tree rather than the quoted form sees the older reading.
+     *
+     * FIXME This is interim, and belongs in the lexer. Deciding it here reconstructs from post-parse
+     * PSI what the lexer knew and discarded, so it only reaches the case where the ambiguous operator
+     * is the outermost node: `a + b +(c)` quotes as `(a + b) + c` where Elixir 1.17 gives `a + b(+c)`,
+     * and `one +(two) + three` as `one(+two) + three` where Elixir gives `one(+two + three)`. Both are
+     * out of reach because **association** was committed at lex time, and no reshape at a single node
+     * can move an operand across an operator that bound differently. The fix is `op_identifier`
+     * classification in `Elixir.flex` - keyed on the file's Elixir version, since the exclusion set
+     * changed at 1.17.0 - with an `Elixir.bnf` rule that produces this shape directly, at which point
+     * delete this function rather than leaving two mechanisms for one rule.
+     */
+    @RequiresReadLock
+    private fun ambiguousDualOperatorCall(infix: Infix): OtpErlangObject? {
+        val operator = infix.operator()
+        val sign = operator.text.singleOrNull()?.takeIf { it == '+' || it == '-' } ?: return null
+
+        // `?dual_op(Sign), not(?is_space(NotMarker))`: a space before the sign and none after is what
+        // makes the identifier a call rather than the operation's left operand.
+        if (operator.prevSibling !is PsiWhiteSpace) return null
+        val afterOperator = operator.nextSibling?.takeUnless { it is PsiWhiteSpace } ?: return null
+
+        // `NotMarker =/= Sign, NotMarker =/= $/, NotMarker =/= $>` - the three exclusions 1.17.0 kept.
+        val notMarker = afterOperator.text.firstOrNull() ?: return null
+        if (notMarker == sign || notMarker == '/' || notMarker == '>') return null
+
+        val call = infix.leftOperand() as? UnqualifiedNoArgumentsCall<*> ?: return null
+        // A `do` block makes it a call on its own terms, with the block as keyword arguments.
+        if (call.doBlock != null) return null
+
+        val identifier = call.identifier
+
+        if (!dialectFor(identifier).quotesAmbiguousDualOperatorAsCall) return null
+
+        val quotedRightOperand = infix.rightOperand()?.quote() ?: return null
+
+        return quotedFunctionCall(
+                identifier.text,
+                // `ambiguous_op` leads the keyword list, as Elixir's `meta_with_ambiguous_op` prepends it.
+                OtpErlangList(arrayOf(AMBIGUOUS_OP_KEYWORD_PAIR, metadata(identifier).elementAt(0))),
+                quotedFunctionCall(sign.toString(), metadata(operator), quotedRightOperand)
         )
     }
 

--- a/src/org/elixir_lang/psi/quoting/QuotingDialect.kt
+++ b/src/org/elixir_lang/psi/quoting/QuotingDialect.kt
@@ -1,0 +1,139 @@
+package org.elixir_lang.psi.quoting
+
+/**
+ * Which shape of quoted form to emit, as a threshold on the Elixir version that produced it.
+ *
+ * Elixir's quoted form changes between versions, so a single answer is wrong for every version but
+ * one. Each constant marks a version at which a divergence appeared; the predicates below read as
+ * "this dialect is at least that version", so a dialect answers every predicate for every earlier
+ * constant too.
+ *
+ * All the divergences known so far are **additive** - a newer Elixir emits metadata, or a richer
+ * node, where an older one emitted less - which is exactly what a monotonic threshold expresses.
+ * Adding a version therefore costs one constant and one predicate. Should a future Elixir *remove*
+ * something instead, a monotonic threshold can no longer express it and this becomes a hierarchy;
+ * likewise if a divergence ever needs different *construction* rather than a different *decision*.
+ *
+ * Every threshold here was pinned against Elixir's own history and confirmed by quoting the
+ * construct with the reference implementation on either side of the boundary - see each constant.
+ */
+enum class QuotingDialect {
+    /**
+     * Everything before Elixir 1.15.0: no bracket or interpolation metadata, and `...` quotes as a
+     * variable. Named for the oldest version this plugin's CI covers, but it is the floor, not a
+     * point - 1.14.5 resolves here too.
+     */
+    V1_13,
+
+    /**
+     * Elixir 1.15.0 added `from_brackets: true` to the `Access.get/2` metadata, but only for the
+     * `bracket_expr -> access_expr bracket_arg` production - bracket access on an expression, as in
+     * `[1, 2][0]`. The other four bracket forms did not get it until [V1_16_2].
+     *
+     * `elixir_parser.yrl`, `meta_with_from_brackets`, introduced by elixir-lang/elixir aa8e6d3fe
+     * ("Add error message when piping into an expression ending in bracket-based access", #12359),
+     * first released in v1.15.0.
+     *
+     * 1.15.0 also narrowed where a solitary `not` or `!` gets a `__block__` wrapper. That clause
+     * lived in `build_block`, which every block position went through - a stab body, a file, an
+     * interpolation - so `( -> ! one )` and `a not in b` were wrapped. 1.15.0 moved it into
+     * `build_paren_stab`, leaving only a parenthesised single unary expression wrapped, and wrapped
+     * with empty metadata rather than the parentheses' own. From elixir-lang/elixir 318681950
+     * ("Apply rearrange ops only inside parens", #12296), also first released in v1.15.0.
+     * `?rearrange_uop` is `Op == 'not' orelse Op == '!'`; the neighbouring `unquote_splicing`
+     * clause was not touched and still wraps in every version.
+     *
+     * That one is read via [wrapsSolitaryUnaryNotInEveryBlock], the only predicate here true
+     * *below* its threshold, because the behaviour was narrowed rather than added.
+     */
+    V1_15,
+
+    /**
+     * Elixir 1.16.0 added `from_interpolation: true` to the metadata of the `Kernel.to_string/1`
+     * call that interpolation quotes to.
+     *
+     * elixir-lang/elixir 5225b33ba ("Add interpolation token metadata"), first released in v1.16.0.
+     */
+    V1_16_0,
+
+    /**
+     * Elixir 1.16.2 extended `from_brackets: true` to the remaining four bracket productions:
+     * `bracket_expr -> dot_bracket_identifier` (`foo[:a]` and `Foo.bar[:a]`) and both
+     * `bracket_at_expr` forms (`@foo[:a]` and `@1[:a]`).
+     *
+     * elixir-lang/elixir d8cc841ab ("Include from_brackets metadata in all cases", #13317),
+     * first released in v1.16.2 (the same change reached master as eb1499ac2, released in v1.17.0).
+     */
+    V1_16_2,
+
+    /**
+     * Elixir 1.17.0 made `...` a nullary call - `{:..., meta, []}` - where earlier versions quoted
+     * it as a variable, `{:..., meta, nil}`.
+     *
+     * `elixir_parser.yrl` gained `sub_matched_expr -> ellipsis_op : build_nullary_op('$1')` in
+     * v1.17.0; v1.16.3 has no `ellipsis_op` production. Note this is **not** the 1.19 the code
+     * comment on the plugin side claimed: quoting `...` gives `nil` on 1.16.3 and `[]` on 1.17.3.
+     */
+    V1_17;
+
+    /** `[1, 2][0]` and friends - the `bracket_expr -> access_expr bracket_arg` production. */
+    val emitsFromBracketsOnBracketedExpression: Boolean get() = this >= V1_15
+
+    /**
+     * Whether a solitary `not`/`!` is wrapped in `__block__` in *every* block position, rather than
+     * only inside parentheses. True below [V1_15] - see there for why this one reads downwards.
+     */
+    val wrapsSolitaryUnaryNotInEveryBlock: Boolean get() = this < V1_15
+
+    /** The `Kernel.to_string/1` call that `"a#{b}c"` quotes to. */
+    val emitsFromInterpolation: Boolean get() = this >= V1_16_0
+
+    /** `foo[:a]`, `Foo.bar[:a]`, `@foo[:a]` and `@1[:a]` - every bracket form. */
+    val emitsFromBracketsOnEveryBracketForm: Boolean get() = this >= V1_16_2
+
+    /** `...` as `{:..., meta, []}` rather than `{:..., meta, nil}`. */
+    val quotesEllipsisAsNullaryCall: Boolean get() = this >= V1_17
+
+    companion object {
+        /**
+         * The dialect to assume when the Elixir version behind an element cannot be determined - no
+         * module, no Elixir SDK, or an SDK whose version string carries no version.
+         *
+         * Deliberately the newest rather than the oldest: most users are on a recent Elixir, so a
+         * wrong-but-modern quoted form is the least surprising default. It is also the direction
+         * that ages well, since a new threshold added below shifts the fallback forward with it.
+         */
+        val FALLBACK: QuotingDialect = entries.last()
+
+        /** Leading `MAJOR.MINOR[.PATCH]`, wherever it sits in the string. */
+        private val VERSION = Regex("""(\d+)\.(\d+)(?:\.(\d+))?""")
+
+        /**
+         * The dialect for an Elixir version, or [FALLBACK] when [version] carries no version number.
+         *
+         * [version] may be a bare canonical version (`"1.16.2"`, as
+         * `ElixirVersionDetector.ELIXIR_VERSION_KEY` holds it), a mise-style version with a build
+         * tag (`"1.13.4-otp-24"`), or a whole SDK version string
+         * (`"mise Elixir 1.13.4 (OTP 24)"`). Anything after the version number is ignored, which
+         * also means a pre-release resolves as its release - correct for these thresholds, since a
+         * `1.16.2-rc` carries the 1.16.2 change.
+         */
+        @JvmStatic
+        fun of(version: String?): QuotingDialect {
+            val match = version?.let { VERSION.find(it) } ?: return FALLBACK
+            val (major, minor, patch) = match.destructured
+            val numbers = Triple(major.toInt(), minor.toInt(), patch.ifEmpty { "0" }.toInt())
+
+            return when {
+                numbers >= Triple(1, 17, 0) -> V1_17
+                numbers >= Triple(1, 16, 2) -> V1_16_2
+                numbers >= Triple(1, 16, 0) -> V1_16_0
+                numbers >= Triple(1, 15, 0) -> V1_15
+                else -> V1_13
+            }
+        }
+
+        private operator fun Triple<Int, Int, Int>.compareTo(other: Triple<Int, Int, Int>): Int =
+            compareValuesBy(this, other, Triple<Int, Int, Int>::first, Triple<Int, Int, Int>::second, Triple<Int, Int, Int>::third)
+    }
+}

--- a/src/org/elixir_lang/psi/quoting/QuotingDialect.kt
+++ b/src/org/elixir_lang/psi/quoting/QuotingDialect.kt
@@ -73,6 +73,15 @@ enum class QuotingDialect {
      * `elixir_parser.yrl` gained `sub_matched_expr -> ellipsis_op : build_nullary_op('$1')` in
      * v1.17.0; v1.16.3 has no `ellipsis_op` production. Note this is **not** the 1.19 the code
      * comment on the plugin side claimed: quoting `...` gives `nil` on 1.16.3 and `[]` on 1.17.3.
+     *
+     * 1.17.0 also widened which ambiguous dual operators make the identifier before them a call.
+     * `elixir_tokenizer.erl`'s `handle_space_sensitive_tokens` refused the `op_identifier`
+     * conversion when the character after the sign was any of `( [ < { % + - / > :`; 1.17.0 shrank
+     * that guard to `NotMarker =/= Sign, NotMarker =/= $/, NotMarker =/= $>`, so `one +(two)` went
+     * from the operation `one + two` to the call `one(+two)`. From elixir-lang/elixir b8f069d08
+     * ("Fix parsing of ambiguous operators followed by containers"), first released in v1.17.0.
+     *
+     * Read via [quotesAmbiguousDualOperatorAsCall].
      */
     V1_17;
 
@@ -93,6 +102,14 @@ enum class QuotingDialect {
 
     /** `...` as `{:..., meta, []}` rather than `{:..., meta, nil}`. */
     val quotesEllipsisAsNullaryCall: Boolean get() = this >= V1_17
+
+    /**
+     * `one +(two)` as the call `one(+two)` rather than the operation `one + two` - a container, `%`
+     * or the opposite sign after a spaced dual operator. `one +two` is a call in every version this
+     * plugin supports and is not affected; `one ++two` and `one +/two` are operations in every
+     * version, being the exclusions 1.17.0 kept.
+     */
+    val quotesAmbiguousDualOperatorAsCall: Boolean get() = this >= V1_17
 
     companion object {
         /**

--- a/src/org/elixir_lang/psi/quoting/QuotingDialectResolver.kt
+++ b/src/org/elixir_lang/psi/quoting/QuotingDialectResolver.kt
@@ -1,0 +1,102 @@
+package org.elixir_lang.psi.quoting
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.ProjectRootModificationTracker
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.CachedValue
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.sdk.elixir.ElixirVersionDetector
+import org.elixir_lang.sdk.elixir.ElixirSdkLookup
+import org.elixir_lang.sdk.elixir.sdk
+import org.jetbrains.annotations.TestOnly
+
+/**
+ * Resolves the [QuotingDialect] to quote a given element in.
+ *
+ * Quoting recurses through the parameterless `Quotable.quote()`, so a child inherits nothing from
+ * its parent's call, and consumers call `quote()` on arbitrary nodes rather than only on a file
+ * root. The dialect therefore has to be derivable from any element on its own, which is what this
+ * resolves: element to containing file to module to Elixir SDK to version.
+ */
+object QuotingDialectResolver {
+    /**
+     * Set by tests that must exercise a specific dialect. See [overrideDialect] for why this exists
+     * at all rather than the test reading the version the way production does.
+     */
+    private val OVERRIDE_KEY = Key.create<QuotingDialect>("ELIXIR_QUOTING_DIALECT_OVERRIDE")
+
+    private val CACHE_KEY = Key.create<CachedValue<QuotingDialect>>("ELIXIR_QUOTING_DIALECT")
+
+    /**
+     * The dialect for [element], or [QuotingDialect.FALLBACK] when its Elixir version cannot be
+     * determined.
+     *
+     * Only the handful of sites that actually diverge between versions call this, not every node of
+     * a parse, so the cost is bounded by the number of bracket, interpolation and ellipsis
+     * constructs in the file rather than by its size.
+     */
+    @RequiresReadLock
+    fun dialectFor(element: PsiElement): QuotingDialect {
+        // Before the read-access assertion below, and before touching the module model: an override
+        // needs neither, which is what lets the parser tests - light fixtures with a mock project
+        // that has no module, no SDK and no ProjectFileIndex - resolve a dialect at all.
+        element.project.getUserData(OVERRIDE_KEY)?.let { return it }
+
+        val file = element.containingFile ?: return QuotingDialect.FALLBACK
+
+        return CachedValuesManager.getCachedValue(file, CACHE_KEY) {
+            // Invalidated on root changes, so pointing a module at a different Elixir SDK - or
+            // changing that SDK's home - re-resolves rather than serving the old dialect for the
+            // rest of the session.
+            CachedValueProvider.Result.create(
+                resolve(file),
+                ProjectRootModificationTracker.getInstance(file.project)
+            )
+        }
+    }
+
+    @RequiresReadLock
+    private fun resolve(file: PsiFile): QuotingDialect {
+        ThreadingAssertions.assertReadAccess()
+        val sdk = ElixirSdkLookup.resolve(file).sdk ?: return QuotingDialect.FALLBACK
+
+        return QuotingDialect.of(version(sdk))
+    }
+
+    /**
+     * The Elixir version recorded on [sdk], without reading `elixir.app`.
+     *
+     * Deliberately **not** `ElixirVersionDetector.canonicalVersion(sdk)`: that falls back to file
+     * I/O on a cold cache, and it is annotated `@RequiresBackgroundThread` and asserts no read lock
+     * is held - both of which quoting violates, since it runs synchronously inside a read action
+     * and on the EDT. The user data is the same value that call would cache, and the SDK's version
+     * string carries the version too (`"mise Elixir 1.13.4 (OTP 24)"`), so between them a
+     * configured SDK is covered without ever going to disk.
+     */
+    private fun version(sdk: Sdk): String? =
+        sdk.getUserData(ElixirVersionDetector.ELIXIR_VERSION_KEY) ?: sdk.versionString
+
+    /**
+     * Forces [dialect] for every element in [project], or clears the override when it is null.
+     *
+     * The parser tests run against light fixtures with no Elixir SDK, so production resolution would
+     * always reach [QuotingDialect.FALLBACK] and every CI leg would test the same dialect no matter
+     * which Elixir it ran against. They set this instead, from the `ELIXIR_VERSION` the build
+     * already exports to the test JVM.
+     *
+     * The env var stays on the test side of that seam on purpose: it is a build artefact, and a
+     * production code path that read it would be a test-only backdoor in shipped code of exactly
+     * the kind that later gets depended on.
+     */
+    @TestOnly
+    @JvmStatic
+    fun overrideDialect(project: Project, dialect: QuotingDialect?) {
+        project.putUserData(OVERRIDE_KEY, dialect)
+    }
+}

--- a/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
+++ b/tests/org/elixir_lang/parser_definition/ParsingTestCase.java
@@ -7,6 +7,8 @@ import org.elixir_lang.ElixirLanguage;
 import org.elixir_lang.ElixirParserDefinition;
 import org.elixir_lang.intellij_elixir.Quoter;
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil;
+import org.elixir_lang.psi.quoting.QuotingDialect;
+import org.elixir_lang.psi.quoting.QuotingDialectResolver;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedList;
@@ -22,6 +24,29 @@ public abstract class ParsingTestCase extends com.intellij.testFramework.Parsing
 
     protected ParsingTestCase(String extension, ParserDefinition... parserDefinitions) {
         super("", extension, parserDefinitions);
+    }
+
+    /**
+     * Quotes in the dialect of the Elixir the reference quoter is running, so both sides of
+     * {@link #assertQuotedCorrectly()} speak the same version.
+     *
+     * These are light fixtures with no Elixir SDK, so production resolution would reach
+     * {@link QuotingDialect#FALLBACK} on every CI leg and every leg would compare against the same
+     * dialect however old the Elixir it ran. {@code ELIXIR_VERSION} is exported to the test JVM by
+     * the build, from the SDK it resolved - the same SDK the quoter was built against.
+     *
+     * Absent (a bare {@code ./gradlew test} outside the build's environment), the override is not
+     * installed at all and resolution falls back as production would.
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        String elixirVersion = System.getenv("ELIXIR_VERSION");
+
+        if (elixirVersion != null && !elixirVersion.isBlank()) {
+            QuotingDialectResolver.overrideDialect(getProject(), QuotingDialect.of(elixirVersion));
+        }
     }
 
     protected void assertParsedAndQuotedAroundError() {

--- a/tests/org/elixir_lang/psi/quoting/QuotingDialectTest.kt
+++ b/tests/org/elixir_lang/psi/quoting/QuotingDialectTest.kt
@@ -1,0 +1,146 @@
+package org.elixir_lang.psi.quoting
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The thresholds are the whole design, and every other test exercises them only indirectly - a
+ * misplaced boundary shows up as a quoting failure on one CI leg rather than as a wrong mapping.
+ * So they are pinned here, one assertion per side of each boundary.
+ *
+ * Each expected value was confirmed against the reference implementation; see [QuotingDialect] for
+ * the Elixir commit and release behind each one.
+ */
+class QuotingDialectTest {
+    @Test
+    fun `versions before 1_15 have no bracket or interpolation metadata`() {
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.13.4"))
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.14.5"))
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.14.99"))
+    }
+
+    @Test
+    fun `from_brackets on a bracketed expression starts at 1_15_0`() {
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.14.5"))
+        assertEquals(QuotingDialect.V1_15, QuotingDialect.of("1.15.0"))
+        assertEquals(QuotingDialect.V1_15, QuotingDialect.of("1.15.8"))
+    }
+
+    @Test
+    fun `from_interpolation starts at 1_16_0`() {
+        assertEquals(QuotingDialect.V1_15, QuotingDialect.of("1.15.8"))
+        assertEquals(QuotingDialect.V1_16_0, QuotingDialect.of("1.16.0"))
+        assertEquals(QuotingDialect.V1_16_0, QuotingDialect.of("1.16.1"))
+    }
+
+    @Test
+    fun `from_brackets on every bracket form starts at 1_16_2`() {
+        assertEquals(QuotingDialect.V1_16_0, QuotingDialect.of("1.16.1"))
+        assertEquals(QuotingDialect.V1_16_2, QuotingDialect.of("1.16.2"))
+        assertEquals(QuotingDialect.V1_16_2, QuotingDialect.of("1.16.3"))
+    }
+
+    @Test
+    fun `ellipsis becomes a nullary call at 1_17_0`() {
+        assertEquals(QuotingDialect.V1_16_2, QuotingDialect.of("1.16.3"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("1.17.0"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("1.17.3"))
+    }
+
+    @Test
+    fun `versions after the newest threshold resolve to it`() {
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("1.18.4"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("1.19.5"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("1.20.3"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("2.0.0"))
+    }
+
+    /** Minor is compared numerically, so 1.9 must not sort above 1.15 the way strings would. */
+    @Test
+    fun `version parts are compared as numbers`() {
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.9.4"))
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.2.6"))
+    }
+
+    /** A missing patch is 0, which is what puts a bare "1.16" below the 1.16.2 threshold. */
+    @Test
+    fun `an absent patch counts as zero`() {
+        assertEquals(QuotingDialect.V1_16_0, QuotingDialect.of("1.16"))
+        assertEquals(QuotingDialect.V1_15, QuotingDialect.of("1.15"))
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.14"))
+    }
+
+    /** mise reports Elixir versions with the OTP build tag attached. */
+    @Test
+    fun `a build tag is ignored`() {
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("1.13.4-otp-24"))
+        assertEquals(QuotingDialect.V1_16_2, QuotingDialect.of("1.16.3-otp-26"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("1.19.5-otp-28"))
+    }
+
+    /** The SDK's own version string, used when the canonical version has not been detected yet. */
+    @Test
+    fun `a whole SDK version string resolves on its embedded version`() {
+        assertEquals(QuotingDialect.V1_13, QuotingDialect.of("mise Elixir 1.13.4 (OTP 24)"))
+        assertEquals(QuotingDialect.V1_17, QuotingDialect.of("Elixir 1.17.3 (OTP 27)"))
+        assertEquals(
+            QuotingDialect.V1_13,
+            QuotingDialect.of("mise Elixir 1.13.4-otp-24 (Erlang 24.3.4.6)")
+        )
+    }
+
+    @Test
+    fun `a version-less string falls back`() {
+        assertEquals(QuotingDialect.FALLBACK, QuotingDialect.of(null))
+        assertEquals(QuotingDialect.FALLBACK, QuotingDialect.of(""))
+        assertEquals(QuotingDialect.FALLBACK, QuotingDialect.of("Elixir at /opt/elixir"))
+    }
+
+    /**
+     * The fallback is deliberately the newest dialect, not the oldest. Asserted against
+     * `entries.last()` rather than a literal so adding a threshold moves it rather than breaking
+     * here - but asserted at all, because flipping it to the oldest would silently change what
+     * every module-less file quotes as.
+     */
+    @Test
+    fun `the fallback is the newest dialect`() {
+        assertEquals(QuotingDialect.entries.last(), QuotingDialect.FALLBACK)
+    }
+
+    @Test
+    fun `each divergence is on from its own threshold and stays on`() {
+        assertEquals(
+            listOf(false, true, true, true, true),
+            QuotingDialect.entries.map { it.emitsFromBracketsOnBracketedExpression }
+        )
+        assertEquals(
+            listOf(false, false, true, true, true),
+            QuotingDialect.entries.map { it.emitsFromInterpolation }
+        )
+        assertEquals(
+            listOf(false, false, false, true, true),
+            QuotingDialect.entries.map { it.emitsFromBracketsOnEveryBracketForm }
+        )
+        assertEquals(
+            listOf(false, false, false, false, true),
+            QuotingDialect.entries.map { it.quotesEllipsisAsNullaryCall }
+        )
+    }
+
+    /**
+     * The one predicate that reads downwards: 1.15.0 narrowed the wrapper rather than adding it, so
+     * it is on for the oldest dialect and off from [QuotingDialect.V1_15]. Asserted across every
+     * constant because getting the direction backwards is the easy mistake, and it would emit a
+     * spurious `__block__` on every modern Elixir while looking like the other four predicates.
+     */
+    @Test
+    fun `the unary block wrapper is on only below 1_15`() {
+        assertEquals(
+            listOf(true, false, false, false, false),
+            QuotingDialect.entries.map { it.wrapsSolitaryUnaryNotInEveryBlock }
+        )
+        assertEquals(true, QuotingDialect.of("1.14.5").wrapsSolitaryUnaryNotInEveryBlock)
+        assertEquals(false, QuotingDialect.of("1.15.0").wrapsSolitaryUnaryNotInEveryBlock)
+        assertEquals(false, QuotingDialect.FALLBACK.wrapsSolitaryUnaryNotInEveryBlock)
+    }
+}

--- a/tests/org/elixir_lang/psi/quoting/QuotingDialectTest.kt
+++ b/tests/org/elixir_lang/psi/quoting/QuotingDialectTest.kt
@@ -125,6 +125,22 @@ class QuotingDialectTest {
             listOf(false, false, false, false, true),
             QuotingDialect.entries.map { it.quotesEllipsisAsNullaryCall }
         )
+        assertEquals(
+            listOf(false, false, false, false, true),
+            QuotingDialect.entries.map { it.quotesAmbiguousDualOperatorAsCall }
+        )
+    }
+
+    /**
+     * Shares [QuotingDialect.V1_17] with the ellipsis change, so the boundary is asserted on the
+     * versions either side of it as well as across the constants - a threshold that silently moved to
+     * 1.16.2 would still pass the list above by matching the ellipsis row.
+     */
+    @Test
+    fun `the ambiguous dual operator call is on from 1_17_0`() {
+        assertEquals(false, QuotingDialect.of("1.16.3").quotesAmbiguousDualOperatorAsCall)
+        assertEquals(true, QuotingDialect.of("1.17.0").quotesAmbiguousDualOperatorAsCall)
+        assertEquals(true, QuotingDialect.FALLBACK.quotesAmbiguousDualOperatorAsCall)
     }
 
     /**


### PR DESCRIPTION
Elixir's quoted form changes between releases, so the plugin emitting one shape for every version was
wrong everywhere but one — and every fix for a newer Elixir was a regression on an older one. This
resolves a quoting *dialect* per file and routes the diverging operations through it.

## Thresholds, and how each was pinned

Each divergence's version was taken from Elixir's own history and then confirmed by quoting the
construct with the reference implementation on either side of the boundary. None of it is inferred
from failure counts.

| Divergence | Since | Evidence |
|---|---|---|
| `from_brackets` on a bracketed expression | **1.15.0** | `aa8e6d3fe` (#12359), first tag `v1.15.0` |
| solitary `not`/`!` `__block__` wrapper *(narrowed)* | **1.15.0** | `318681950` (#12296), first tag `v1.15.0` |
| `from_interpolation` | **1.16.0** | `5225b33ba`, first tag `v1.16.0` |
| `from_brackets` on every other bracket form | **1.16.2** | `d8cc841ab` (#13317), first tag `v1.16.2` |
| `...` as a nullary call, not a variable | **1.17.0** | `ellipsis_op` + `build_nullary_op` in `v1.17.0`, absent in `v1.16.3` |

Three of these are not what the surrounding notes assumed:

- **`from_brackets` arrived in two stages**, which is why a single flag could not express it. 1.15.0
  tagged only `bracket_expr -> access_expr bracket_arg`; 1.16.2 tagged the other four productions.
  This reconciles the otherwise contradictory observation that `from_brackets` already fails 67 times
  on 1.15.8.
- **The ellipsis change is 1.17.0, not 1.19.** Quoting `...` gives `{:..., meta, nil}` on 1.16.3 and
  `{:..., meta, []}` on 1.17.3.
- **The `not`/`!` wrapper was never version-accounted-for at all.** 1.15.0 *moved* it out of
  `build_block` — which a file, a stab body and an interpolation all go through — into
  `build_paren_stab`. So `( -> ! one )`, `a not in b` and `"#{!x}"` lose it, a parenthesised single
  unary expression keeps it (with *empty* metadata, since that clause returns before the one adding
  the parentheses' own), and `unquote_splicing` sits beside it untouched and wraps in every version.
  The plugin mirrors those two clauses rather than inspecting the tree around the node.

## Design

- `QuotingDialect` — a monotonic threshold enum. Four divergences are additive and read as "at least
  this version". The `not`/`!` wrapper was *narrowed*, so its predicate reads *below* its threshold —
  an inverted predicate, not a reason to make this a class hierarchy. Escalation is warranted only
  when a divergence needs different *construction* rather than a different *decision*; none of the
  five does.
- `QuotingDialectResolver.dialectFor(element)` — element → containing file → module → Elixir SDK →
  version, cached with `CachedValuesManager` on a `ProjectRootModificationTracker`, so repointing a
  module at another SDK re-resolves. Recursion re-enters through the parameterless `Quotable.quote()`
  and consumers call `quote()` on arbitrary nodes, so the dialect must be derivable from any element
  alone. Only the diverging sites call it, not every node, so cost is bounded by the number of
  bracket / interpolation / ellipsis / block constructs rather than by file size.
- Files with no module or no Elixir SDK take the **newest** dialect, deliberately: most users are on
  a recent Elixir, and it is the direction that ages well.

### Threading

`dialectFor` is `@RequiresReadLock`, consistent with the `quote()` overloads that already declare it,
and satisfied by both production consumers (`OtpApp` wraps in `computeReadAction`;
`FunctionArityKeywordPair` is annotated). It reads the version from the SDK's user data or its version
string and **never** calls `ElixirVersionDetector.canonicalVersion`, which reads `elixir.app`, is
`@RequiresBackgroundThread` and asserts no read lock is held — all three of which quoting violates.

## Measured

Parser suite, 1 974 tests, against the reference quoter for each release:

| Elixir | `main` | this PR |
|---|---:|---:|
| 1.13.4 (required leg) | 0 | **0** |
| 1.15.8 | 89 | **5** |
| 1.16.3 | 288 | **5** |
| 1.17.3 | 289 | **7** |
| 1.18.4 | 291 | **10** |

No `from_brackets`, `from_interpolation`, ellipsis or `__block__` mismatch remains on any leg.
Verified cause-by-cause on 1.18.4, whose remaining 10 are 5 corpus `FileNotFoundException`, 2
`PsiErrorElements` (parsing, not quoting) and 3 **ambiguous-operator** failures — a separate
divergence, and now the largest remaining quoting cause at 3 rather than hidden behind 291.

Full `check` on 1.13.4: **6 577 tests, 0 failures**. The ellipsis gate was A/B'd by forcing it off —
1.17.3 then fails a test — to confirm the branch is live rather than dead code.

## Commits

1. `feat(quoting)` — the dialect value, resolver and boundary tests. Nothing routes through it, so
   behaviour is unchanged; verified by `git grep` finding no reference outside its own package.
2. `fix(quoting)` — routes the bracket, interpolation, ellipsis and block sites. The test seam lands
   here of necessity: `com.intellij.testFramework.ParsingTestCase` builds a `MockProjectEx` that
   registers `CachedValuesManager` but not `ProjectFileIndex`, so routing without the seam fails
   inside `findModuleForPsiElement` rather than merely comparing the wrong dialect.
3. `docs(changelog)` — plus dropping the per-leg failure counts from `.github/ci-versions.json`; they
   move with every quoting fix and go stale silently, and the Test Results check is the live figure.

The parser tests are light fixtures with no Elixir SDK, so they install an override from the
`ELIXIR_VERSION` the build already exports; otherwise every CI leg would compare against the same
dialect whatever Elixir it ran. The env var stays on the test side of the seam — it is a build
artefact, and a production path reading it would be a test-only backdoor in shipped code.

## Not in this PR

- **The 1.20 `do`-block signature.** Not reproducible from the constructs to hand: `foo do bar end`
  and `def foo do :ok end` quote identically on 1.15.8 through 1.20.3. Its ~223 occurrences need a
  reproducer before a threshold can be written; adding a constant nothing reads would be dead code.
- **The ambiguous-operator divergence** — the 3 remaining quoting failures per leg.
- **The corpus axis** — `ElixirLangElixirParsingTestCase` reads the live stdlib by hardcoded path, so
  its expectations move with the SDK too. Both axes must be version-aware before any leg reaches zero.
- **1.19.5 and 1.20.2 stay unmeasurable** — the committed quoter cannot build on 1.19+ (`:artificery`
  fails to compile), so ~1 967 tests per leg fail at the door. Nothing here can be evaluated on them.

## For review

`dialectFor` falling through to `ElixirSdkLookup.resolve` in a mock project is a latent trap: a future
light-fixture test that quotes without installing the override fails deep in `findModuleForPsiElement`
rather than with a useful message. Nothing is broken today — only the parser tests quote, and they all
inherit the base class — but a guard may be worth adding.
