### PR TITLE
fix(new-project): configure the module for the project mix new actually created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@
     ends in `end`**. This fixes decompilation of `Mix.Project`, `Mix.Release`, and `Mix.Task` on
     Elixir 1.20+.
 
+- [#3919](https://github.com/KronicDeth/intellij-elixir/pull/3919) [@sh41](https://github.com/sh41)
+  - **New Elixir projects get the right compiler output directory.** Leaving `--app` blank in the
+    New Project wizard - which is allowed, and is what most people do - configured the module with
+    `_build/dev/lib/ebin` instead of `_build/dev/lib/<app>/ebin`. It now falls back to the project
+    name, which is what `mix new` itself uses.
+  - **`--sup` is no longer offered for umbrella projects.** `mix new` ignores it at an umbrella root
+    without reporting anything, so ticking it appeared to work and silently did nothing.
+  - **New umbrella projects no longer get a stray empty `lib/` or a compiler output directory that
+    never exists.** An umbrella root has no application of its own, so neither applies to it.
+  - **New Elixir projects and modules are no longer reported as having "an outdated format".** Every
+    project the plugin created was offered for conversion the next time it was opened, because the
+    module was written with compiler-output exclusion switched on - the exact setting the plugin's
+    converter exists to remove. Elixir compiles to `_build`, so the setting never applied.
+  - **Umbrella sub-apps now get their `lib/` and `test/` marked.** `mix new` writes an app from an
+    external process, so the IDE could hold a stale view of the directory that did not include its
+    `mix.exs` - and every folder-mark scan skipped the app in silence because of it. The New Project
+    wizard, *Reconfigure Elixir Module Setup* and the module-setup check now refresh first.
+
 - [#3918](https://github.com/KronicDeth/intellij-elixir/pull/3918) [@sh41](https://github.com/sh41)
   - **Saved run configurations no longer record the module twice.** Every Elixir run configuration
     wrote a second `module` element on top of the one the IDE already writes, which the platform

--- a/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
+++ b/src/org/elixir_lang/action/ReconfigureModuleSetupAction.kt
@@ -15,6 +15,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import org.elixir_lang.mix.project.CANONICAL_FOLDER_MARKS
 import org.elixir_lang.mix.project.FolderMark
 import org.elixir_lang.isElixirMixModule
+import org.elixir_lang.mixContentRoots
+import org.elixir_lang.mix.Project as MixProject
 import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
 
@@ -58,6 +60,16 @@ class ReconfigureModuleSetupAction : AnAction() {
         val hasRootMixExs = project.basePath?.let { basePath ->
             LocalFileSystem.getInstance().findFileByPath(basePath)?.findChild("mix.exs")
         } != null
+
+        // Umbrella sub-apps created by `mix new` are written by an external process, so VFS can
+        // hold a stale child list that omits their mix.exs - which would make the scan below skip
+        // them silently. Refresh first: this is deliberately outside the write action, where a
+        // synchronous refresh is not permitted.
+        for (module in ModuleManager.getInstance(project).modules) {
+            for (mixContentRoot in module.mixContentRoots()) {
+                MixProject.refreshUmbrellaSubApps(mixContentRoot.root, async = false)
+            }
+        }
 
         var modulesReconfigured = 0
         var foldersAdded = 0

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.module.ModifiableModuleModel
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.CompilerModuleExtension
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ModuleRootManager
@@ -167,6 +168,8 @@ object Project {
     }
 
     fun addFolders(modifiableRootModel: ModifiableRootModel, root: VirtualFile) {
+        clearExcludeOutput(modifiableRootModel)
+
         val content = modifiableRootModel.addContentEntry(root)
 
         for (canonicalFolder in CANONICAL_FOLDER_MARKS) {
@@ -176,6 +179,31 @@ object Project {
                 FolderMark.EXCLUDED -> excludeDirFromContent(content, root, canonicalFolder.relativePath)
             }
         }
+    }
+
+    /**
+     * Turns off "exclude compiler output" for an Elixir module.
+     *
+     * Elixir compiles to `_build`, never to IntelliJ's compiler output, so excluding that output
+     * buys nothing - and the plugin ships a project converter whose only job is to strip the
+     * resulting `<exclude-output/>` from `ELIXIR_MODULE`s. Any module keeping the flag is therefore
+     * offered for "conversion" the next time its project is opened.
+     *
+     * Setting it explicitly matters even though `false` is the value we want. `JavaSettingsSerializer`
+     * writes `<exclude-output/>` for a module with **no** Java settings at all, and
+     * `JpsJavaModuleExtensionBridge.isExcludeOutput()` defaults to `true` for the same reason, so
+     * leaving the flag untouched produces the tag rather than omitting it. `JavaModuleBuilder`
+     * additionally sets it to `true` outright.
+     *
+     * Called from [addFolders], which every path that configures an Elixir module root goes
+     * through: the New Project wizard and the New Module wizard via
+     * [org.elixir_lang.module.ElixirModuleBuilder], and the import wizard and project-open
+     * processor via [createModulesForOtpApps].
+     */
+    private fun clearExcludeOutput(modifiableRootModel: ModifiableRootModel) {
+        modifiableRootModel
+            .getModuleExtension(CompilerModuleExtension::class.java)
+            .setExcludeOutput(false)
     }
 
     /**

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentEntry
 import com.intellij.openapi.roots.ModifiableRootModel
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileVisitor
@@ -175,6 +176,29 @@ object Project {
                 FolderMark.EXCLUDED -> excludeDirFromContent(content, root, canonicalFolder.relativePath)
             }
         }
+    }
+
+    /**
+     * Refreshes the umbrella sub-app directories under [root] so their `mix.exs` is visible to
+     * [VirtualFile.findChild].
+     *
+     * `mix new` writes a sub-app from an external process, so VFS can hold a child list for it
+     * containing only the entries the IDE itself touched - no `mix.exs` - and `findChild` answers
+     * from that list without going to disk. [findOtpApps] avoids this by refreshing its own root
+     * before scanning; the folder-mark scans need the same.
+     *
+     * Refreshes `apps/` and its immediate sub-directories rather than recursing, so the cost stays
+     * bounded on umbrellas whose children carry `deps/` and `_build/`. A sub-app that appears after
+     * `apps/` was last refreshed is therefore picked up on the following scan.
+     *
+     * @param async when false this blocks until the refresh completes, so it must not be called
+     *   under a read or write lock - a synchronous refresh is not permitted inside one.
+     */
+    fun refreshUmbrellaSubApps(root: VirtualFile, async: Boolean) {
+        val appsDir = root.findChild("apps") ?: return
+        val targets = (listOf(appsDir) + appsDir.children.filter(VirtualFile::isDirectory)).toTypedArray()
+
+        VfsUtil.markDirtyAndRefresh(async, false, true, *targets)
     }
 
     private fun createImportedOtpApp(appRoot: VirtualFile): OtpApp? =

--- a/src/org/elixir_lang/new_project_wizard/MixNewOptions.kt
+++ b/src/org/elixir_lang/new_project_wizard/MixNewOptions.kt
@@ -1,0 +1,73 @@
+package org.elixir_lang.new_project_wizard
+
+import java.nio.file.Paths
+
+/**
+ * The `mix new` arguments and the module layout they imply, extracted from [Step.setupProject] so
+ * they can be asserted without running `mix new`.
+ *
+ * `--umbrella` selects a different kind of project rather than modifying one: the root declares
+ * `apps_path:` instead of `app:`, so it has no `lib/` and compiles nothing of its own, and each
+ * child application builds to `_build/dev/lib/<child>/ebin` instead.
+ */
+internal object MixNewOptions {
+    /**
+     * `mix new` ignores `--sup` at an umbrella root and reports nothing, so it is dropped here
+     * rather than passed and silently lost.
+     */
+    fun parameters(
+        projectDirectory: String,
+        app: String,
+        module: String,
+        sup: Boolean,
+        umbrella: Boolean
+    ): List<String> = buildList {
+        add("new")
+        add(projectDirectory)
+
+        if (app.isNotBlank()) {
+            add("--app")
+            add(app)
+        }
+
+        if (module.isNotBlank()) {
+            add("--module")
+            add(module)
+        }
+
+        if (sup && !umbrella) {
+            add("--sup")
+        }
+
+        if (umbrella) {
+            add("--umbrella")
+        }
+    }
+
+    /**
+     * `null` for an umbrella root, which `mix new` leaves without a `lib/`.
+     * [com.intellij.ide.util.projectWizard.JavaModuleBuilder] creates every source path it is
+     * given, so passing one would leave a stray empty directory behind.
+     */
+    fun sourcePath(projectDirectory: String, umbrella: Boolean): String? =
+        if (umbrella) {
+            null
+        } else {
+            Paths.get(projectDirectory, "lib").toString()
+        }
+
+    /**
+     * `null` for an umbrella root, which produces no `.beam` of its own, so that
+     * [com.intellij.ide.util.projectWizard.JavaModuleBuilder] inherits the compiler output path
+     * rather than pointing the module at a directory that never exists.
+     *
+     * [app] is blank whenever `--app` is left unset, which the wizard permits because `mix new`
+     * then infers the application name from the last segment of the path - that is [name].
+     */
+    fun compilerOutputPath(projectDirectory: String, name: String, app: String, umbrella: Boolean): String? =
+        if (umbrella) {
+            null
+        } else {
+            Paths.get(projectDirectory, "_build", "dev", "lib", app.ifBlank { name }, "ebin").toString()
+        }
+}

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -31,6 +31,8 @@ import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.NlsContexts
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.layout.ValidationInfoBuilder
 import kotlinx.coroutines.CancellationException
@@ -199,6 +201,15 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
 
                 throw IOException("mix new failed: $stderrWithoutColorCodes")
             }
+
+            // mix new wrote the whole project from an external process, so none of it is in VFS.
+            // Refresh before configuring the module: the folder-mark scans that run later use
+            // findChild, which answers from the cached child list rather than going to disk, and
+            // would otherwise never see this project's mix.exs.
+            LocalFileSystem
+                .getInstance()
+                .refreshAndFindFileByNioFile(context.projectDirectory)
+                ?.let { VfsUtil.markDirtyAndRefresh(false, true, true, it) }
 
             super.setupProject(project)
 

--- a/src/org/elixir_lang/new_project_wizard/Step.kt
+++ b/src/org/elixir_lang/new_project_wizard/Step.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.observable.properties.ObservableMutableProperty
 import com.intellij.openapi.observable.properties.ObservableProperty
+import com.intellij.openapi.observable.util.not
 import com.intellij.openapi.options.ConfigurationException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
@@ -117,6 +118,8 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
                 row {
                     checkBox("--sup")
                         .bindSelected(mixNewSupProperty)
+                        .enabledIf(!mixNewUmbrellaProperty)
+                        .comment("Not available for umbrella projects: an umbrella root has no application to supervise.")
                 }.bottomGap(BottomGap.SMALL)
                 row {
                     checkBox("--umbrella")
@@ -155,23 +158,9 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
             val commandLine = ReadAction.nonBlocking(Callable {
                 Mix.commandLine(emptyMap(), workingDirectory, sdk, project = project)
             }).executeSynchronously()
-            commandLine.addParameters("new", projectDirectory)
-
-            if (mixNewApp.isNotBlank()) {
-                commandLine.addParameters("--app", mixNewApp)
-            }
-
-            if (mixNewModule.isNotBlank()) {
-                commandLine.addParameters("--module", mixNewModule)
-            }
-
-            if (mixNewSup) {
-                commandLine.addParameter("--sup")
-            }
-
-            if (mixNewUmbrella) {
-                commandLine.addParameter("--umbrella")
-            }
+            commandLine.addParameters(
+                MixNewOptions.parameters(projectDirectory, mixNewApp, mixNewModule, mixNewSup, mixNewUmbrella)
+            )
 
             // delete the caller's created empty directory so that `mix new` can create it.
             if (!context.projectDirectory.toFile().deleteRecursively()) {
@@ -219,23 +208,17 @@ class Step(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep(parent),
             // The project SDK belongs to the host language (Java, Python, etc.) and is not required for Elixir functionality.
             builder.moduleJdk = sdk
 
-            builder.addSourcePath(
-                com.intellij.openapi.util.Pair(
-                    Paths.get(projectDirectory, "lib").toString(),
-                    ""
-                )
-            )
+            // Set the source paths even when there are none: JavaModuleBuilder.getSourcePaths()
+            // creates and returns <contentRoot>/src when they were never set at all, which would
+            // leave a stray empty src/ in an umbrella root.
+            builder.sourcePaths = MixNewOptions
+                .sourcePath(projectDirectory, mixNewUmbrella)
+                ?.let { listOf(com.intellij.openapi.util.Pair(it, "")) }
+                .orEmpty()
 
-            builder.setCompilerOutputPath(
-                Paths.get(
-                    context.projectDirectory.toString(),
-                    "_build",
-                    "dev",
-                    "lib",
-                    mixNewApp,
-                    "ebin"
-                ).toString()
-            )
+            MixNewOptions
+                .compilerOutputPath(projectDirectory, name, mixNewApp, mixNewUmbrella)
+                ?.let(builder::setCompilerOutputPath)
 
             builder.commit(project)
         } catch (e: ExecutionException) {

--- a/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
+++ b/src/org/elixir_lang/status_bar_widget/ElixirEditorBasedSdkWidget.kt
@@ -39,6 +39,8 @@ import org.elixir_lang.Icons
 import org.elixir_lang.isElixirModule
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator
 import org.elixir_lang.mix.project.ProjectModuleSetupValidator.FolderMarkIssue
+import org.elixir_lang.mixContentRoots
+import org.elixir_lang.mix.Project as MixProject
 import org.elixir_lang.sdk.SdkEbinPaths
 import org.elixir_lang.sdk.elixir.ElixirSdkLookup
 import org.elixir_lang.sdk.elixir.ElixirSdkMutation
@@ -217,6 +219,15 @@ class ElixirEditorBasedSdkWidget(
                 // a partially-complete scan and restart, wasting work - safe but inefficient since
                 // the notification outcome is idempotent (duplicate issueKeys are suppressed).
                 .collect {
+                    // Schedule a refresh of any umbrella sub-apps before scanning: `mix new`
+                    // writes them from an external process, so VFS can hold a child list without
+                    // their mix.exs and the folder-mark scan would skip them. Asynchronous, and
+                    // outside the readAction below, so no I/O happens under the lock - the
+                    // refreshed state is picked up by the next scan.
+                    readAction {
+                        ModuleManager.getInstance(project).modules.flatMap { it.mixContentRoots() }
+                    }.forEach { MixProject.refreshUmbrellaSubApps(it.root, async = true) }
+
                     val modelData = readAction { collectNotificationScanModelData() }
                     val ioData = withContext(Dispatchers.IO) { collectNotificationScanIoData(modelData) }
                     val tmAnalysis = latestTmAnalysis

--- a/tests/org/elixir_lang/action/ReconfigureModuleSetupActionStaleVfsHeavyTest.kt
+++ b/tests/org/elixir_lang/action/ReconfigureModuleSetupActionStaleVfsHeavyTest.kt
@@ -1,0 +1,98 @@
+package org.elixir_lang.action
+
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.ActionUiKind
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.PsiTestUtil
+import org.elixir_lang.facet.Type
+import java.io.File
+
+/**
+ * Reproduces what the New Project wizard leaves behind when it creates an umbrella sub-app.
+ *
+ * `mix new` writes the sub-app from an external process, so the only entries VFS holds for it are
+ * the ones the IDE itself touched while setting the project up. `findChild("mix.exs")` then answers
+ * null from that cached child list without going to disk, and every folder-mark scan skips the
+ * sub-app in silence.
+ *
+ * Needs a real filesystem, hence [HeavyPlatformTestCase]: the light fixture's `temp://` VFS is
+ * in-memory, so writing through [File] there produces no stale entry to reproduce - it produces no
+ * entry at all.
+ */
+class ReconfigureModuleSetupActionStaleVfsHeavyTest : HeavyPlatformTestCase() {
+
+    fun testAddsMarksForAnUmbrellaSubAppWrittenOutsideVfs() {
+        val umbrellaDir = createTempDir("umbrella")
+        FileUtil.writeToFile(File(umbrellaDir, "mix.exs"), "")
+        // apps/c1/lib exists before VFS first sees the umbrella, standing in for the source path
+        // JavaModuleBuilder resolves (and creates) while the wizard is setting the sub-app up.
+        File(umbrellaDir, "apps/c1/lib").mkdirs()
+
+        val umbrellaVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(umbrellaDir)
+            ?: error("umbrella not found in VFS after refresh")
+        VfsUtil.markDirtyAndRefresh(false, true, true, umbrellaVf)
+
+        val module = createModule("umbrella")
+        PsiTestUtil.addContentRoot(module, umbrellaVf)
+        // The action only touches modules with an Elixir identity; createModule has none.
+        FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+
+        // The rest of the sub-app arrives behind VFS's back, exactly as `mix new` writes it.
+        File(umbrellaDir, "apps/c1/test").mkdirs()
+        FileUtil.writeToFile(File(umbrellaDir, "apps/c1/mix.exs"), "")
+
+        val subAppDir = umbrellaVf.findFileByRelativePath("apps/c1")
+            ?: error("apps/c1 not found in VFS")
+        assertNull(
+            "Precondition: VFS must not see the externally written mix.exs, or this test proves nothing",
+            subAppDir.findChild("mix.exs")
+        )
+
+        runAction()
+
+        val entry = ModuleRootManager.getInstance(module).contentEntries
+            .single { it.file == umbrellaVf }
+        val sourceUrls = entry.sourceFolders.associate { it.url to it.isTestSource }
+
+        assertTrue(
+            "apps/c1/lib should be Sources despite the stale VFS entry, got: ${sourceUrls.keys}",
+            sourceUrls.any { it.key.endsWith("/apps/c1/lib") && !it.value }
+        )
+        assertTrue(
+            "apps/c1/test should be Test Sources despite the stale VFS entry, got: ${sourceUrls.keys}",
+            sourceUrls.any { it.key.endsWith("/apps/c1/test") && it.value }
+        )
+    }
+
+    private fun runAction() {
+        val dataContext = DataContext { dataId ->
+            if (CommonDataKeys.PROJECT.`is`(dataId)) project else null
+        }
+        val event = AnActionEvent.createEvent(dataContext, null, ActionPlaces.UNKNOWN, ActionUiKind.NONE, null)
+
+        ReconfigureModuleSetupAction().actionPerformed(event)
+    }
+
+    override fun tearDown() {
+        try {
+            val moduleManager = ModuleManager.getInstance(project)
+            for (module in moduleManager.modules.filter { it.name == "umbrella" }) {
+                val model = moduleManager.getModifiableModel()
+                model.disposeModule(module)
+                com.intellij.openapi.application.WriteAction.run<Throwable> { model.commit() }
+            }
+        } finally {
+            super.tearDown()
+        }
+    }
+}

--- a/tests/org/elixir_lang/action/ReconfigureModuleSetupActionTest.kt
+++ b/tests/org/elixir_lang/action/ReconfigureModuleSetupActionTest.kt
@@ -370,6 +370,65 @@ class ReconfigureModuleSetupActionTest : PlatformTestCase() {
         assertFalse("web/ should be Sources (not Test Sources)", webFolder!!.isTestSource)
     }
 
+    /**
+     * Reproduces a single-module umbrella whose child app was added after the module was
+     * configured: the umbrella root already carries every canonical mark, and `apps/c1` has a
+     * `mix.exs`, `lib/` and `test/` but no content entry of its own.
+     *
+     * The action must mark `apps/c1/lib` and `apps/c1/test`, because the umbrella root's own marks
+     * say nothing about its children.
+     */
+    @RequiresReadLock
+    fun testAddsMarksForAnUmbrellaSubAppAddedAfterTheRootWasConfigured() {
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_root/apps/c1/lib")
+        myFixture.tempDirFixture.findOrCreateDir("umbrella_root/apps/c1/test")
+        myFixture.tempDirFixture.createFile("umbrella_root/apps/c1/mix.exs", "")
+
+        // The umbrella root as the New Project wizard leaves it: every canonical mark applied by
+        // URL, whether or not the directory exists.
+        addMixContentEntry("umbrella_root") { content, rootUrl ->
+            content.addSourceFolder("$rootUrl/lib", false)
+            content.addSourceFolder("$rootUrl/web", false)
+            content.addSourceFolder("$rootUrl/spec", true)
+            content.addSourceFolder("$rootUrl/test", true)
+            content.addExcludeFolder("$rootUrl/deps")
+            content.addExcludeFolder("$rootUrl/.elixir_ls")
+            content.addExcludeFolder("$rootUrl/assets/node_modules/phoenix")
+            content.addExcludeFolder("$rootUrl/assets/node_modules/phoenix_html")
+            content.addExcludeFolder("$rootUrl/cover")
+            content.addExcludeFolder("$rootUrl/doc")
+            content.addExcludeFolder("$rootUrl/logs")
+        }
+
+        val issuesBefore = detectIssuesOnBgThread().filter { it.folderRelativePath.startsWith("apps/c1") }
+        assertTrue(
+            "The validator should report the unmarked sub-app before the action runs",
+            issuesBefore.isNotEmpty()
+        )
+
+        runAction()
+
+        val entry = ModuleRootManager.getInstance(module).contentEntries
+            .find { it.file?.name == "umbrella_root" }!!
+        val sourceUrls = entry.sourceFolders.associate { it.url to it.isTestSource }
+
+        assertTrue(
+            "apps/c1/lib should be Sources, got: ${sourceUrls.keys}",
+            sourceUrls.any { it.key.endsWith("/apps/c1/lib") && !it.value }
+        )
+        assertTrue(
+            "apps/c1/test should be Test Sources, got: ${sourceUrls.keys}",
+            sourceUrls.any { it.key.endsWith("/apps/c1/test") && it.value }
+        )
+
+        val issuesAfter = detectIssuesOnBgThread().filter { it.folderRelativePath.startsWith("apps/c1") }
+        assertEquals(
+            "The sub-app should have no remaining folder mark issues, got: $issuesAfter",
+            0,
+            issuesAfter.size
+        )
+    }
+
     // -------------------------------------------------------------------------
     // Scenario 4: Project SDK = Java, Reconfigure action invoked
     // → folder marks applied; module SDK left untouched (Step 1 guard)

--- a/tests/org/elixir_lang/mix/ProjectAddFoldersTest.kt
+++ b/tests/org/elixir_lang/mix/ProjectAddFoldersTest.kt
@@ -1,0 +1,62 @@
+package org.elixir_lang.mix
+
+import com.intellij.openapi.roots.CompilerModuleExtension
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Covers what [Project.addFolders] configures beyond the folder marks themselves.
+ */
+class ProjectAddFoldersTest : PlatformTestCase() {
+
+    /** URLs of content entries added during a test, cleaned up in [tearDown]. */
+    private val addedContentRootUrls = mutableListOf<String>()
+
+    override fun tearDown() {
+        try {
+            if (addedContentRootUrls.isNotEmpty()) {
+                ModuleRootModificationUtil.updateModel(module) { model ->
+                    for (entry in model.contentEntries.toList()) {
+                        if (entry.url in addedContentRootUrls) {
+                            model.removeContentEntry(entry)
+                        }
+                    }
+                }
+                addedContentRootUrls.clear()
+            }
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    /**
+     * An Elixir module must not exclude IntelliJ's compiler output: Elixir compiles to `_build`, and
+     * the plugin's own project converter exists to strip `<exclude-output/>` from `ELIXIR_MODULE`s -
+     * so a module that keeps the flag is offered for "conversion" every time its project is opened.
+     *
+     * `JavaSettingsSerializer.saveJavaSettings` writes the tag when this property is true, and also
+     * when a module has no Java settings at all, which is why [Project.addFolders] sets it rather
+     * than leaving it alone.
+     */
+    fun testDoesNotExcludeCompilerOutput() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("mix_app")
+
+        ModuleRootModificationUtil.updateModel(module) { model ->
+            // Mirrors JavaModuleBuilder.setupRootModel, which turns this on before
+            // ElixirModuleBuilder gets to call addFolders.
+            model.getModuleExtension(CompilerModuleExtension::class.java).setExcludeOutput(true)
+
+            Project.addFolders(model, root)
+        }
+        addedContentRootUrls.add(root.url)
+
+        assertFalse(
+            "addFolders must clear exclude-output, or every project the plugin creates is offered" +
+                    " for conversion when it is next opened",
+            ModuleRootManager.getInstance(module)
+                .getModuleExtension(CompilerModuleExtension::class.java)
+                .isExcludeOutput
+        )
+    }
+}

--- a/tests/org/elixir_lang/new_project_wizard/MixNewOptionsTest.kt
+++ b/tests/org/elixir_lang/new_project_wizard/MixNewOptionsTest.kt
@@ -1,0 +1,75 @@
+package org.elixir_lang.new_project_wizard
+
+import junit.framework.TestCase
+import java.nio.file.Paths
+
+/**
+ * Pins the `mix new` arguments and the module layout they imply, in particular the two shapes that
+ * differ: a single application, and an umbrella root that has no application of its own.
+ */
+class MixNewOptionsTest : TestCase() {
+    private val projectDirectory = Paths.get("home", "developer", "my_app").toString()
+
+    private fun path(vararg more: String): String = Paths.get(projectDirectory, *more).toString()
+
+    fun testParametersWithNoOptionsSet() {
+        assertEquals(
+            listOf("new", projectDirectory),
+            MixNewOptions.parameters(projectDirectory, app = "", module = "", sup = false, umbrella = false)
+        )
+    }
+
+    fun testParametersPassesEverySetOption() {
+        assertEquals(
+            listOf("new", projectDirectory, "--app", "other_app", "--module", "OtherModule", "--sup"),
+            MixNewOptions.parameters(
+                projectDirectory,
+                app = "other_app",
+                module = "OtherModule",
+                sup = true,
+                umbrella = false
+            )
+        )
+    }
+
+    fun testParametersDropsSupForAnUmbrella() {
+        assertEquals(
+            "mix new ignores --sup at an umbrella root without reporting it, so it must not be sent",
+            listOf("new", projectDirectory, "--umbrella"),
+            MixNewOptions.parameters(projectDirectory, app = "", module = "", sup = true, umbrella = true)
+        )
+    }
+
+    fun testSourcePathIsLibForAnApplication() {
+        assertEquals(path("lib"), MixNewOptions.sourcePath(projectDirectory, umbrella = false))
+    }
+
+    fun testSourcePathIsAbsentForAnUmbrella() {
+        assertNull(
+            "an umbrella root has no lib/, and JavaModuleBuilder creates every source path it is given",
+            MixNewOptions.sourcePath(projectDirectory, umbrella = true)
+        )
+    }
+
+    fun testCompilerOutputPathUsesTheApplicationName() {
+        assertEquals(
+            path("_build", "dev", "lib", "other_app", "ebin"),
+            MixNewOptions.compilerOutputPath(projectDirectory, name = "my_app", app = "other_app", umbrella = false)
+        )
+    }
+
+    fun testCompilerOutputPathFallsBackToTheProjectNameWhenAppIsBlank() {
+        assertEquals(
+            "a blank --app means mix infers the application name from the path, which is the project name",
+            path("_build", "dev", "lib", "my_app", "ebin"),
+            MixNewOptions.compilerOutputPath(projectDirectory, name = "my_app", app = "", umbrella = false)
+        )
+    }
+
+    fun testCompilerOutputPathIsAbsentForAnUmbrella() {
+        assertNull(
+            "an umbrella root compiles nothing; its children build to _build/dev/lib/<child>/ebin",
+            MixNewOptions.compilerOutputPath(projectDirectory, name = "my_app", app = "other_app", umbrella = true)
+        )
+    }
+}


### PR DESCRIPTION
Reviewing #22 (*Elixir project creation*) established that its last outstanding task — "Allow setting of `mix new` options using mix from Setup SDK" — shipped in [v13.1.0](https://github.com/KronicDeth/intellij-elixir/releases/tag/v13.1.0). Checking what the wizard configures *after* running `mix new` turned up three unrelated defects, one commit each.

## 1. The module is configured for the project `mix new` actually created

`setupProject` treated the result as a single root OTP application. True for three of the four option combinations, false for `--umbrella`.

- **A blank `--app` lost the app name.** The compiler output came from the `--app` field, which is empty unless the user types into it — the wizard permits that, because `mix new` infers the name from the path. `Paths.get` drops empty segments, so the default path configured `_build/dev/lib/ebin` rather than `_build/dev/lib/<app>/ebin`. Now falls back to the project name, the value `mix new` itself uses.
- **`--sup` was silently swallowed alongside `--umbrella`.** `mix new` ignores it at an umbrella root and exits 0 without a warning (verified against mix 1.13.4: `mix new x --umbrella --sup` produces byte-identical output to `mix new x --umbrella`). It is now unavailable while `--umbrella` is ticked, and dropped from the arguments regardless — disabling a check box does not clear its bound property.
- **Umbrella roots got a source path and a compiler output that cannot apply.** An umbrella root declares `apps_path:` rather than `app:`, so it compiles nothing and `mix new` gives it no `lib/`; children build to `_build/dev/lib/<child>/ebin` and do not exist yet. `JavaModuleBuilder` inherits the output path when none is set. Source paths are set to an empty list rather than left unset, because `JavaModuleBuilder.getSourcePaths()` **creates and returns** `<contentRoot>/src` when they were never set — which otherwise leaves a stray empty directory behind.

## 2. Umbrella sub-apps never got their folder marks

`apps/<child>/lib` and `apps/<child>/test` were left unmarked, nothing reported it, and *Reconfigure Elixir Module Setup* said "All modules are configured correctly".

`mix new` writes a sub-app from an external process, so VFS can hold a child list for it containing only the entries the IDE itself touched. `findChild("mix.exs")` answers from that cached list without going to disk and returns null, so both `ReconfigureModuleSetupAction` and `ProjectModuleSetupValidator` skipped the sub-app in silence.

Found by debugger rather than inspection — at the guard, the sub-app's VFS children were `lib` and a phantom `.idea`, against a disk holding `.formatter.exs`, `.gitignore`, `lib`, `mix.exs`, `README.md`, `test`.

`Project.findOtpApps` already opens with `root.refresh(false, true)` for this exact reason; the two folder-mark paths did not. `refreshUmbrellaSubApps` gives them the same, and the wizard refreshes the project it just created so the staleness does not arise at all. It refreshes `apps/` and its immediate children rather than recursing, to stay bounded on umbrellas carrying `deps/` and `_build/`. The action refreshes outside its write command and the widget schedules an async refresh outside its read action, since a synchronous refresh is not permitted under either lock.

## 3. Every new project and module was reported as having an outdated format

Opening a project the plugin had just created offered to convert it and back the old files up. The plugin's own `project.converterProvider` exists to strip `<exclude-output/>` from `ELIXIR_MODULE`s, and every module the plugin created carried it — so the plugin's output always tripped the plugin's own converter.

Two independent sources, which is why it reached the import and open paths as well as both wizards:

- `JavaModuleBuilder.setupRootModel` sets the flag outright.
- `JavaSettingsSerializer.saveJavaSettings` also writes the tag for a module with **no** Java settings at all when the Java plugin is present, and `JpsJavaModuleExtensionBridge.isExcludeOutput()` returns `?: true` for the same reason.

So leaving the flag alone *produces* the tag; it has to be set `false` explicitly. Cleared in `Project.addFolders` — the one function every path configuring an Elixir module root goes through: both wizards via `ElixirModuleBuilder`, and the import wizard and project-open processor via `createModulesForOtpApps`. Elixir compiles to `_build`, so the exclusion never applied.

## Tests

`org.elixir_lang.new_project_wizard.MixNewOptions` and the module layout it implies are extracted so they can be asserted without running `mix new`.

- `MixNewOptionsTest` — arguments and layout for each option combination, including `--sup` dropped for umbrella and the blank-`--app` fallback
- `ReconfigureModuleSetupActionTest` — an umbrella sub-app added after the root was configured; this path had no coverage at all
- `ReconfigureModuleSetupActionStaleVfsHeavyTest` — a heavy test writing the sub-app through `java.io.File`. It has to be heavy: the light fixture's `temp://` filesystem is in-memory, so a test built on it cannot produce the stale entry this fixes — my first attempt passed against the live bug for exactly that reason.
- `ProjectAddFoldersTest` — the module does not exclude compiler output

Both regression tests were confirmed to fail with their fix removed. 202 passing across `mix`, `action` and `new_project_wizard`.

## Not included

- `CANONICAL_FOLDER_MARKS` still marks `lib`, `web`, `spec` and `test` on an umbrella root that will never have them. It is shared with the import wizard and the reconfigure action, so it belongs in its own change.
- `--umbrella` sits among `--app`/`--module`/`--sup` as though it modified the project, when it selects a different kind of project — an umbrella with no child apps is inert, and the plugin already models umbrellas correctly on the import path (one module per OTP app) but not here. An `Application` / `Umbrella` fork in the wizard would fix that at the root; it is too large for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
