### PR TITLE
fix(sdk): stop booting WSL distros from SDK home-path comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,65 +6,56 @@
 
 ### Enhancements
 
-- [#3914](https://github.com/KronicDeth/intellij-elixir/issues/3914) [@sh41](https://github.com/sh41)
-  - **Parsing/Lexing of Elixir 1.13.4 through 1.20.2 is now fully supported**
+- [#3914](https://github.com/KronicDeth/intellij-elixir/pull/3914) [@sh41](https://github.com/sh41)
+  - **Elixir 1.13 through 1.20 are now fully supported.** Code written for any Elixir from 1.13.4 to
+    1.20.2 parses without spurious errors, including syntax whose meaning changed between releases.
+  - **`.beam` files compiled by OTP 24 through 29 decompile to valid Elixir.**
 
 ### Bug Fixes
 
-- [#3914](https://github.com/KronicDeth/intellij-elixir/issues/3914) [@sh41](https://github.com/sh41)
-  - **A capture argument keeps its Elixir 1.15+ meaning when reformatted.** `&1` is one argument, but
-    `& 1` is `&` applied to `1` from Elixir 1.15.0 on - a change to a whole expression's meaning, not a
-    style choice. Reformat Code no longer inserts that space, so `&(&1 + &2)` cannot silently become
-    `&(&(1 + &2))`.
-  - **`&1` and `& 1` parse the way the project's own Elixir version parses them,** rather than always
-    the way Elixir versions before 1.15.0 do. A spaced capture argument now binds the rest of the
-    expression on 1.15+ and stays one argument below it, matching each Elixir's own tokenizer.
-  - **The stepped range operator now parses as an atom, `:..//`,** instead of splitting into the atom
-    `:..` and a stranded `//` that Elixir's own tokenizer never leaves stranded.
-  - **Opening some decompiled `.beam` files no longer shows a spurious parse error.** A `cond`/`case`/
-    `receive` clause whose condition renders as a `do...end` block - as `Mix.Project`, `Mix.Release`
-    and `Mix.Task` in Elixir 1.20 all do, from compiling `&&`/`||` - needs parentheses before its own
-    `->`, the same rule already applied to a binary operator's left operand; the decompiler was missing
-    it for clause conditions.
+- [#3914](https://github.com/KronicDeth/intellij-elixir/pull/3914) [@sh41](https://github.com/sh41)
+  - **Reformat Code no longer changes what a capture expression means.** Since Elixir 1.15,
+    `&1` and `& 1` are different expressions; the formatter was inserting that space, silently
+    turning `&(&1 + &2)` into code meaning `&(&(1 + &2))`.
+  - **`& 1` now parses the way the containing module/project's configured Elixir SDK parses it**. The
+    plugin previously always used the pre-1.15 meaning.
+    - On Elixir 1.15 and higher: `&` applied to the whole following expression.
+    - On Elixir 1.14 and lower: the single capture argument `&1`.
+  - **The stepped-range atom `:..//` no longer shows a parse error.** It was previously read as
+    `:..` followed by a stray `//`.
+  - **Decompiled `.beam` files no longer show a parse error when a `cond` or `case` clause condition
+    ends in `end`**. This fixes decompilation of `Mix.Project`, `Mix.Release`, and `Mix.Task` on
+    Elixir 1.20+.
+
+- [#3915](https://github.com/KronicDeth/intellij-elixir/pull/3915) [@sh41](https://github.com/sh41)
+  - **The IDE no longer starts every WSL distro that hosts a registered Erlang or Elixir SDK, and
+    will no longer freeze if WSL is slow or hangs while starting.** Checking whether two WSL-hosted
+    SDKs are the same no longer touches the distro's filesystem.
 
 ### Threading / Platform Hygiene
 
 ### Build / CI
 
-- [#3913](https://github.com/KronicDeth/intellij-elixir/issues/3913) [@sh41](https://github.com/sh41)
-  - **Quoting now follows the Elixir version behind the file instead of emitting one shape for every
-    version.** Elixir's quoted form changes between releases, so a single answer was wrong everywhere
-    but one version, and each fix for a newer Elixir was a regression on an older one. A quoting
-    dialect is resolved from the module's Elixir SDK and cached per file, and six divergences are gated
-    on the release that changed them: `from_brackets` on a bracketed expression and the `__block__`
-    wrapper around a solitary `not`/`!` (1.15.0), `from_interpolation` (1.16.0), `from_brackets` on
-    every other bracket form (1.16.2), and both `...` as a nullary call and `one +(two)` as the call
-    `one(+two)` (1.17.0). Files with no module or no Elixir SDK take the newest dialect. Nothing in
-    production reads the quoted form - its consumers read atoms and arities - so this is test
-    correctness across the nine Elixir/OTP pairs CI covers, not behaviour anyone can observe in the
-    IDE.
-  - **A quoter that fails to build no longer stops the whole test suite.** `releaseQuoter` records
-    whether it produced a daemon and succeeds either way, so the tests that need no quoter still run.
-    The ones that need it fail immediately, naming the Elixir/OTP pair and the recorded reason - they
-    fail rather than skip, so the counts still say what was not asserted. A recorded failure is never
-    up to date, so the next build retries it, and `mix release` output is logged in full when it fails.
-  - `-PquoterRequired=true` stops the build at `releaseQuoter` instead, for anyone debugging the
-    quoter itself.
-  - **CI asks the build for the quoter cache paths instead of re-deriving them.** The workflow grepped
-    `quoterRef` out of `gradle.properties` and rebuilt the Elixir/OTP pair token in bash - second
-    implementations of rules owned by `build.gradle.kts` and `sdk.pairToken`, blind to `-PquoterRef`
-    and `ORG_GRADLE_PROJECT_quoterRef`, and silent when they disagreed, since a cache entry naming a
-    directory nothing writes misses on every restore and then collides on save. A `quoterCachePaths`
-    task reports them instead, and `--github-output="$GITHUB_OUTPUT"` reduces the step to one line.
-  - **The quoter is pinned to a commit SHA of `sh41/intellij_elixir` instead of the `v2.1.0` tag.**
-    v2.1.0 predates `mix release` and still uses `use Mix.Config` and `Supervisor.Spec`, so it warned
-    on every Elixir the pipeline tests. Same quoter, modernised build, unchanged quoted forms.
-  - **The quoter is built with an explicit `MIX_ENV=prod`, and its release path derives from the same
-    value.** `mix release` has no preferred environment, so an unset `MIX_ENV` built under `:dev`,
-    compiling dev/test-only dependencies the daemon never uses; with the path hard-coded to
-    `_build/dev`, an ambient `MIX_ENV` could leave the marker claiming a daemon `startQuoter` could not
-    find. `deps.get` fetches `--only` that environment too, taking the cold-cache download for the
-    pinned quoter from eleven packages to two. An exported `MIX_ENV` still overrides all of it.
+- [#3913](https://github.com/KronicDeth/intellij-elixir/pull/3913) [@sh41](https://github.com/sh41)
+  - **Quoter tests now respect the quoting rules for the Elixir version under test.** Six quoted-form
+    divergences are gated on the release that introduced each, so the same fixtures pass on every
+    Elixir/OTP pair CI tests.
+  - **A quoter that fails to build no longer blocks the whole test suite.** Tests that require the
+    quoter fail immediately with the recorded reason; all other tests run as normal.
+    `-PquoterRequired=true` restores the hard stop for anyone debugging the quoter itself.
+  - **CI gets the quoter cache paths from the build** (a `quoterCachePaths` task) instead of
+    re-deriving them in bash, so the workflow can no longer disagree with Gradle about where the
+    cache lives.
+  - **The quoter is pinned to a commit of `sh41/intellij_elixir` which can be built without warnings
+    on all Elixir versions 1.13-1.20**, pending merge/tagging of the
+    [PR](https://github.com/KronicDeth/intellij_elixir/pull/11).
+  - **The quoter builds with an explicit `MIX_ENV=prod`**, and only prod dependencies are fetched. An exported `MIX_ENV` still overrides it.
+
+- [#3914](https://github.com/KronicDeth/intellij-elixir/pull/3914) [@sh41](https://github.com/sh41)
+  - **All Elixir/OTP test legs now pass and are required for merge.** Getting there also gated two
+    more quoted-form divergences by version (1.20's `__block__` line metadata, pre-1.17 parens
+    metadata) and froze copies of stdlib files that newer Elixirs deleted, so the parsing corpus no
+    longer shifts underneath the tests.
 
 ## [24.0.1] - 2026-08-09
 

--- a/src/org/elixir_lang/action/RefreshAllElixirSdksAction.kt
+++ b/src/org/elixir_lang/action/RefreshAllElixirSdksAction.kt
@@ -3,7 +3,6 @@ package org.elixir_lang.action
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.platform.ide.progress.ModalTaskOwner
@@ -13,7 +12,6 @@ import org.elixir_lang.sdk.elixir.ElixirSdkValidation
 import org.elixir_lang.status_bar_widget.ElixirSdkRefreshListener
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
-import java.util.concurrent.Callable
 
 class RefreshAllElixirSdksAction : AnAction() {
 
@@ -76,9 +74,9 @@ class RefreshAllElixirSdksAction : AnAction() {
             // Check OTP mismatches for each Elixir SDK after refresh (informational).
             // ElixirSdkValidation.detectOtpMismatch handles the suppress flag internally.
             for (elixirSdk in allElixirSdks) {
-                val mismatch = ReadAction
-                    .nonBlocking(Callable { ElixirSdkValidation.detectOtpMismatch(elixirSdk) })
-                    .executeSynchronously() ?: continue
+                // detectOtpMismatch takes its own short read action internally and does its file
+                // I/O unlocked - do not wrap this call in an outer read action.
+                val mismatch = ElixirSdkValidation.detectOtpMismatch(elixirSdk) ?: continue
                 otpMismatches.add(
                     "'${elixirSdk.name}' compiled for OTP ${mismatch.first} but paired with OTP ${mismatch.second}"
                 )

--- a/src/org/elixir_lang/sdk/elixir/ElixirSdkValidation.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirSdkValidation.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.sdk.elixir
 
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.util.io.FileUtil
@@ -12,6 +13,7 @@ import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.sdk.erlang.ErlangVersionDetector
 import org.elixir_lang.sdk.erlang_dependent.SdkAdditionalData
 import org.elixir_lang.sdk.wsl.wslCompat
+import java.util.concurrent.Callable
 
 /**
  * Validation and health-check queries for Elixir SDK pairings.
@@ -34,24 +36,37 @@ object ElixirSdkValidation {
      * when either side cannot be determined (e.g. missing BEAM file, missing Erlang SDK),
      * or when the user has suppressed this warning for the SDK.
      *
-     * Must be called on a background thread and under a read lock.
-     *
-     * - Background thread: reads `Elixir.System.beam` and `OTP_VERSION` from disk.
-     * - Read lock: resolves the paired Erlang SDK via [SdkAdditionalData.getErlangSdk],
-     *   which may access the SDK table through [org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver].
+     * Must be called on a background thread. Callers must NOT wrap this call in a read action:
+     * it takes its own short read action internally to resolve the paired Erlang SDK, then does
+     * the (potentially WSL-booting) file I/O in [detectOtpMismatch] with no lock held. An outer
+     * read action would hold the lock across that I/O too - see
+     * [WslCompatService.canonicalizePath] for why that risks freezing the IDE.
      *
      * Use [org.elixir_lang.util.runWithEdtGuard] when calling from EDT-context code such as
      * [org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable].
      */
     @RequiresBackgroundThread
-    @RequiresReadLock
     fun detectOtpMismatch(sdk: Sdk): Pair<String, String>? {
         ThreadingAssertions.assertBackgroundThread()
+        val erlangSdk = ReadAction.nonBlocking(Callable { pairedErlangSdkForMismatchCheck(sdk) })
+            .executeSynchronously() ?: return null
+        return detectOtpMismatch(sdk, erlangSdk)
+    }
+
+    /**
+     * Resolves the Erlang SDK to compare [sdk] against for [detectOtpMismatch], or `null` when
+     * there is nothing to compare (no pairing, or the user suppressed the warning).
+     *
+     * Requires a read lock: reads [SdkAdditionalData] and resolves the paired Erlang SDK via
+     * [SdkAdditionalData.getErlangSdk], which may access the SDK table through
+     * [org.elixir_lang.sdk.erlang_dependent.ErlangSdkResolver]. Performs no file I/O.
+     */
+    @RequiresReadLock
+    private fun pairedErlangSdkForMismatchCheck(sdk: Sdk): Sdk? {
         ThreadingAssertions.assertReadAccess()
         val additionalData = sdk.sdkAdditionalData as? SdkAdditionalData ?: return null
         if (additionalData.isSuppressOtpMismatchWarning()) return null
-        val erlangSdk = additionalData.getErlangSdk() ?: return null
-        return detectOtpMismatch(sdk, erlangSdk)
+        return additionalData.getErlangSdk()
     }
 
     /**

--- a/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
+++ b/src/org/elixir_lang/sdk/elixir/ElixirVersionDetector.kt
@@ -72,14 +72,8 @@ object ElixirVersionDetector {
         if (!resolvedVersion.isNullOrBlank()) {
             return resolvedVersion
         }
-        val canonicalHome = try {
-            wslCompat.canonicalizePath(sdkHome)
-        } catch (e: Exception) {
-            LOG.debug("Failed to canonicalize Elixir SDK home '$sdkHome'; using raw path", e)
-            sdkHome
-        }
         return runWithEdtGuard("Detecting Elixir SDK version...") {
-            readElixirAppVersion(canonicalHome)
+            readElixirAppVersion(wslCompat.canonicalizePath(sdkHome))
         }
     }
 

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -174,9 +174,8 @@ ELIXIR_SDK_HOME
         currentSdkName: String?,
         sdkHome: String,
     ): String {
-        val canonicalHome = wslCompat.canonicalizePath(sdkHome)
         val otpMajor = runWithEdtGuard("Detecting Elixir SDK...") {
-            ElixirBuildInfo.elixirOtpRelease(canonicalHome)
+            ElixirBuildInfo.elixirOtpRelease(wslCompat.canonicalizePath(sdkHome))
         }
         return suggestSdkNameForHome(sdkHome, null, otpMajor, null)
     }
@@ -236,9 +235,8 @@ ELIXIR_SDK_HOME
         internal fun versionStringForHome(sdkHome: String, resolvedVersion: String?): String? {
             val version = ElixirVersionDetector.elixirVersion(sdkHome, resolvedVersion) ?: return null
             val source = SdkPaths.detectSource(sdkHome)
-            val canonicalHome = wslCompat.canonicalizePath(sdkHome)
             val otpMajor = runWithEdtGuard("Detecting Elixir SDK...") {
-                ElixirBuildInfo.elixirOtpRelease(canonicalHome)
+                ElixirBuildInfo.elixirOtpRelease(wslCompat.canonicalizePath(sdkHome))
             }
             return buildString {
                 if (source != null) {

--- a/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatService.kt
@@ -7,7 +7,10 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.system.OS
 import org.jetbrains.annotations.VisibleForTesting
+import java.io.IOException
+import java.nio.file.InvalidPathException
 import java.nio.file.Paths
+import java.util.concurrent.CancellationException
 import kotlin.io.path.absolutePathString
 
 const val MODERN_WSL_PREFIX = "\\\\wsl.localhost\\"
@@ -74,19 +77,37 @@ interface WslCompatService {
      *  use a symlink of `latest` -> `1.19.1` or `1.19` -> `1.19.1`. It also helps to keep a standard WSL prefix for
      *  things like class paths in SDK data avoiding having a mix of //wsl$/distro and //wsl.localhost/distro paths.
      *
+     *  Performs filesystem I/O (boots WSL distros for `\\wsl.localhost` paths). Never call under
+     *  a read or write lock, and never in a loop over the SDK table - use [pathsEqualWslAware]
+     *  for comparison.
+     *
      * @param path the path to canonicalize
      * @return the canonicalized path,
      */
     fun canonicalizePath(path: String): String {
+        // Must stay outside the try/catch below: moving it inside would let an unresolvable-path
+        // fallback silently swallow a genuine read-lock violation.
+        check(!ApplicationManager.getApplication().holdsReadLock()) {
+            "canonicalizePath() resolves symlinks and must not be called under a read lock - " +
+                "filesystem I/O on a \\\\wsl.localhost path boots the WSL distro and can block indefinitely"
+        }
         val maybeConvertedPath = path.canonicalizeWslPrefix()
+        // toRealPath can fail for reasons other than IOException - a dead IJent bridge can surface
+        // as e.g. ClassNotFoundException when the ijent module isn't fully wired up. Any such
+        // failure means the path can't be resolved, which is valid input: fall back lexically.
+        // Cancellation is not a resolution failure: ProcessCanceledException extends
+        // CancellationException, and both must reach the platform's cancellation machinery.
         return try {
             toRealPath(maybeConvertedPath)
+        } catch (e: CancellationException) {
+            throw e
         } catch (_: Exception) {
             maybeConvertedPath
         }
     }
 
     @VisibleForTesting
+    @Throws(IOException::class, InvalidPathException::class)
     fun toRealPath(myPath: String) = Paths.get(myPath).toRealPath().absolutePathString()
 
     /**
@@ -130,15 +151,28 @@ interface WslCompatService {
         this
 
     /**
-     * Compares two SDK home paths, normalizing WSL UNC paths before comparison.
+     * Pure lexical normalization for path comparison: WSL UNC prefix rewrite
+     * ([canonicalizeWslPrefix]) plus system-independent separators. Performs NO filesystem
+     * access - safe to call under any lock.
+     */
+    fun normalizeForComparison(path: String): String =
+        FileUtil.toSystemIndependentName(path.canonicalizeWslPrefix())
+
+    /**
+     * Compares two SDK home paths lexically after WSL-prefix and separator normalization.
+     * Performs NO filesystem access, so it is safe to call inside read/write actions and in
+     * `ProjectJdkTable` scan predicates.
+     *
+     * Symlinks are NOT resolved here. Persisted SDK home paths are canonicalized once at
+     * registration (see [canonicalizePath]); callers comparing an external (user-supplied) path
+     * against persisted paths must canonicalize the external path once, off-lock, before
+     * comparing.
      */
     fun pathsEqualWslAware(first: String?, second: String?): Boolean =
         if (first.isNullOrBlank() || second.isNullOrBlank()) {
             false
         } else {
-                val canonicalizedFirst = canonicalizePath(first)
-                val canonicalizedSecond = canonicalizePath(second)
-                FileUtil.pathsEqual(canonicalizedFirst, canonicalizedSecond)
+            FileUtil.pathsEqual(normalizeForComparison(first), normalizeForComparison(second))
         }
 
     /**

--- a/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
+++ b/src/org/elixir_lang/sdk/wsl/WslCompatServiceImpl.kt
@@ -87,15 +87,16 @@ internal class WslCompatServiceImpl : WslCompatService {
             return null
         }
 
-        return try {
-            // Delegate to native IntelliJ API
+        // canonicalizePath handles an unresolvable path on its own; keep it outside this try or
+        // a catch(Exception) here would also swallow its read-lock assertion.
+        val converted = try {
             val wslPath = WslPath(distribution.msId, linuxPath)
-            val converted = wslPath.toWindowsUncPath()
-            canonicalizePath(converted)
+            wslPath.toWindowsUncPath()
         } catch (e: Exception) {
             log.debug("Error converting Linux path to Windows UNC: $linuxPath", e)
-            null
+            return null
         }
+        return canonicalizePath(converted)
     }
 
     override fun convertSingleWslPath(windowsPath: String, distribution: WSLDistribution): String? {

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -428,10 +428,10 @@ class ElixirEditorBasedSdkWidget(
 
     private suspend fun collectNotificationScanIoData(modelData: NotificationScanModelData): NotificationScanIoData {
         val snapshot = modelData.projectSdkSnapshot
-        // detectOtpMismatch(sdk) is @RequiresReadLock: it reads sdkAdditionalData (suppression flag + paired
-        // Erlang SDK) from the model. This runs on Dispatchers.IO, which holds no read lock, so wrap the call in
-        // a read action. The single-arg overload is used deliberately to keep honouring isSuppressOtpMismatchWarning.
-        val projectSdkOtpMismatch = snapshot.elixirSdk?.let { elixirSdk -> readAction { detectOtpMismatch(elixirSdk) } }
+        // detectOtpMismatch(sdk) takes its own short read action internally and does its file I/O
+        // unlocked - do NOT wrap this call in an outer readAction (see its KDoc for why). The
+        // single-arg overload is used deliberately to keep honouring isSuppressOtpMismatchWarning.
+        val projectSdkOtpMismatch = snapshot.elixirSdk?.let { elixirSdk -> detectOtpMismatch(elixirSdk) }
         return NotificationScanIoData(
             projectSdkOtpMismatch = projectSdkOtpMismatch,
             classpathIssues = detectClasspathIssues(snapshot),

--- a/tests/org/elixir_lang/sdk/elixir/OtpMismatchTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/OtpMismatchTest.kt
@@ -24,8 +24,9 @@ import java.util.concurrent.Callable
  *    [org.elixir_lang.sdk.erlang.ErlangVersionDetector.detectRelease]).
  *  - `detectOtpMismatch(sdk)` - the single-argument overload used by the refresh actions. It resolves
  *    the paired Erlang SDK via [SdkAdditionalData.getErlangSdk] (which needs the Erlang SDK registered
- *    in the [ProjectJdkTable]) and honours the per-SDK suppress flag. It is `@RequiresReadLock` +
- *    `@RequiresBackgroundThread`, so it is invoked inside a [ReadAction] on a pooled thread.
+ *    in the [ProjectJdkTable]) and honours the per-SDK suppress flag. It is `@RequiresBackgroundThread`
+ *    and takes its own short internal read action for that resolution - callers must NOT wrap the
+ *    whole call in an outer [ReadAction], which would hold the read lock across its file I/O too.
  *
  * Every call is dispatched off the EDT to satisfy the `@RequiresBackgroundThread` contract.
  */
@@ -96,7 +97,7 @@ class OtpMismatchTest : PlatformTestCase() {
         assertEquals(
             "Should resolve the paired Erlang SDK and report the mismatch",
             "27" to "25",
-            detectOnBackgroundThreadUnderReadAction(elixirSdk),
+            detectSingleArgOnBackgroundThread(elixirSdk),
         )
     }
 
@@ -107,7 +108,7 @@ class OtpMismatchTest : PlatformTestCase() {
 
         assertNull(
             "A suppressed OTP-mismatch warning must short-circuit to null even when majors differ",
-            detectOnBackgroundThreadUnderReadAction(elixirSdk),
+            detectSingleArgOnBackgroundThread(elixirSdk),
         )
     }
 
@@ -120,14 +121,14 @@ class OtpMismatchTest : PlatformTestCase() {
             .executeOnPooledThread(Callable { ElixirSdkValidation.detectOtpMismatch(elixirSdk, erlangSdk) })
             .get()
 
-    /** Runs the read-lock-requiring single-arg overload on a pooled thread inside a read action. */
-    private fun detectOnBackgroundThreadUnderReadAction(elixirSdk: Sdk): Pair<String, String>? =
-        ApplicationManager.getApplication().executeOnPooledThread(
-            Callable {
-                ReadAction.nonBlocking(Callable { ElixirSdkValidation.detectOtpMismatch(elixirSdk) })
-                    .executeSynchronously()
-            },
-        ).get()
+    /**
+     * Runs the single-arg overload on a pooled thread, without an outer read action - it manages
+     * its own short internal read action for the SDK resolution and does its file I/O unlocked.
+     */
+    private fun detectSingleArgOnBackgroundThread(elixirSdk: Sdk): Pair<String, String>? =
+        ApplicationManager.getApplication()
+            .executeOnPooledThread(Callable { ElixirSdkValidation.detectOtpMismatch(elixirSdk) })
+            .get()
 
     private fun newElixirSdk(otpMajor: String): Sdk {
         val sdk = ProjectJdkImpl("Test Elixir SDK", Type.instance, "/fake/elixir/1.16", "")

--- a/tests/org/elixir_lang/sdk/elixir/TypeNamingTest.kt
+++ b/tests/org/elixir_lang/sdk/elixir/TypeNamingTest.kt
@@ -10,6 +10,7 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.*
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 
 /**
  * Tests for Elixir SDK Type naming methods.
@@ -121,7 +122,7 @@ class TypeNamingTest : PlatformTestCase() {
 
     fun testSuggestSdkName_doesNotThrowWhenCanonicalizeFails() {
         val throwingService = spy(MockWslCompatService())
-        doThrow(IllegalStateException("boom"))
+        doThrow(NoSuchFileException("boom"))
             .`when`(throwingService)
             .toRealPath(anyString())
 
@@ -164,7 +165,7 @@ class TypeNamingTest : PlatformTestCase() {
 
     fun testGetVersionString_doesNotThrowWhenCanonicalizeFails() {
         val throwingService = spy(MockWslCompatService())
-        doThrow(IllegalStateException("boom"))
+        doThrow(NoSuchFileException("boom"))
             .`when`(throwingService)
             .toRealPath(anyString())
 
@@ -185,7 +186,7 @@ class TypeNamingTest : PlatformTestCase() {
         VfsRootAccess.allowRootAccess(testRootDisposable, sdkHome)
 
         val throwingService = spy(MockWslCompatService())
-        doThrow(IllegalStateException("boom"))
+        doThrow(NoSuchFileException("boom"))
             .`when`(throwingService)
             .toRealPath(anyString())
 

--- a/tests/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolverTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang_dependent/ErlangSdkResolverTest.kt
@@ -127,6 +127,26 @@ class ErlangSdkResolverTest : PlatformTestCase() {
         assertEquals(erlangSdk, (result as ErlangSdkResult.Success).sdk)
     }
 
+    fun testResolveByHomePath_matchesAcrossWslPrefixSpellings() {
+        // Registered Erlang SDK home uses the legacy \\wsl$\ spelling; the persisted Elixir SDK
+        // configuration uses the modern \\wsl.localhost\ spelling for the same install. Path-first
+        // resolution must match across both spellings of the same distro.
+        val legacyHomePath = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.asdf\\installs\\erlang\\26.0"
+        val modernHomePath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.asdf\\installs\\erlang\\26.0"
+        val erlangSdk = createSdk(name = "Erlang 26", sdkType = ErlangSdkType.instance, homePath = legacyHomePath)
+
+        val elixirSdk = createElixirSdk { sdk ->
+            SdkAdditionalData(sdk).apply {
+                readExternal(erlangSdkElement(name = "Erlang 26", homePath = modernHomePath))
+            }
+        }
+
+        val result = resolver.resolveErlangSdkResult(elixirSdk, sdkModel(erlangSdk))
+
+        assertTrue("Should resolve across WSL prefix spellings", result is ErlangSdkResult.Success)
+        assertEquals(erlangSdk, (result as ErlangSdkResult.Success).sdk)
+    }
+
     fun testResolveByName_legacyFallback() {
         val configuredName = "Erlang 26"
         val erlangSdk = createSdk(name = configuredName, sdkType = ErlangSdkType.instance, homePath = "/fake/erlang/26.0")

--- a/tests/org/elixir_lang/sdk/wsl/MockWslCompatService.kt
+++ b/tests/org/elixir_lang/sdk/wsl/MockWslCompatService.kt
@@ -117,11 +117,7 @@ class MockWslCompatService(
         // Mock implementation returns a well-formed Windows UNC path
         val linuxAsWindows = linuxPath.replace('/', '\\')
         val converted = "\\\\wsl.localhost\\${distribution.msId}$linuxAsWindows"
-        return try {
-            canonicalizePath(converted)
-        } catch (_: Exception) {
-            converted
-        }
+        return canonicalizePath(converted)
     }
 
     override fun convertSingleWslPath(windowsPath: String, distribution: WSLDistribution): String? {

--- a/tests/org/elixir_lang/sdk/wsl/WslCompatServiceExtensionsTest.kt
+++ b/tests/org/elixir_lang/sdk/wsl/WslCompatServiceExtensionsTest.kt
@@ -1,11 +1,15 @@
 package org.elixir_lang.sdk.wsl
 
 import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.util.system.OS
 import org.elixir_lang.PlatformTestCase
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.*
+import java.util.concurrent.Callable
 
 class WslCompatServiceExtensionsTest : PlatformTestCase() {
     private val wslCompatMock = MockWslCompatService()
@@ -88,120 +92,122 @@ class WslCompatServiceExtensionsTest : PlatformTestCase() {
         assertEquals(linuxPath, converted)
     }
 
-    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsWindows() {
+    // -------------------------------------------------------------------------
+    // pathsEqualWslAware: pure lexical comparison, no filesystem access at all.
+    // -------------------------------------------------------------------------
+
+    fun testPathsEqualWslAware_neverTouchesTheFilesystem() {
+        // toRealPath throws AssertionError rather than a caught type, so any call that reaches it
+        // fails the test loudly instead of silently falling back.
+        val spiedService = spy(wslCompatMock)
+        doThrow(AssertionError("pathsEqualWslAware must not perform filesystem I/O"))
+            .`when`(spiedService)
+            .toRealPath(anyString())
+
+        assertTrue(spiedService.pathsEqualWslAware("C:\\sdk-a", "C:\\sdk-a"))
+        assertFalse(spiedService.pathsEqualWslAware("C:\\sdk-a", "C:\\sdk-b"))
+        verify(spiedService, never()).toRealPath(anyString())
+    }
+
+    fun testPathsEqualWslAware_returnsTrueForIdenticalWindowsPaths() {
         val myPath = "C:\\sdk-a"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath)
-
-        assertTrue(equal)
-        verify(throwingService, times(2)).toRealPath(anyString())
+        assertTrue(wslCompatMock.pathsEqualWslAware(myPath, myPath))
     }
 
-    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsLinux() {
-        val myPath = "/home/testuser/.local/share//mise//installs//elixir//1.15.7"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath)
-
-        assertTrue(equal)
-        verify(throwingService, times(2)).toRealPath(anyString())
+    fun testPathsEqualWslAware_returnsFalseForDifferentWindowsPaths() {
+        assertFalse(wslCompatMock.pathsEqualWslAware("C:\\sdk-a", "C:\\sdk-b"))
     }
 
-    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsWsl() {
-        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath)
-
-        assertTrue(equal)
-        verify(throwingService, times(2)).toRealPath(anyString())
+    fun testPathsEqualWslAware_returnsTrueForIdenticalLinuxPaths() {
+        val myPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
+        assertTrue(wslCompatMock.pathsEqualWslAware(myPath, myPath))
     }
 
-    fun testPathsEqualWslAware_returnsTrueWhenEqualButRealpathThrowsDifferentPrefixWsl() {
-        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
-        val myPath2 = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
-
-        assertTrue(equal)
-        // path is canonicalized before comparison, so same path calls twice
-        verify(throwingService, times(2)).toRealPath(anyString())
+    fun testPathsEqualWslAware_returnsFalseForDifferentLinuxPaths() {
+        val myPath = "/home/testuser/.local/share/mise/installs/elixir/1.15.7"
+        val myPath2 = "/home/testuser/.local/share/mise/installs/elixir/1.19.7"
+        assertFalse(wslCompatMock.pathsEqualWslAware(myPath, myPath2))
     }
 
-    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsWindows() {
-        val myPath = "C:\\sdk-a"
-        val myPath2 = "C:\\sdk-b"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
-
-        assertFalse(equal)
-        verify(throwingService).toRealPath(myPath)
-        verify(throwingService).toRealPath(myPath2)
+    fun testPathsEqualWslAware_rewritesLegacyWslPrefixBeforeComparing() {
+        val modern = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val legacy = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        // Default mock policy is legacy -> modern.
+        assertTrue(wslCompatMock.pathsEqualWslAware(modern, legacy))
     }
 
-    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsLinux() {
-        val myPath = "/home/testuser/.local/share//mise//installs//elixir//1.15.7"
-        val myPath2 = "/home/testuser/.local/share//mise//installs//elixir//1.19.7"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
-
-        assertFalse(equal)
-        verify(throwingService).toRealPath(myPath)
-        verify(throwingService).toRealPath(myPath2)
+    fun testPathsEqualWslAware_rewritesModernWslPrefixBeforeComparing() {
+        val legacyOnlyPolicy = MockWslCompatService(prefixConversionOverride = MODERN_WSL_PREFIX to LEGACY_WSL_PREFIX)
+        val modern = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        val legacy = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
+        assertTrue(legacyOnlyPolicy.pathsEqualWslAware(modern, legacy))
     }
 
-    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsWsl() {
-        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
-        val myPath2 = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.19.7"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
-
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
-
-        assertFalse(equal)
-        verify(throwingService).toRealPath(myPath)
-        verify(throwingService).toRealPath(myPath2)
+    fun testPathsEqualWslAware_returnsFalseForDifferentWslDistros() {
+        val ubuntuA = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\project"
+        val ubuntuB = "\\\\wsl.localhost\\ItronUbuntu\\home\\testuser\\project"
+        assertFalse(wslCompatMock.pathsEqualWslAware(ubuntuA, ubuntuB))
     }
 
-    fun testPathsEqualWslAware_returnsFalseWhenNotEqualButRealpathThrowsDifferentPrefixWsl() {
-        val myPath = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.15.7"
-        val myPath2 = "\\\\wsl$\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.19.7"
-        val myPath2Canonicalized = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\.local\\share\\mise\\installs\\elixir\\1.19.7"
-        val throwingService = spy(wslCompatMock)
-        doThrow(IllegalStateException("boom"))
-            .`when`(throwingService)
-            .toRealPath(anyString())
+    fun testPathsEqualWslAware_treatsMixedSeparatorsAsEqual() {
+        val forwardSlash = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\a/b"
+        val backslash = "\\\\wsl.localhost\\Ubuntu-24.04\\home\\testuser\\a\\b"
+        assertTrue(wslCompatMock.pathsEqualWslAware(forwardSlash, backslash))
+    }
 
-        val equal = throwingService.pathsEqualWslAware(myPath, myPath2)
+    fun testPathsEqualWslAware_returnsFalseForNullOrBlank() {
+        assertFalse(wslCompatMock.pathsEqualWslAware(null, "C:\\sdk-a"))
+        assertFalse(wslCompatMock.pathsEqualWslAware("C:\\sdk-a", null))
+        assertFalse(wslCompatMock.pathsEqualWslAware(null, null))
+        assertFalse(wslCompatMock.pathsEqualWslAware("", "C:\\sdk-a"))
+        assertFalse(wslCompatMock.pathsEqualWslAware("   ", "   "))
+    }
 
-        assertFalse(equal)
-        // path is canonicalized before comparison, so same path calls twice
-        verify(throwingService).toRealPath(myPath)
-        verify(throwingService).toRealPath(myPath2Canonicalized)
+    fun testPathsEqualWslAware_matchesFileUtilPathsEqualCaseRule() {
+        // Asserted against FileUtil.pathsEqual itself, not a hard-coded expectation, so this
+        // passes under either case-sensitivity rule the CI matrix runs under.
+        val lower = "\\\\wsl.localhost\\ubuntu-24.04\\home\\testuser\\project"
+        val upper = "\\\\wsl.localhost\\Ubuntu-24.04\\HOME\\testuser\\project"
+        assertEquals(FileUtil.pathsEqual(lower, upper), wslCompatMock.pathsEqualWslAware(lower, upper))
+    }
+
+    fun testPathsEqualWslAware_treatsWindowsDriveLettersCaseInsensitively() {
+        if (OS.CURRENT != OS.Windows) return
+        assertTrue(wslCompatMock.pathsEqualWslAware("C:\\Elixir", "c:/elixir"))
+    }
+
+    // -------------------------------------------------------------------------
+    // canonicalizePath: the I/O funnel - must never run under a read lock, and
+    // must never throw for a path that simply cannot be resolved.
+    // -------------------------------------------------------------------------
+
+    fun testCanonicalizePath_throwsUnderReadLock() {
+        val real = WslCompatServiceImpl()
+        // Must run on a pooled thread: test methods themselves run on the EDT, and the EDT's
+        // implicit write-intent read access does not register as holdsReadLock().
+        val threw = ApplicationManager.getApplication().executeOnPooledThread(Callable {
+            try {
+                ReadAction.nonBlocking(Callable {
+                    real.canonicalizePath("C:\\sdk-a")
+                }).executeSynchronously()
+                false
+            } catch (_: IllegalStateException) {
+                true
+            }
+        }).get()
+
+        assertTrue("Expected canonicalizePath to throw when called under a read lock", threw)
+    }
+
+    fun testCanonicalizePath_fallsBackToLexicalFormForNonexistentPath() {
+        val real = WslCompatServiceImpl()
+        val nonexistent = "\\\\wsl.localhost\\NoSuchDistro-doesNotExist\\home\\nobody"
+
+        // Must not throw, and must not boot anything - it returns the prefix-rewritten string.
+        val expected = with(real) { nonexistent.canonicalizeWslPrefix() }
+        val result = real.canonicalizePath(nonexistent)
+
+        assertEquals(expected, result)
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
pathsEqualWslAware canonicalized both sides of every comparison with Path.toRealPath(), so ProjectJdkTable scan predicates did real filesystem I/O per candidate SDK - under the read lock, and under the write lock in registerOrUpdatePreparedErlangSdk. On 2026.1+ any NIO access to a \\wsl.localhost\<distro>\ path deploys an ijent agent and boots the distro if stopped, so a single scan booted every WSL distro hosting a registered SDK - including SDKs invisible to and unrelated to the open project - and a hung WSL/IJent bridge could freeze the IDE unrecoverably while the lock was held.

- pathsEqualWslAware now compares lexically after WSL-prefix and separator normalization (new normalizeForComparison) - no filesystem access, safe in scan predicates and under either lock. Persisted SDK homes are already canonicalized at registration time, so persisted-vs- persisted comparisons are unchanged.
- canonicalizePath keeps toRealPath for single-target registration and validation flows, and now asserts no read lock is held so any future locked caller fails loudly instead of silently booting distros.
- detectOtpMismatch resolves the paired Erlang SDK in its own short read action and reads Elixir.System.beam/OTP_VERSION with no lock held; RefreshAllElixirSdksAction and the SDK status-bar widget no longer wrap the call in an outer read action.
- convertLinuxPathToWindowsUnc no longer swallows the read-lock assertion in its catch block.

Verified in a sandbox A/B run: with identical projects and SDK tables, the previous build booted two stopped, unrelated WSL distros minutes into an idle session; this build boots none, resolves the same SDKs, and never trips the new assertion.