### PR TITLE
fix(run): stop writing the module element twice and persist passParentEnvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@
     ends in `end`**. This fixes decompilation of `Mix.Project`, `Mix.Release`, and `Mix.Task` on
     Elixir 1.20+.
 
+- [#3918](https://github.com/KronicDeth/intellij-elixir/pull/3918) [@sh41](https://github.com/sh41)
+  - **Saved run configurations no longer record the module twice.** Every Elixir run configuration
+    wrote a second `module` element on top of the one the IDE already writes, which the platform
+    logs as "Module serialized more than one time".
+  - **"Include system environment variables" is now remembered.** The setting was accepted in the
+    run configuration editor but silently discarded when the configuration was saved.
+  - **A run configuration whose module is not loaded yet keeps it.** Reading a saved configuration
+    before its module exists no longer clears the module instead of leaving the IDE to resolve it.
+
 - [#3915](https://github.com/KronicDeth/intellij-elixir/pull/3915) [@sh41](https://github.com/sh41)
   - **The IDE no longer starts every WSL distro that hosts a registered Erlang or Elixir SDK, and
     will no longer freeze if WSL is slow or hangs while starting.** Checking whether two WSL-hosted

--- a/src/org/elixir_lang/run/Configuration.kt
+++ b/src/org/elixir_lang/run/Configuration.kt
@@ -138,20 +138,29 @@ fun Element.readModuleFilters(
     }
 }
 
+/**
+ * [ModuleBasedConfiguration.writeExternal] already serializes the module name as a `module` element, so this reuses
+ * that element instead of adding a second one: the platform's own [com.intellij.execution.configurations.RunConfigurationModule.readExternal]
+ * warns that the module was "serialized more than one time" when a scheme carries two.
+ */
 fun Element.writeExternalModule(configuration: Configuration) {
     val moduleName = configuration.configurationModule.moduleName
 
     if (!moduleName.isBlank()) {
-        val moduleElement = Element(MODULE)
-        moduleElement.setAttribute(NAME, moduleName)
-        addContent(moduleElement)
+        ensureChild(MODULE).setAttribute(NAME, moduleName)
     }
 }
 
+/**
+ * Only overrides what [ModuleBasedConfiguration.readExternal] already restored when the module can actually be
+ * resolved: a configuration read before its module is loaded keeps the platform's pointer, which resolves later,
+ * rather than being reset to no module at all.
+ */
 fun Element.readExternalModule(configuration: Configuration) {
-    getChild(MODULE)?.getAttributeValue(NAME)?.let { moduleName ->
-        configuration.configurationModule.module = configuration.configurationModule.findModule(moduleName)
-    }
+    getChild(MODULE)
+            ?.getAttributeValue(NAME)
+            ?.let { moduleName -> configuration.configurationModule.findModule(moduleName) }
+            ?.let { module -> configuration.configurationModule.module = module }
 }
 
 fun Element.writeExternalWorkingDirectory(workingDirectoryURL: String?) {
@@ -183,6 +192,7 @@ const val ERL = "erl"
 const val MIX = "mix"
 private const val MODULE = "module"
 private const val NAME = "name"
+private const val PASS_PARENT_ENVS = "pass-parent-envs"
 private const val URL = "url"
 private const val WORKING_DIRECTORY = "working-directory"
 
@@ -221,6 +231,24 @@ abstract class Configuration(name: String, project: Project, configurationFactor
 
     override fun setPassParentEnvs(passParentEnvs: Boolean) {
         _passParentEnvs = passParentEnvs
+    }
+
+    /**
+     * [com.intellij.execution.configuration.EnvironmentVariablesComponent.readExternal] restores only the variables
+     * map, so the flag deciding whether the parent environment is inherited is read here. Subclasses get it through
+     * their `super.readExternal` call.
+     */
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        _passParentEnvs = element.getAttributeValue(PASS_PARENT_ENVS)?.toBoolean() ?: false
+    }
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+
+        if (_passParentEnvs) {
+            element.setAttribute(PASS_PARENT_ENVS, true.toString())
+        }
     }
 
     override fun getValidModules(): Collection<com.intellij.openapi.module.Module> =

--- a/tests/org/elixir_lang/run/ConfigurationRoundTripTest.kt
+++ b/tests/org/elixir_lang/run/ConfigurationRoundTripTest.kt
@@ -1,0 +1,116 @@
+package org.elixir_lang.run
+
+import com.intellij.openapi.util.JDOMUtil
+import com.intellij.openapi.util.io.FileUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.debugger.settings.stepping.ModuleFilter
+import org.jdom.Element
+
+/**
+ * Pins the run-configuration XML round trip for the two configuration types users report as
+ * "Cannot read scheme <TYPE_ID>-<factory>.xml": whatever [Configuration.writeExternal] emits,
+ * [Configuration.readExternal] must read back into an equivalent configuration.
+ */
+class ConfigurationRoundTripTest : PlatformTestCase() {
+    fun testMixConfigurationRoundTrip() {
+        val written = mixConfiguration().apply {
+            erlArguments = "-sname round_trip"
+            elixirArguments = "--no-halt"
+            programParameters = "run --no-start"
+            workingDirectory = myFixture.tempDirPath
+            envs = mapOf("MIX_ENV" to "dev")
+            isPassParentEnvs = true
+            inheritApplicationModuleFilters = false
+            moduleFilterList = mutableListOf(ModuleFilter(true, "Elixir.Foo.*"))
+            configurationModule.module = myFixture.module
+        }
+
+        val read = mixConfiguration()
+        read.readExternal(writeToElement(written))
+
+        assertEquals("-sname round_trip", read.erlArguments)
+        assertEquals("--no-halt", read.elixirArguments)
+        assertEquals("run --no-start", read.programParameters)
+        assertWorkingDirectoryEquals(myFixture.tempDirPath, read.workingDirectory)
+        assertEquals(mapOf("MIX_ENV" to "dev"), read.envs)
+        assertTrue("Expected passParentEnvs to survive the round trip", read.isPassParentEnvs)
+        assertFalse(read.inheritApplicationModuleFilters)
+        assertEquals(listOf(ModuleFilter(true, "Elixir.Foo.*")), read.moduleFilterList)
+        assertEquals(myFixture.module, read.configurationModule.module)
+    }
+
+    fun testExUnitConfigurationRoundTrip() {
+        val written = exUnitConfiguration().apply {
+            erlArgumentList = mutableListOf("-sname", "round_trip")
+            elixirArgumentList = mutableListOf("--no-halt")
+            mixTestArgumentList = mutableListOf("--trace", "test/foo_test.exs")
+            workingDirectory = myFixture.tempDirPath
+            envs = mapOf("MIX_ENV" to "test")
+            isPassParentEnvs = true
+            inheritApplicationModuleFilters = false
+            moduleFilterList = mutableListOf(ModuleFilter(false, "Elixir.Bar.*"))
+            configurationModule.module = myFixture.module
+        }
+
+        val read = exUnitConfiguration()
+        read.readExternal(writeToElement(written))
+
+        assertEquals(listOf("-sname", "round_trip"), read.erlArgumentList)
+        assertEquals(listOf("--no-halt"), read.elixirArgumentList)
+        assertEquals(listOf("--trace", "test/foo_test.exs"), read.mixTestArgumentList)
+        assertWorkingDirectoryEquals(myFixture.tempDirPath, read.workingDirectory)
+        assertEquals(mapOf("MIX_ENV" to "test"), read.envs)
+        assertTrue("Expected passParentEnvs to survive the round trip", read.isPassParentEnvs)
+        assertFalse(read.inheritApplicationModuleFilters)
+        assertEquals(listOf(ModuleFilter(false, "Elixir.Bar.*")), read.moduleFilterList)
+        assertEquals(myFixture.module, read.configurationModule.module)
+    }
+
+    /**
+     * The module name is written by both [com.intellij.execution.configurations.ModuleBasedConfiguration]
+     * (through its serialized options) and by this plugin's own `writeExternalModule`, so the saved
+     * scheme must not end up with conflicting `module` elements.
+     */
+    fun testMixConfigurationWritesOneModuleElement() {
+        val configuration = mixConfiguration().apply { configurationModule.module = myFixture.module }
+
+        val element = writeToElement(configuration)
+
+        assertEquals(
+            "module written more than once:\n${JDOMUtil.write(element)}",
+            1,
+            element.getChildren("module").size
+        )
+    }
+
+    /**
+     * A saved scheme whose `module` element carries children but no `name` attribute is what used to raise
+     * `java.lang.AssertionError` out of the platform's option-tag deserialization, surfacing as
+     * "Cannot read scheme <TYPE_ID>-<factory>.xml" and losing the whole run configuration.
+     */
+    fun testReadsSchemeWithMalformedModuleElement() {
+        val element = JDOMUtil.load("<configuration><module><child /></module></configuration>")
+
+        mixConfiguration().readExternal(element)
+    }
+
+    private fun mixConfiguration() =
+        org.elixir_lang.mix.Configuration(NAME, project, org.elixir_lang.mix.configuration.Factory)
+
+    private fun exUnitConfiguration() = org.elixir_lang.exunit.Configuration(NAME, project)
+
+    private fun writeToElement(configuration: Configuration): Element =
+        Element("configuration").also { configuration.writeExternal(it) }
+
+    private fun assertWorkingDirectoryEquals(expected: String, actual: String?) {
+        assertNotNull(actual)
+        assertEquals(
+            FileUtil.toSystemIndependentName(expected),
+            FileUtil.toSystemIndependentName(actual!!)
+        )
+    }
+
+    companion object {
+        private const val NAME = "round trip"
+    }
+}


### PR DESCRIPTION
Found while reviewing four 2018 crash reports of *"Cannot read scheme `<TYPE_ID>-<factory>.xml`"*. Reading their stack traces properly turned up three real defects in the run-configuration save/load path, none of which any test covered.

## What the reports actually say

All four carry a bare `java.lang.AssertionError` from `com.intellij.util.xmlb.OptionTagBinding.deserialize`, reached from `RunConfigurationBase.readExternal`. In IDEA 2018.1 that line is `assert myBinding != null`, on the branch taken when an option's value attribute is absent but the element has children. The option is `ModuleBasedConfigurationOptions.module`, declared `@OptionTag(tag = "module", valueAttribute = "name", nameAttribute = "")` — a plain `String`, so the binding is null and the assertion fires.

That branch no longer exists: `OptionTagBinding` is now `TagBinding`, and when an option declares a value attribute it reads the attribute and stops. The original defect is fixed upstream, and the plugin frame under it, `MixRunConfigurationBase`, was rewritten away. The issues below are closed on that basis, not on this change.

## What this changes

- **`module` was written twice.** `ModuleBasedConfiguration.writeExternal` serializes the module name through its options bean; `writeExternalModule` then appended a second element unconditionally. The platform's `RunConfigurationModule.readExternal` logs *"Module serialized more than one time"* for exactly this. Now reuses the existing child via the `ensureChild` helper already in the file.
- **`passParentEnvs` was never persisted.** `EnvironmentVariablesComponent.writeExternal` writes only the variables map, so "include system environment variables" was accepted in the editor and silently dropped on save. Read and written on the base `org.elixir_lang.run.Configuration`, so all seven configuration classes get it through their existing `super` call — no caller changes.
- **`readExternalModule` discarded an unresolved module.** It assigned `findModule(name)` unconditionally, overwriting the platform's already-restored `ModulePointer` with null when the module had not loaded yet. Now only assigns when the module resolves.

All three live in `src/org/elixir_lang/run/Configuration.kt`.

## Tests

New `tests/org/elixir_lang/run/ConfigurationRoundTripTest.kt` — nothing previously exercised `readExternal`/`writeExternal` for any configuration type.

- round trip for `MixRunConfigurationType` and `MixExUnitRunConfigurationType`: arguments, working directory, envs, `passParentEnvs`, module filters, module
- `module` is written exactly once
- a scheme whose `module` element carries children and no `name` attribute — the exact shape that tripped the 2018 assertion — reads without throwing

Three of the four failed on `main` before this change. Full suite green: 6594 passing.

Fixes #1074
Fixes #1129

#1083 and #1104 are duplicates of #1129 and are deliberately not listed here — they need closing as duplicates rather than completed, so the canonical is recorded.