### PR TITLE
fix(sdk): detect and resolve the SDK install layouts packagers actually produce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
     [#3670](https://github.com/KronicDeth/intellij-elixir/issues/3670).
   - **Homebrew SDKs on Apple Silicon are now detected.** Only the Intel `/usr/local/Cellar` prefix
     was scanned, never `/opt/homebrew/Cellar`.
+  - **Selecting an install prefix in the SDK chooser now finds the home inside it.** A prefix such
+    as a Homebrew version directory, `/usr` or `/usr/local` holds the SDK in `lib/<tool>` and only
+    symlinks in `bin`, so picking the directory a user naturally lands on was rejected as an invalid
+    home with no hint of where the real one was. Erlang had no adjustment at all. Refs
+    [#3670](https://github.com/KronicDeth/intellij-elixir/issues/3670),
+    [#312](https://github.com/KronicDeth/intellij-elixir/issues/312).
   - **Version-pinned Homebrew formulae are now detected.** `erlang@25` through `erlang@28` live
     under their own Cellar directory rather than beside the unpinned versions, so a pinned OTP
     release - the usual way to hold an OTP version for a given Elixir - was never offered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,42 @@
 
 ### Enhancements
 
+- [#3923](https://github.com/KronicDeth/intellij-elixir/pull/3923) [@sh41](https://github.com/sh41)
+  - **Elixir and Erlang SDKs under `/usr/lib64` are now detected automatically.** Gentoo builds both
+    with the multilib libdir, and Fedora does for Erlang, so the SDK had to be selected by hand on
+    those distributions even though the path was valid. Refs
+    [#312](https://github.com/KronicDeth/intellij-elixir/issues/312).
+  - **Elixir SDKs under `/usr/share/elixir/<version>` are now detected automatically.** Fedora and
+    RHEL package Elixir there rather than under a libdir; the version is read from the directory
+    name, so several installed versions are offered separately.
+  - **Homebrew Elixir installed since 2024-09-22 is now detected and accepted.** Homebrew changed to
+    the Makefile's `install` target, which nests the SDK home in `lib/elixir` instead of placing it
+    directly in the version directory. Installs predating the change keep working. Refs
+    [#3670](https://github.com/KronicDeth/intellij-elixir/issues/3670).
+  - **Homebrew SDKs on Apple Silicon are now detected.** Only the Intel `/usr/local/Cellar` prefix
+    was scanned, never `/opt/homebrew/Cellar`.
+  - **Version-pinned Homebrew formulae are now detected.** `erlang@25` through `erlang@28` live
+    under their own Cellar directory rather than beside the unpinned versions, so a pinned OTP
+    release - the usual way to hold an OTP version for a given Elixir - was never offered.
+  - **macOS now detects SDKs installed by the `elixir-install` script.** Every platform now scans
+    the same set of sources, so a source can no longer be present on one platform and missing on
+    another.
+  - **Homebrew SDKs on Linux and WSL are now detected.** Homebrew's Linux prefix
+    (`/home/linuxbrew/.linuxbrew`) was never scanned on any platform, and a Homebrew home there is
+    now labelled as such in the SDK list.
+
 - [#3914](https://github.com/KronicDeth/intellij-elixir/pull/3914) [@sh41](https://github.com/sh41)
   - **Elixir 1.13 through 1.20 are now fully supported.** Code written for any Elixir from 1.13.4 to
     1.20.2 parses without spurious errors, including syntax whose meaning changed between releases.
   - **`.beam` files compiled by OTP 24 through 29 decompile to valid Elixir.**
 
 ### Bug Fixes
+
+- [#3923](https://github.com/KronicDeth/intellij-elixir/pull/3923) [@sh41](https://github.com/sh41)
+  - **Homebrew Erlang SDKs no longer report an unknown version.** The version was read from the
+    home path after the Homebrew layout adjustment had been applied, so every Homebrew Erlang was
+    keyed on the literal string `erlang` instead of its version, leaving them unsorted and
+    unlabelled in the SDK list.
 
 - [#3914](https://github.com/KronicDeth/intellij-elixir/pull/3914) [@sh41](https://github.com/sh41)
   - **Reformat Code no longer changes what a capture expression means.** Since Elixir 1.15,

--- a/jps-shared/src/org/elixir_lang/jps/shared/sdk/SdkPaths.kt
+++ b/jps-shared/src/org/elixir_lang/jps/shared/sdk/SdkPaths.kt
@@ -21,32 +21,68 @@ object SdkPaths {
 
     private val IS_WINDOWS =
         System.getProperty("os.name").lowercase(Locale.ROOT).contains("windows")
+
+    // Installer roots, named once for both halves of the plugin: SdkHomePaths scans them and
+    // detectSource recognises what a scan or a user produced. Adding one here is the whole change.
     const val MISE_POSIX_PATH_FROM_HOME = ".local/share/mise/installs"
     const val MISE_WINDOWS_PATH_FROM_HOME = "appdata/local/mise/installs"
-    private const val ASDF_INSTALLS_PREFIX = "/.asdf/installs/"
-    private const val ELIXIR_INSTALL_INSTALLS_PREFIX = "/.elixir-install/installs/"
-    private const val ELIXIR_INSTALL_PATH_SEGMENT = "/.elixir-install/"
+    const val ASDF_INSTALLS_PATH_FROM_HOME = ".asdf/installs"
+    const val ELIXIR_INSTALL_INSTALLS_PATH_FROM_HOME = ".elixir-install/installs"
+    const val HOMEBREW_INTEL_CELLAR_PATH = "/usr/local/Cellar"
+    const val HOMEBREW_APPLE_SILICON_CELLAR_PATH = "/opt/homebrew/Cellar"
+    const val LINUXBREW_CELLAR_PATH = "/home/linuxbrew/.linuxbrew/Cellar"
+    const val LINUXBREW_CELLAR_PATH_FROM_HOME = ".linuxbrew/Cellar"
+    const val NIX_STORE_PATH = "/nix/store"
+
+    /** kerl installs wherever it is told, so only Travis CI's `~/otp/<version>` is a known layout. */
+    const val TRAVIS_CI_KERL_DIR_NAME = "otp"
+
+    /**
+     * Whether any of [segments] appears anywhere in this already-lowercased path.
+     *
+     * Deliberately a substring test rather than [FileUtil.isAncestor] or [FileUtil.startsWith]:
+     * those anchor at the start of the path, and a home reached inside a WSL distribution is a UNC
+     * path (`//wsl.localhost/<distro>/home/linuxbrew/...`) that no Linux root is a prefix of. The
+     * roots above are absolute only on the machine that owns them, and the home-relative ones
+     * belong to the distribution's user rather than this JVM's, so both are matched as segments.
+     *
+     * Matching is case-insensitive on every platform for the same reason - the case sensitivity of
+     * the filesystem actually holding the path is not the host's. Lowercasing the needle here is
+     * what lets the constants above keep their real casing; comparing against `"/usr/local/Cellar/"`
+     * by hand silently never matches.
+     */
+    private fun String.containsAnyPath(vararg segments: String): Boolean =
+        segments.any { contains(it.lowercase(Locale.ROOT)) }
 
     fun detectSource(homePath: String): String? {
         val posixPath = FileUtil.toSystemIndependentName(homePath)
         val matchPath = posixPath.lowercase(Locale.ROOT)
 
-        if (matchPath.contains(MISE_POSIX_PATH_FROM_HOME) || matchPath.contains(MISE_WINDOWS_PATH_FROM_HOME)) {
+        if (matchPath.containsAnyPath(MISE_POSIX_PATH_FROM_HOME, MISE_WINDOWS_PATH_FROM_HOME)) {
             return SOURCE_NAME_MISE
         }
-        if (matchPath.contains(ASDF_INSTALLS_PREFIX)) {
+        if (matchPath.containsAnyPath("/$ASDF_INSTALLS_PATH_FROM_HOME/")) {
             return SOURCE_NAME_ASDF
         }
-        if (matchPath.contains(ELIXIR_INSTALL_PATH_SEGMENT)) {
+        if (matchPath.containsAnyPath("/$ELIXIR_INSTALL_INSTALLS_PATH_FROM_HOME/")) {
             return SOURCE_NAME_ELIXIR_INSTALL
         }
-        if (matchPath.contains("/usr/local/cellar/") || matchPath.contains("/opt/homebrew/cellar/")) {
+        if (matchPath.containsAnyPath(
+                "$HOMEBREW_INTEL_CELLAR_PATH/",
+                "$HOMEBREW_APPLE_SILICON_CELLAR_PATH/",
+                "/$LINUXBREW_CELLAR_PATH_FROM_HOME/"
+            )
+        ) {
             return SOURCE_NAME_HOMEBREW
         }
-        if (matchPath.contains("/nix/store/")) {
+        if (matchPath.containsAnyPath("$NIX_STORE_PATH/")) {
             return SOURCE_NAME_NIX
         }
-        if (matchPath.contains("/otp/") || File(homePath, ".kerl_config").exists()) {
+        // Unlike the rest, the second test touches the filesystem - see TRAVIS_CI_KERL_DIR_NAME for
+        // why there is no installer root to match instead.
+        if (matchPath.containsAnyPath("/$TRAVIS_CI_KERL_DIR_NAME/") ||
+            File(homePath, ".kerl_config").exists()
+        ) {
             return SOURCE_NAME_KERL
         }
 
@@ -71,8 +107,8 @@ object SdkPaths {
 
     private fun expectedMixHomePrefix(source: String?, homePath: String?): String? = when (source) {
         SOURCE_NAME_MISE -> expectedMisePrefix(homePath)
-        SOURCE_NAME_ASDF -> ASDF_INSTALLS_PREFIX
-        SOURCE_NAME_ELIXIR_INSTALL -> ELIXIR_INSTALL_INSTALLS_PREFIX
+        SOURCE_NAME_ASDF -> "/$ASDF_INSTALLS_PATH_FROM_HOME/"
+        SOURCE_NAME_ELIXIR_INSTALL -> "/$ELIXIR_INSTALL_INSTALLS_PATH_FROM_HOME/"
         else -> null
     }
 

--- a/src/org/elixir_lang/sdk/SdkHomePaths.kt
+++ b/src/org/elixir_lang/sdk/SdkHomePaths.kt
@@ -34,7 +34,7 @@ object SdkHomePaths {
     @JvmField
     val UNKNOWN_VERSION = Version(0, 0, 0)
 
-    private val HOMEBREW_ROOT = File(SdkPaths.HOMEBREW_INTEL_CELLAR_PATH)
+    private val HOMEBREW_CELLAR_PATHS = listOf(SdkPaths.HOMEBREW_INTEL_CELLAR_PATH)
     private val NIX_STORE = File(SdkPaths.NIX_STORE_PATH)
     private val LOGGER = Logger.getInstance(SdkHomePaths::class.java)
 
@@ -124,19 +124,32 @@ object SdkHomePaths {
         )
     }
 
+    /**
+     * Every Cellar root reachable through [toLocalPath].
+     *
+     * The native scan and a WSL scan reach the same roots by different routes, so both ask here
+     * rather than each naming them.
+     */
+    @JvmStatic
+    fun homebrewCellarPaths(userHome: String?, toLocalPath: (String) -> String?): List<String> =
+        HOMEBREW_CELLAR_PATHS.mapNotNull(toLocalPath)
+
     @JvmStatic
     fun mergeHomebrew(
         homePathByVersion: MutableMap<SdkHomeKey, String>,
         name: String,
         versionPathToHomePath: (File) -> File,
+        cellarPaths: List<String>,
     ) {
-        mergeNameSubdirectories(
-            homePathByVersion,
-            HOMEBREW_ROOT,
-            name,
-            SdkPaths.SOURCE_NAME_HOMEBREW,
-            versionPathToHomePath
-        )
+        for (cellar in cellarPaths.map { File(it) }) {
+            mergeNameSubdirectories(
+                homePathByVersion,
+                cellar,
+                name,
+                SdkPaths.SOURCE_NAME_HOMEBREW,
+                versionPathToHomePath
+            )
+        }
     }
 
     @JvmStatic

--- a/src/org/elixir_lang/sdk/SdkHomePaths.kt
+++ b/src/org/elixir_lang/sdk/SdkHomePaths.kt
@@ -24,8 +24,6 @@ object SdkHomePaths {
      */
     private const val LINUX_DISTRO_ROOT_PATH = "/usr/lib"
 
-    const val NIX_STORE_PATH = "/nix/store"
-
     /**
      * Roots a source build or a distribution package installs a tool under, in scan order.
      * [linuxSystemHomePaths] suffixes the tool name onto each; a new distro layout is added here and
@@ -36,8 +34,8 @@ object SdkHomePaths {
     @JvmField
     val UNKNOWN_VERSION = Version(0, 0, 0)
 
-    private val HOMEBREW_ROOT = File("/usr/local/Cellar")
-    private val NIX_STORE = File(NIX_STORE_PATH)
+    private val HOMEBREW_ROOT = File(SdkPaths.HOMEBREW_INTEL_CELLAR_PATH)
+    private val NIX_STORE = File(SdkPaths.NIX_STORE_PATH)
     private val LOGGER = Logger.getInstance(SdkHomePaths::class.java)
 
     @JvmStatic
@@ -91,7 +89,7 @@ object SdkHomePaths {
     fun mergeASDF(homePathByVersion: MutableMap<SdkHomeKey, String>, name: String, userHome: String) {
         mergeNameSubdirectories(
             homePathByVersion,
-            Path.of(userHome, ".asdf", "installs").toFile(),
+            Path.of(userHome, SdkPaths.ASDF_INSTALLS_PATH_FROM_HOME).toFile(),
             name, SdkPaths.SOURCE_NAME_ASDF
         )
     }
@@ -121,7 +119,7 @@ object SdkHomePaths {
     fun mergeElixirInstallScript(homePathByVersion: MutableMap<SdkHomeKey, String>, name: String, userHome: String) {
         mergeNameSubdirectories(
             homePathByVersion,
-            Path.of(userHome, ".elixir-install", "installs").toFile(),
+            Path.of(userHome, SdkPaths.ELIXIR_INSTALL_INSTALLS_PATH_FROM_HOME).toFile(),
             name, SdkPaths.SOURCE_NAME_ELIXIR_INSTALL
         )
     }
@@ -197,7 +195,7 @@ object SdkHomePaths {
         mergeNameSubdirectories(
             homePathByVersion,
             File(userHome),
-            "otp",
+            SdkPaths.TRAVIS_CI_KERL_DIR_NAME,
             SdkPaths.SOURCE_NAME_KERL,
             versionPathToHomePath
         )

--- a/src/org/elixir_lang/sdk/SdkHomePaths.kt
+++ b/src/org/elixir_lang/sdk/SdkHomePaths.kt
@@ -192,6 +192,39 @@ object SdkHomePaths {
     }
 
     /**
+     * Children of a home a chooser selection can land on instead of the home itself.
+     *
+     * `releases` is one an Erlang home has and an Elixir home does not, so listing it costs Elixir
+     * nothing. `usr` is deliberately absent even though an Erlang home has one: treating it as a
+     * child would step `/usr` up to the filesystem root and break selecting a distribution install.
+     */
+    private val SDK_HOME_CHILD_BASE_NAMES = setOf("bin", "lib", "src", "releases")
+
+    /**
+     * The home for [toolName] implied by a path chosen in the SDK file chooser.
+     *
+     * A selection lands on the home, on a child of it, or on an install prefix holding it, so step
+     * up out of a known child and then down into a prefix. Both steps are no-ops for a path that is
+     * already a home, and neither invents a path that does not exist.
+     *
+     * The scan applies [toolHomePath] to what it discovers; this is the same rule for what a user
+     * picks, so the two agree on which directory is the home.
+     */
+    @JvmStatic
+    fun adjustSelectedSdkHome(homePath: String, toolName: String): String {
+        val homePathFile = File(homePath)
+        if (!homePathFile.isDirectory) return homePath
+
+        val candidate = if (homePathFile.name in SDK_HOME_CHILD_BASE_NAMES) {
+            homePathFile.parentFile ?: homePathFile
+        } else {
+            homePathFile
+        }
+
+        return toolHomePath(candidate, toolName).path
+    }
+
+    /**
      * Every Cellar root reachable through [toLocalPath], plus the one under [userHome].
      *
      * Homebrew's prefix differs by platform, but a prefix that belongs to another platform simply

--- a/src/org/elixir_lang/sdk/SdkHomePaths.kt
+++ b/src/org/elixir_lang/sdk/SdkHomePaths.kt
@@ -125,6 +125,25 @@ object SdkHomePaths {
     }
 
     /**
+     * The SDK home for [toolName] at or under [candidate].
+     *
+     * An install prefix is not itself a home: `make install PREFIX=<prefix>` puts the home in
+     * `<prefix>/lib/<toolName>` and leaves only symlinks in `<prefix>/bin`. Homebrew version
+     * prefixes, kiex version directories, `/usr` and `/usr/local` are all this shape, while an
+     * already-correct home is not, so the two are told apart by whether the nested directory has a
+     * `bin` of its own - a home always does, and a bare OTP application directory never does.
+     *
+     * Homebrew is the reason both shapes are live at once: it switched Elixir to the Makefile's
+     * `install` target on 2024-09-22, so anything installed before that keeps the flat layout.
+     */
+    @JvmStatic
+    fun toolHomePath(candidate: File, toolName: String): File {
+        val nested = File(candidate, "lib/$toolName")
+
+        return if (File(nested, "bin").isDirectory) nested else candidate
+    }
+
+    /**
      * Every Cellar root reachable through [toLocalPath].
      *
      * The native scan and a WSL scan reach the same roots by different routes, so both ask here

--- a/src/org/elixir_lang/sdk/SdkHomePaths.kt
+++ b/src/org/elixir_lang/sdk/SdkHomePaths.kt
@@ -14,9 +14,24 @@ import java.util.regex.Pattern
 
 object SdkHomePaths {
     private const val HEAD_PREFIX = "HEAD-"
-    const val LINUX_MINT_HOME_PATH = "/usr/lib"
-    const val LINUX_DEFAULT_HOME_PATH = "/usr/local/lib"
+
+    /** `make install` with the Makefile's default `PREFIX`, i.e. a build from source. */
+    private const val LINUX_SOURCE_ROOT_PATH = "/usr/local/lib"
+
+    /**
+     * `PREFIX=/usr` with the default `LIBDIR`, i.e. a distribution package. Debian, Ubuntu, Mint,
+     * Arch, Alpine and openSUSE all land here; it is not specific to Mint.
+     */
+    private const val LINUX_DISTRO_ROOT_PATH = "/usr/lib"
+
     const val NIX_STORE_PATH = "/nix/store"
+
+    /**
+     * Roots a source build or a distribution package installs a tool under, in scan order.
+     * [linuxSystemHomePaths] suffixes the tool name onto each; a new distro layout is added here and
+     * nowhere else.
+     */
+    private val LINUX_SYSTEM_ROOT_PATHS = listOf(LINUX_SOURCE_ROOT_PATH, LINUX_DISTRO_ROOT_PATH)
 
     @JvmField
     val UNKNOWN_VERSION = Version(0, 0, 0)
@@ -28,6 +43,43 @@ object SdkHomePaths {
     @JvmStatic
     fun nixPattern(name: String): Pattern {
         return Pattern.compile(".+-$name-(\\d+)\\.(\\d+)\\.(\\d+)")
+    }
+
+    /**
+     * Every hardcoded Linux home path for [toolName], in scan order.
+     */
+    @JvmStatic
+    fun linuxSystemHomePaths(toolName: String): List<String> =
+        LINUX_SYSTEM_ROOT_PATHS.map { "$it/$toolName" }
+
+    /**
+     * Adds each of [linuxSystemHomePaths] that exists as a directory.
+     *
+     * The native Linux scan and the WSL scan differ only by [toLocalPath], which maps a Linux path
+     * to how this machine reaches it - identity when running on Linux, a UNC path when reaching into
+     * a WSL distribution, and null when it cannot be reached at all. Both therefore go through this
+     * one call, so the WSL scan cannot be left without a path the native scan gained.
+     */
+    @JvmStatic
+    fun mergeLinuxSystemHomePaths(
+        homePathByVersion: MutableMap<SdkHomeKey, String>,
+        toolName: String,
+        toLocalPath: (String) -> String? = { it },
+    ) {
+        for (candidate in linuxSystemHomePaths(toolName)) {
+            val homePath = toLocalPath(candidate)
+
+            if (homePath == null) {
+                LOGGER.trace { "$candidate: Not reachable" }
+                continue
+            }
+
+            if (File(homePath).isDirectory) {
+                homePathByVersion[unknownVersionKey(homePath)] = homePath
+            } else {
+                LOGGER.trace { "$homePath: Not a directory" }
+            }
+        }
     }
 
     @JvmStatic

--- a/src/org/elixir_lang/sdk/SdkHomePaths.kt
+++ b/src/org/elixir_lang/sdk/SdkHomePaths.kt
@@ -25,16 +25,32 @@ object SdkHomePaths {
     private const val LINUX_DISTRO_ROOT_PATH = "/usr/lib"
 
     /**
+     * `PREFIX=/usr` with a multilib `LIBDIR`. Gentoo builds both tools with it, and Fedora uses it
+     * for Erlang.
+     */
+    private const val LINUX_MULTILIB_ROOT_PATH = "/usr/lib64"
+
+    /** Version-scoped homes for packages installed outside a libdir, as Fedora does for Elixir. */
+    const val LINUX_SHARE_ROOT_PATH = "/usr/share"
+
+
+    /**
      * Roots a source build or a distribution package installs a tool under, in scan order.
      * [linuxSystemHomePaths] suffixes the tool name onto each; a new distro layout is added here and
      * nowhere else.
      */
-    private val LINUX_SYSTEM_ROOT_PATHS = listOf(LINUX_SOURCE_ROOT_PATH, LINUX_DISTRO_ROOT_PATH)
+    private val LINUX_SYSTEM_ROOT_PATHS =
+        listOf(LINUX_SOURCE_ROOT_PATH, LINUX_DISTRO_ROOT_PATH, LINUX_MULTILIB_ROOT_PATH)
 
     @JvmField
     val UNKNOWN_VERSION = Version(0, 0, 0)
 
-    private val HOMEBREW_CELLAR_PATHS = listOf(SdkPaths.HOMEBREW_INTEL_CELLAR_PATH)
+    /** Intel macOS, Apple Silicon macOS, and Homebrew on Linux, whose prefix is `.linuxbrew`. */
+    private val HOMEBREW_CELLAR_PATHS = listOf(
+        SdkPaths.HOMEBREW_INTEL_CELLAR_PATH,
+        SdkPaths.HOMEBREW_APPLE_SILICON_CELLAR_PATH,
+        SdkPaths.LINUXBREW_CELLAR_PATH
+    )
     private val NIX_STORE = File(SdkPaths.NIX_STORE_PATH)
     private val LOGGER = Logger.getInstance(SdkHomePaths::class.java)
 
@@ -52,6 +68,10 @@ object SdkHomePaths {
 
     /**
      * Adds each of [linuxSystemHomePaths] that exists as a directory.
+     *
+     * These keep [unknownVersionKey], so they sort below every version-manager install. That is
+     * intended: a system install declares no version in its path, and a version manager's is
+     * preferred whenever both are present.
      *
      * The native Linux scan and the WSL scan differ only by [toLocalPath], which maps a Linux path
      * to how this machine reaches it - identity when running on Linux, a UNC path when reaching into
@@ -125,6 +145,34 @@ object SdkHomePaths {
     }
 
     /**
+     * Scans `/usr/share/<name>/<version>` for packages installing version-scoped homes outside a
+     * libdir, as Fedora and RHEL do for Elixir. Same `<root>/<name>/<version>` shape as the version
+     * managers, so the version is parsed from the directory name.
+     *
+     * Only subdirectories naming a parseable version are taken. `/usr/share/<name>` also holds
+     * directories that are not homes - Fedora puts Erlang's `ERL_LIBS` at `/usr/share/erlang/lib` -
+     * and suggesting those would offer the user a path that cannot validate.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun mergeSystemShare(
+        homePathByVersion: MutableMap<SdkHomeKey, String>,
+        name: String,
+        shareRoot: String = LINUX_SHARE_ROOT_PATH,
+    ) {
+        val versioned = mutableMapOf<SdkHomeKey, String>()
+        mergeNameSubdirectories(versioned, File(shareRoot), name, source = null)
+
+        for ((key, homePath) in versioned) {
+            if (key.version != UNKNOWN_VERSION) {
+                homePathByVersion[key] = homePath
+            } else {
+                LOGGER.trace { "$homePath: Not a version directory" }
+            }
+        }
+    }
+
+    /**
      * The SDK home for [toolName] at or under [candidate].
      *
      * An install prefix is not itself a home: `make install PREFIX=<prefix>` puts the home in
@@ -144,15 +192,35 @@ object SdkHomePaths {
     }
 
     /**
-     * Every Cellar root reachable through [toLocalPath].
+     * Every Cellar root reachable through [toLocalPath], plus the one under [userHome].
      *
-     * The native scan and a WSL scan reach the same roots by different routes, so both ask here
-     * rather than each naming them.
+     * Homebrew's prefix differs by platform, but a prefix that belongs to another platform simply
+     * does not exist, so all of them are offered rather than chosen by OS - and a Homebrew on Linux
+     * installed to a macOS-looking custom prefix is then found too.
      */
     @JvmStatic
     fun homebrewCellarPaths(userHome: String?, toLocalPath: (String) -> String?): List<String> =
-        HOMEBREW_CELLAR_PATHS.mapNotNull(toLocalPath)
+        HOMEBREW_CELLAR_PATHS.mapNotNull(toLocalPath) +
+            listOfNotNull(userHome?.let { File(it, SdkPaths.LINUXBREW_CELLAR_PATH_FROM_HOME).path })
 
+    @JvmStatic
+    fun mergeHomebrew(
+        homePathByVersion: MutableMap<SdkHomeKey, String>,
+        name: String,
+        versionPathToHomePath: (File) -> File,
+    ) {
+        mergeHomebrew(
+            homePathByVersion, name, versionPathToHomePath,
+            HOMEBREW_CELLAR_PATHS + File(
+                System.getProperty("user.home"), SdkPaths.LINUXBREW_CELLAR_PATH_FROM_HOME
+            ).path
+        )
+    }
+
+    /**
+     * Scans explicit Cellar roots. Homebrew does not run natively on Windows, so the only Windows
+     * users with one are reaching into a WSL distribution, whose roots are UNC paths.
+     */
     @JvmStatic
     fun mergeHomebrew(
         homePathByVersion: MutableMap<SdkHomeKey, String>,
@@ -161,14 +229,36 @@ object SdkHomePaths {
         cellarPaths: List<String>,
     ) {
         for (cellar in cellarPaths.map { File(it) }) {
-            mergeNameSubdirectories(
-                homePathByVersion,
-                cellar,
-                name,
-                SdkPaths.SOURCE_NAME_HOMEBREW,
-                versionPathToHomePath
-            )
+            for (formula in homebrewFormulaNames(cellar, name)) {
+                mergeNameSubdirectories(
+                    homePathByVersion,
+                    cellar,
+                    formula,
+                    SdkPaths.SOURCE_NAME_HOMEBREW,
+                    versionPathToHomePath
+                )
+            }
         }
+    }
+
+    /**
+     * Cellar directory names holding [toolName], newest-pinned last.
+     *
+     * Homebrew keeps every installed version of a formula in its own Cellar directory until
+     * `brew cleanup` runs, and it also ships version-pinned formulae - `erlang@25` through
+     * `erlang@28` - which live under their own name rather than beside the unpinned versions. Both
+     * have to be scanned or a pinned Erlang, the usual way to hold an OTP release for a given
+     * Elixir, is invisible.
+     */
+    private fun homebrewFormulaNames(cellar: File, toolName: String): List<String> {
+        val pinnedPrefix = "$toolName@"
+        val names = cellar
+            .listFiles { file -> file.isDirectory && file.name.startsWith(pinnedPrefix) }
+            ?.map { it.name }
+            ?.sorted()
+            .orEmpty()
+
+        return listOf(toolName) + names
     }
 
     @JvmStatic
@@ -280,7 +370,7 @@ object SdkHomePaths {
         homePathByVersion: MutableMap<SdkHomeKey, String>,
         parent: File,
         name: String,
-        source: String,
+        source: String?,
         versionPathToHomePath: (File) -> File = { it },
     ) {
         LOGGER.trace { "$parent: Scanning for SDK Home Paths" }
@@ -301,7 +391,9 @@ object SdkHomePaths {
                 LOGGER.trace { "$child: Scanning" }
             if (child.isDirectory) {
                 val homePath = wslCompat.canonicalizePath(versionPathToHomePath(child).absolutePath)
-                val versionString = File(homePath).name
+                // The version names the directory scanned, not the home inside it: a transform that
+                // descends (Homebrew's `lib/<tool>`) would otherwise read the tool name as a version.
+                val versionString = child.name
                 val version = parseVersion(versionString)
                 val key = SdkHomeKey(version, versionString, source, homePath)
                 LOGGER.trace { "$child: Adding $key" }

--- a/src/org/elixir_lang/sdk/SdkHomeScan.kt
+++ b/src/org/elixir_lang/sdk/SdkHomeScan.kt
@@ -24,8 +24,6 @@ object SdkHomeScan {
      *
      * @property toolName The tool name used by version managers (e.g., "elixir", "erlang")
      * @property nixPattern Regex pattern for matching Nix store packages
-     * @property linuxDefaultPath System install path on Linux (e.g., "/usr/local/lib/elixir")
-     * @property linuxMintPath Linux Mint install path (e.g., "/usr/lib/elixir")
      * @property windowsDefaultPath Primary Windows install path (null if no default)
      * @property windows32BitPath 32-bit Windows install path (null if same as default)
      * @property homebrewTransform Path transform for Homebrew (null = identity)
@@ -36,8 +34,6 @@ object SdkHomeScan {
     data class Config(
         val toolName: String,
         val nixPattern: java.util.regex.Pattern,
-        val linuxDefaultPath: String,
-        val linuxMintPath: String,
         val windowsDefaultPath: String?,
         val windows32BitPath: String? = null,
         val elixirInstallScriptDirName: String,
@@ -143,8 +139,7 @@ object SdkHomeScan {
         homePathByVersion: MutableMap<SdkHomeKey, String>,
         config: Config
     ): Map<SdkHomeKey, String> {
-        putIfDirectory(homePathByVersion, SdkHomePaths.unknownVersionKey(config.linuxDefaultPath), config.linuxDefaultPath)
-        putIfDirectory(homePathByVersion, SdkHomePaths.unknownVersionKey(config.linuxMintPath), config.linuxMintPath)
+        SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, config.toolName)
 
         SdkHomePaths.mergeASDF(homePathByVersion, config.toolName)
         SdkHomePaths.mergeMise(homePathByVersion, config.toolName)
@@ -223,11 +218,8 @@ object SdkHomeScan {
             }
         }
 
-        wslCompat.convertLinuxPathToWindowsUnc(distribution, config.linuxDefaultPath)?.let {
-            putIfDirectory(homePathByVersion, SdkHomePaths.unknownVersionKey(it), it)
-        }
-        wslCompat.convertLinuxPathToWindowsUnc(distribution, config.linuxMintPath)?.let {
-            putIfDirectory(homePathByVersion, SdkHomePaths.unknownVersionKey(it), it)
+        SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, config.toolName) {
+            wslCompat.convertLinuxPathToWindowsUnc(distribution, it)
         }
 
         wslCompat.convertLinuxPathToWindowsUnc(distribution, SdkHomePaths.NIX_STORE_PATH)?.let { wslNixStore ->

--- a/src/org/elixir_lang/sdk/SdkHomeScan.kt
+++ b/src/org/elixir_lang/sdk/SdkHomeScan.kt
@@ -4,6 +4,7 @@ import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.system.CpuArch
 import com.intellij.util.system.OS
+import org.elixir_lang.jps.shared.sdk.SdkPaths
 import org.elixir_lang.sdk.wsl.wslCompat
 import java.io.File
 import java.nio.file.Path
@@ -222,7 +223,7 @@ object SdkHomeScan {
             wslCompat.convertLinuxPathToWindowsUnc(distribution, it)
         }
 
-        wslCompat.convertLinuxPathToWindowsUnc(distribution, SdkHomePaths.NIX_STORE_PATH)?.let { wslNixStore ->
+        wslCompat.convertLinuxPathToWindowsUnc(distribution, SdkPaths.NIX_STORE_PATH)?.let { wslNixStore ->
             val nixTransform = config.nixTransform ?: { it }
             SdkHomePaths.mergeNixStore(homePathByVersion, config.nixPattern, nixTransform, wslNixStore)
         }

--- a/src/org/elixir_lang/sdk/SdkHomeScan.kt
+++ b/src/org/elixir_lang/sdk/SdkHomeScan.kt
@@ -25,8 +25,6 @@ object SdkHomeScan {
      *
      * @property toolName The tool name used by version managers (e.g., "elixir", "erlang")
      * @property nixPattern Regex pattern for matching Nix store packages
-     * @property homebrewTransform Path transform for Homebrew (null = identity)
-     * @property nixTransform Path transform for Nix Store (null = identity)
      * @property windowsDefaultPath Primary Windows install path (null if no default)
      * @property windows32BitPath 32-bit Windows install path (null if same as default)
      * @property kerlTransform Path transform for kerl (null = skip kerl scanning)
@@ -39,12 +37,17 @@ object SdkHomeScan {
         val windows32BitPath: String? = null,
         val elixirInstallScriptDirName: String,
 
-        // Path transformations (null = identity for homebrew/nix, skip for kerl)
-        val homebrewTransform: ((File) -> File)? = null,
-        val nixTransform: ((File) -> File)? = null,
+        // Path transformation (null = skip kerl)
         val kerlTransform: ((File) -> File)? = null,
         val travisCIKerlTransform: ((File) -> File)? = null
-    )
+    ) {
+        /**
+         * Resolves an install prefix to the home inside it. Every source that hands back a prefix
+         * rather than a home - Homebrew, Nix, kiex - goes through this, so none of them needs a
+         * transform of its own.
+         */
+        val toolHome: (File) -> File get() = { SdkHomePaths.toolHomePath(it, toolName) }
+    }
 
     /**
      * Scans for SDK installations across all platforms.
@@ -127,14 +130,12 @@ object SdkHomeScan {
         }
 
         SdkHomePaths.mergeHomebrew(
-            homePathByVersion, config.toolName, config.homebrewTransform ?: { it },
+            homePathByVersion, config.toolName, config.toolHome,
             SdkHomePaths.homebrewCellarPaths(userHome, toLocalPath)
         )
 
         toLocalPath(SdkPaths.NIX_STORE_PATH)?.let {
-            SdkHomePaths.mergeNixStore(
-                homePathByVersion, config.nixPattern, config.nixTransform ?: { it }, it
-            )
+            SdkHomePaths.mergeNixStore(homePathByVersion, config.nixPattern, config.toolHome, it)
         }
     }
 

--- a/src/org/elixir_lang/sdk/SdkHomeScan.kt
+++ b/src/org/elixir_lang/sdk/SdkHomeScan.kt
@@ -118,6 +118,10 @@ object SdkHomeScan {
     ) {
         SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, config.toolName, toLocalPath)
 
+        toLocalPath(SdkHomePaths.LINUX_SHARE_ROOT_PATH)?.let {
+            SdkHomePaths.mergeSystemShare(homePathByVersion, config.toolName, it)
+        }
+
         if (userHome != null) {
             SdkHomePaths.mergeASDF(homePathByVersion, config.toolName, userHome)
             SdkHomePaths.mergeMise(homePathByVersion, config.toolName, userHome)

--- a/src/org/elixir_lang/sdk/SdkHomeScan.kt
+++ b/src/org/elixir_lang/sdk/SdkHomeScan.kt
@@ -25,10 +25,10 @@ object SdkHomeScan {
      *
      * @property toolName The tool name used by version managers (e.g., "elixir", "erlang")
      * @property nixPattern Regex pattern for matching Nix store packages
-     * @property windowsDefaultPath Primary Windows install path (null if no default)
-     * @property windows32BitPath 32-bit Windows install path (null if same as default)
      * @property homebrewTransform Path transform for Homebrew (null = identity)
      * @property nixTransform Path transform for Nix Store (null = identity)
+     * @property windowsDefaultPath Primary Windows install path (null if no default)
+     * @property windows32BitPath 32-bit Windows install path (null if same as default)
      * @property kerlTransform Path transform for kerl (null = skip kerl scanning)
      * @property travisCIKerlTransform Path transform for Travis CI kerl (null = skip)
      */
@@ -56,177 +56,118 @@ object SdkHomeScan {
     fun homePathByVersion(path: Path?, config: Config): Map<SdkHomeKey, String> {
         LOG.debug("Scanning for ${config.toolName} SDKs (path: $path, platform: ${OS.CURRENT})")
         val homePathByVersion: MutableMap<SdkHomeKey, String> = TreeMap()
+        // A project inside a distribution can only use that distribution's SDKs, and conversely a
+        // host project is not offered a distribution's: enumerating distributions deploys an ijent
+        // agent and boots stopped ones, which is too costly to do for every scan.
+        if (path != null && wslCompat.isWslUncPath(path.toString())) {
+            homePathByVersionWSLs(path, homePathByVersion, config)
+        } else {
+            mergePosixSources(homePathByVersion, config, System.getProperty("user.home")) { it }
+            mergeWindowsInstallerPath(homePathByVersion, config)
 
-        val result = when (OS.CURRENT) {
-            OS.macOS ->
-                homePathByVersionMac(homePathByVersion, config)
-
-            OS.Windows ->
-                homePathByVersionWindows(path, homePathByVersion, config)
-
-            OS.Linux ->
-                homePathByVersionLinux(homePathByVersion, config)
-
-            else -> {
-                LOG.debug("Unsupported platform: ${OS.CURRENT}")
-                homePathByVersion
-            }
+            // The only source located by running a command rather than by looking at a path, so it
+            // is the only one worth skipping when its transform says the tool does not use it.
+            config.kerlTransform?.let { SdkHomePaths.mergeKerl(homePathByVersion, it) }
         }
 
-        LOG.debug("Found ${result.size} ${config.toolName} SDK(s): ${result.values.take(3).joinToString(", ")}${if (result.size > 3) "..." else ""}")
-        return result
-    }
-
-    /**
-     * Scans macOS for SDK installations via ASDF, Mise, kerl, Homebrew, and Nix.
-     * Note: path parameter not used on macOS (no distribution filtering needed).
-     */
-    private fun homePathByVersionMac(
-        homePathByVersion: MutableMap<SdkHomeKey, String>,
-        config: Config
-    ): Map<SdkHomeKey, String> {
-        SdkHomePaths.mergeASDF(homePathByVersion, config.toolName)
-        SdkHomePaths.mergeMise(homePathByVersion, config.toolName)
-
-        if (config.kerlTransform != null) {
-            SdkHomePaths.mergeKerl(homePathByVersion, config.kerlTransform)
-        }
-
-        val homebrewTransform = config.homebrewTransform ?: { it }
-        SdkHomePaths.mergeHomebrew(homePathByVersion, config.toolName, homebrewTransform)
-
-        val nixTransform = config.nixTransform ?: { it }
-        SdkHomePaths.mergeNixStore(homePathByVersion, config.nixPattern, nixTransform)
+        LOG.debug(
+            "Found ${homePathByVersion.size} ${config.toolName} SDK(s): " +
+                homePathByVersion.values.take(3).joinToString(", ") +
+                if (homePathByVersion.size > 3) "..." else ""
+        )
 
         return homePathByVersion
     }
 
     /**
-     * Scans Windows for SDK installations via native paths and WSL distributions.
+     * The installer path that only means anything with a drive letter, so it has no POSIX
+     * equivalent. Scanned everywhere regardless: off Windows it names a directory that cannot exist.
      */
-    private fun homePathByVersionWindows(
-        path: Path?,
+    private fun mergeWindowsInstallerPath(
         homePathByVersion: MutableMap<SdkHomeKey, String>,
         config: Config
-    ): Map<SdkHomeKey, String> {
-        if (wslCompat.isWslUncPath(path.toString())) {
-            // WSL distributions
-            homePathByVersionWSLs(path, homePathByVersion, config)
-            return homePathByVersion
-        }
-
-        // Native Windows paths - select based on CPU architecture
+    ) {
         val windowsPath = if (CpuArch.CURRENT.width == 32) {
             config.windows32BitPath ?: config.windowsDefaultPath
         } else {
             config.windowsDefaultPath
         }
 
-        windowsPath?.let {
-            putIfDirectory(homePathByVersion, SdkHomePaths.unknownVersionKey(it), it)
-        }
-
-        SdkHomePaths.mergeElixirInstallScript(homePathByVersion, config.elixirInstallScriptDirName)
-        SdkHomePaths.mergeMise(homePathByVersion, config.toolName)
-
-        return homePathByVersion
+        windowsPath?.let { putIfDirectory(homePathByVersion, SdkHomePaths.unknownVersionKey(it), it) }
     }
 
     /**
-     * Scans Linux for SDK installations via system paths, ASDF, Mise, kerl, Travis CI kerl, and Nix.
-     * Note: path parameter not used on Linux (no distribution filtering needed).
+     * Every source installed on a POSIX filesystem, for one reached via [toLocalPath] and owning
+     * [userHome].
+     *
+     * Running on Linux passes identity and this JVM's home; scanning a WSL distribution passes its
+     * UNC mapping and the distribution's own home. Adding a source here reaches both, which is the
+     * point - the WSL scan used to restate the Linux one by hand and could silently fall behind it.
+     *
+     * [toLocalPath] returns null for a path this machine cannot reach, and [userHome] is null when
+     * it cannot be determined; both mean "skip that source" rather than "scan nothing".
      */
-    private fun homePathByVersionLinux(
+    private fun mergePosixSources(
         homePathByVersion: MutableMap<SdkHomeKey, String>,
-        config: Config
-    ): Map<SdkHomeKey, String> {
-        SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, config.toolName)
+        config: Config,
+        userHome: String?,
+        toLocalPath: (String) -> String?,
+    ) {
+        SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, config.toolName, toLocalPath)
 
-        SdkHomePaths.mergeASDF(homePathByVersion, config.toolName)
-        SdkHomePaths.mergeMise(homePathByVersion, config.toolName)
-        SdkHomePaths.mergeElixirInstallScript(homePathByVersion, config.elixirInstallScriptDirName)
-
-        if (config.kerlTransform != null) {
-            SdkHomePaths.mergeKerl(homePathByVersion, config.kerlTransform)
+        if (userHome != null) {
+            SdkHomePaths.mergeASDF(homePathByVersion, config.toolName, userHome)
+            SdkHomePaths.mergeMise(homePathByVersion, config.toolName, userHome)
+            SdkHomePaths.mergeElixirInstallScript(
+                homePathByVersion, config.elixirInstallScriptDirName, userHome
+            )
+            config.travisCIKerlTransform?.let {
+                SdkHomePaths.mergeTravisCIKerl(homePathByVersion, it, userHome)
+            }
         }
 
-        if (config.travisCIKerlTransform != null) {
-            SdkHomePaths.mergeTravisCIKerl(homePathByVersion, config.travisCIKerlTransform)
+        SdkHomePaths.mergeHomebrew(
+            homePathByVersion, config.toolName, config.homebrewTransform ?: { it },
+            SdkHomePaths.homebrewCellarPaths(userHome, toLocalPath)
+        )
+
+        toLocalPath(SdkPaths.NIX_STORE_PATH)?.let {
+            SdkHomePaths.mergeNixStore(
+                homePathByVersion, config.nixPattern, config.nixTransform ?: { it }, it
+            )
         }
-
-        val nixTransform = config.nixTransform ?: { it }
-        SdkHomePaths.mergeNixStore(homePathByVersion, config.nixPattern, nixTransform)
-
-        return homePathByVersion
     }
 
     /**
-     * Determines which WSL distributions to scan based on the project path.
-     * - If path is in a WSL distribution, only scan that distribution
-     * - If path is Windows or null, scan all distributions
+     * Scans the distribution the project lives in, which is the only caller's case - a host project
+     * is never offered a distribution's SDKs, so there is no "scan them all" path here.
      */
     private fun homePathByVersionWSLs(
-        path: Path?,
+        path: Path,
         homePathByVersion: MutableMap<SdkHomeKey, String>,
         config: Config
     ) {
-        val distributionsToScan = when {
-            path == null -> {
-                LOG.debug("No project path, scanning all WSL distributions")
-                wslCompat.getInstalledDistributions()
-            }
+        val distribution = wslCompat.getDistributionByWindowsUncPath(path.toString())
 
-            wslCompat.isWslUncPath(path.toString()) -> {
-                val distribution = wslCompat.getDistributionByWindowsUncPath(path.toString())
-                if (distribution != null) {
-                    LOG.debug("Project in WSL (${distribution.msId}), scanning only that distribution")
-                    listOf(distribution)
-                } else {
-                    LOG.debug("Couldn't determine WSL distribution, scanning all")
-                    wslCompat.getInstalledDistributions()
-                }
-            }
-
-            else -> {
-                LOG.debug("Windows project path, scanning all WSL distributions")
-                wslCompat.getInstalledDistributions()
-            }
+        val distributionsToScan = if (distribution != null) {
+            LOG.debug("Project in WSL (${distribution.msId}), scanning only that distribution")
+            listOf(distribution)
+        } else {
+            LOG.debug("Couldn't determine WSL distribution from $path, scanning all")
+            wslCompat.getInstalledDistributions()
         }
 
-        distributionsToScan.forEach { distribution ->
-            homePathByVersionWSL(distribution, homePathByVersion, config)
-        }
+        distributionsToScan.forEach { homePathByVersionWSL(it, homePathByVersion, config) }
     }
 
-    /**
-     * Scans a single WSL distribution for SDK installations.
-     * Mirrors the Linux scanning logic but converts paths to Windows UNC format.
-     */
     private fun homePathByVersionWSL(
         distribution: WSLDistribution,
         homePathByVersion: MutableMap<SdkHomeKey, String>,
         config: Config
     ) {
-        val wslUserHome = wslCompat.getWslUserHomeUncPath(distribution)
-
-        if (wslUserHome != null) {
-            SdkHomePaths.mergeASDF(homePathByVersion, config.toolName, wslUserHome)
-            SdkHomePaths.mergeMise(homePathByVersion, config.toolName, wslUserHome)
-            SdkHomePaths.mergeElixirInstallScript(homePathByVersion, config.elixirInstallScriptDirName, wslUserHome)
-
-            if (config.travisCIKerlTransform != null) {
-                SdkHomePaths.mergeTravisCIKerl(homePathByVersion, config.travisCIKerlTransform, wslUserHome)
-            }
-        }
-
-        SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, config.toolName) {
-            wslCompat.convertLinuxPathToWindowsUnc(distribution, it)
-        }
-
-        wslCompat.convertLinuxPathToWindowsUnc(distribution, SdkPaths.NIX_STORE_PATH)?.let { wslNixStore ->
-            val nixTransform = config.nixTransform ?: { it }
-            SdkHomePaths.mergeNixStore(homePathByVersion, config.nixPattern, nixTransform, wslNixStore)
-        }
+        mergePosixSources(
+            homePathByVersion, config, wslCompat.getWslUserHomeUncPath(distribution)
+        ) { wslCompat.convertLinuxPathToWindowsUnc(distribution, it) }
     }
 
     /**

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -94,8 +94,6 @@ class Type : org.elixir_lang.sdk.erlang_dependent.Type(ElixirSdkTypeId.ELIXIR_SD
             path, SdkHomeScan.Config(
                 toolName = "elixir",
                 nixPattern = NIX_PATTERN,
-                linuxDefaultPath = LINUX_DEFAULT_HOME_PATH,
-                linuxMintPath = LINUX_MINT_HOME_PATH,
                 windowsDefaultPath = WINDOWS_64BIT_DEFAULT_HOME_PATH,
                 windows32BitPath = WINDOWS_32BIT_DEFAULT_HOME_PATH,
                 elixirInstallScriptDirName = "elixir",
@@ -223,8 +221,6 @@ ELIXIR_SDK_HOME
     }
 
     companion object {
-        private const val LINUX_DEFAULT_HOME_PATH = SdkHomePaths.LINUX_DEFAULT_HOME_PATH + "/elixir"
-        private const val LINUX_MINT_HOME_PATH = SdkHomePaths.LINUX_MINT_HOME_PATH + "/elixir"
         private val LOG = Logger.getInstance(Type::class.java)
         private val NIX_PATTERN = SdkHomePaths.nixPattern("elixir")
         private val SDK_HOME_CHILD_BASE_NAME_SET: Set<String> = setOf("lib", "src")

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -32,39 +32,11 @@ import javax.swing.Icon
 
 class Type : org.elixir_lang.sdk.erlang_dependent.Type(ElixirSdkTypeId.ELIXIR_SDK_TYPE_ID) {
     /**
-     * If a path selected in the file chooser is not a valid SDK home path, and the base name is one of the commonly
-     * incorrectly selected subdirectories - bin, lib, or src - then return the parent path, so it can be checked for
-     * validity.
-     *
      * @param homePath the path selected in the file chooser.
      * @return the path to be used as the SDK home.
      */
-    override fun adjustSelectedSdkHome(homePath: String): String {
-        val homePathFile = File(homePath)
-        var adjustedSdkHome = homePath
-        if (homePathFile.isDirectory) {
-            val baseName = FilenameUtils.getBaseName(homePath)
-            if (baseName == "bin") {
-                adjustedSdkHome = homePathFile.parent
-
-                // adjustSelectedSdkHome is only called once, but `bin` could either be the correct `bin` OR in `kiex` a false `bin`.
-                if (!isValidSdkHome(adjustedSdkHome)) {
-                    val libSibling = File(adjustedSdkHome, "lib")
-
-                    // `kiex` has `lib/elixir` and the false `bin` as the same level
-                    if (libSibling.exists()) {
-                        adjustedSdkHome = File(libSibling, "elixir").path
-                    }
-                }
-            } else if (SDK_HOME_CHILD_BASE_NAME_SET.contains(baseName)) {
-                adjustedSdkHome = homePathFile.parent
-            } else if (baseName.startsWith("elixir-") && FilenameUtils.getBaseName(homePathFile.parent) == "elixirs") {
-                // `kiex` versioned directory like `~/.kiex/elixirs/elixir-VERSION`.
-                adjustedSdkHome = File(File(homePathFile, "lib"), "elixir").path
-            }
-        }
-        return adjustedSdkHome
-    }
+    override fun adjustSelectedSdkHome(homePath: String): String =
+        SdkHomePaths.adjustSelectedSdkHome(homePath, "elixir")
 
     override fun getDefaultDocumentationUrl(sdk: Sdk): String? =
         getDefaultDocumentationUrl(sdk.getUserData(ElixirVersionDetector.ELIXIR_VERSION_KEY))
@@ -221,7 +193,7 @@ ELIXIR_SDK_HOME
     companion object {
         private val LOG = Logger.getInstance(Type::class.java)
         private val NIX_PATTERN = SdkHomePaths.nixPattern("elixir")
-        private val SDK_HOME_CHILD_BASE_NAME_SET: Set<String> = setOf("lib", "src")
+
         private const val WINDOWS_32BIT_DEFAULT_HOME_PATH = "C:\\Program Files\\Elixir"
         private const val WINDOWS_64BIT_DEFAULT_HOME_PATH = "C:\\Program Files (x86)\\Elixir"
 

--- a/src/org/elixir_lang/sdk/elixir/Type.kt
+++ b/src/org/elixir_lang/sdk/elixir/Type.kt
@@ -97,8 +97,6 @@ class Type : org.elixir_lang.sdk.erlang_dependent.Type(ElixirSdkTypeId.ELIXIR_SD
                 windowsDefaultPath = WINDOWS_64BIT_DEFAULT_HOME_PATH,
                 windows32BitPath = WINDOWS_32BIT_DEFAULT_HOME_PATH,
                 elixirInstallScriptDirName = "elixir",
-                homebrewTransform = null,  // identity
-                nixTransform = null,  // identity
                 kerlTransform = null,  // TODO: Investigate if Elixir supports kerl builds
                 travisCIKerlTransform = null  // TODO: Verify Travis CI kerl for Elixir
             )

--- a/src/org/elixir_lang/sdk/erlang/Type.kt
+++ b/src/org/elixir_lang/sdk/erlang/Type.kt
@@ -39,8 +39,6 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
             windowsDefaultPath = WINDOWS_DEFAULT_HOME_PATH,
             windows32BitPath = null,
             elixirInstallScriptDirName = "otp",
-            homebrewTransform = { versionPath -> File(versionPath, "lib/erlang") },
-            nixTransform = { versionPath -> File(versionPath, "lib/erlang") },
             kerlTransform = { it },
             travisCIKerlTransform = { it }
         )

--- a/src/org/elixir_lang/sdk/erlang/Type.kt
+++ b/src/org/elixir_lang/sdk/erlang/Type.kt
@@ -194,6 +194,13 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
         return homePathByVersion(SdkDetectionContext.resolve(project)).values
     }
 
+    /**
+     * @param homePath the path selected in the file chooser.
+     * @return the path to be used as the SDK home.
+     */
+    override fun adjustSelectedSdkHome(homePath: String): String =
+        SdkHomePaths.adjustSelectedSdkHome(homePath, "erlang")
+
     override fun isValidSdkHome(path: String): Boolean {
         val erlExe = File(CliTool.ERL.getExecutableFilepathWslSafe(path))
         return erlExe.canExecute()

--- a/src/org/elixir_lang/sdk/erlang/Type.kt
+++ b/src/org/elixir_lang/sdk/erlang/Type.kt
@@ -27,8 +27,6 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
     companion object {
         private const val WINDOWS_DEFAULT_HOME_PATH = "C:\\Program Files\\erl9.0"
         private val NIX_PATTERN = SdkHomePaths.nixPattern("erlang")
-        private const val LINUX_MINT_HOME_PATH = "${SdkHomePaths.LINUX_MINT_HOME_PATH}/erlang"
-        private const val LINUX_DEFAULT_HOME_PATH = "${SdkHomePaths.LINUX_DEFAULT_HOME_PATH}/erlang"
 
         @JvmStatic
         val instance: Type
@@ -38,8 +36,6 @@ class Type : SdkType(ErlangSdkTypeId.ERLANG_SDK_TYPE_ID) {
         private fun createConfig() = SdkHomeScan.Config(
             toolName = "erlang",
             nixPattern = NIX_PATTERN,
-            linuxDefaultPath = LINUX_DEFAULT_HOME_PATH,
-            linuxMintPath = LINUX_MINT_HOME_PATH,
             windowsDefaultPath = WINDOWS_DEFAULT_HOME_PATH,
             windows32BitPath = null,
             elixirInstallScriptDirName = "otp",

--- a/tests/org/elixir_lang/jps/shared/sdk/SdkPathsTest.kt
+++ b/tests/org/elixir_lang/jps/shared/sdk/SdkPathsTest.kt
@@ -23,10 +23,38 @@ class SdkPathsTest : PlatformTestCase() {
         assertEquals("asdf", SdkPaths.detectSource("/home/user/.asdf/installs/elixir/1.14.0"))
     }
 
+    fun testDetectSource_elixirInstall() {
+        assertEquals(
+            "elixir-install",
+            SdkPaths.detectSource("/home/user/.elixir-install/installs/elixir/1.18.4")
+        )
+        assertEquals(
+            "elixir-install",
+            SdkPaths.detectSource("/home/user/.elixir-install/installs/otp/27.2")
+        )
+        // The installer only ever writes under installs/, so the segment is matched at the same
+        // depth as asdf's rather than on the .elixir-install directory alone.
+        assertNull(SdkPaths.detectSource("/home/user/.elixir-install/cache/elixir"))
+    }
+
     fun testDetectSource_homebrew() {
         assertEquals("Homebrew", SdkPaths.detectSource("/usr/local/Cellar/elixir/1.15.0"))
         assertEquals("Homebrew", SdkPaths.detectSource("/opt/homebrew/Cellar/erlang/26.0"))
+        assertEquals(
+            "Homebrew",
+            SdkPaths.detectSource("/home/linuxbrew/.linuxbrew/Cellar/elixir/1.18.4/lib/elixir")
+        )
+        // the constants keep their real casing; the matcher lowercases them, not the caller
+        assertEquals("Homebrew", SdkPaths.detectSource("/opt/homebrew/Cellar/ERLANG/28.0"))
         assertEquals("Homebrew", SdkPaths.detectSource("/opt/homebrew/Cellar/elixir/1.14.0/libexec"))
+        // A home inside a WSL distribution is a UNC path that no Linux root is a prefix of, so the
+        // segment has to match mid-path. This is why FileUtil.isAncestor is not used here.
+        assertEquals(
+            "Homebrew",
+            SdkPaths.detectSource(
+                """\\wsl.localhost\Ubuntu-24.04\home\linuxbrew\.linuxbrew\Cellar\erlang\29.0.5\lib\erlang"""
+            )
+        )
     }
 
     fun testDetectSource_nix() {

--- a/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
+++ b/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
@@ -474,6 +474,156 @@ class SdkHomeScanTest : PlatformTestCase() {
         }
     }
 
+    // ========== Chooser selection (adjustSelectedSdkHome) ==========
+
+    /** Layout of `make install PREFIX=<prefix>`: home in lib/<tool>, symlinks in <prefix>/bin. */
+    private fun installedUnderPrefix(prefix: File, toolName: String): File {
+        val home = File(prefix, "lib/$toolName")
+        assertTrue(File(home, "bin").mkdirs())
+        assertTrue(File(home, "lib/$toolName/ebin").mkdirs())
+        assertTrue(File(prefix, "bin").mkdirs())
+
+        return home
+    }
+
+    fun `test choosing a Homebrew version prefix resolves to the home`() {
+        withTempRoot { root ->
+            val prefix = File(root, "Cellar/elixir/1.20.3")
+            val home = installedUnderPrefix(prefix, "elixir")
+
+            assertEquals(home.path, SdkHomePaths.adjustSelectedSdkHome(prefix.path, "elixir"))
+        }
+    }
+
+    fun `test choosing bare usr resolves to the distro home`() {
+        withTempRoot { root ->
+            val usr = File(root, "usr")
+            val home = installedUnderPrefix(usr, "elixir")
+
+            assertEquals(home.path, SdkHomePaths.adjustSelectedSdkHome(usr.path, "elixir"))
+        }
+    }
+
+    fun `test choosing a prefix resolves for erlang too`() {
+        withTempRoot { root ->
+            val prefix = File(root, "Cellar/erlang/29.0.5")
+            val home = installedUnderPrefix(prefix, "erlang")
+
+            assertEquals(home.path, SdkHomePaths.adjustSelectedSdkHome(prefix.path, "erlang"))
+        }
+    }
+
+    fun `test choosing bin lib or src steps up to the home`() {
+        withTempRoot { root ->
+            // a home selected by one of its own children, not a prefix
+            val home = File(root, "elixir")
+            assertTrue(File(home, "bin").mkdirs())
+            assertTrue(File(home, "lib/elixir/ebin").mkdirs())
+            assertTrue(File(home, "src").mkdirs())
+
+            for (child in listOf("bin", "lib", "src")) {
+                assertEquals(
+                    "selecting $child should resolve to its parent",
+                    home.path,
+                    SdkHomePaths.adjustSelectedSdkHome(File(home, child).path, "elixir")
+                )
+            }
+        }
+    }
+
+    fun `test choosing a home leaves it alone`() {
+        withTempRoot { root ->
+            val home = File(root, "elixir")
+            assertTrue(File(home, "bin").mkdirs())
+            assertTrue(File(home, "lib/elixir/ebin").mkdirs())
+
+            assertEquals(home.path, SdkHomePaths.adjustSelectedSdkHome(home.path, "elixir"))
+        }
+    }
+
+    fun `test choosing a kiex version directory resolves to the home`() {
+        withTempRoot { root ->
+            // kiex keeps a false bin beside lib/elixir; the general rule covers it
+            val versionDir = File(root, "elixirs/elixir-1.9.1")
+            val home = installedUnderPrefix(versionDir, "elixir")
+
+            assertEquals(home.path, SdkHomePaths.adjustSelectedSdkHome(versionDir.path, "elixir"))
+            assertEquals(
+                home.path,
+                SdkHomePaths.adjustSelectedSdkHome(File(versionDir, "bin").path, "elixir")
+            )
+        }
+    }
+
+    fun `test choosing an erlang home child steps up`() {
+        withTempRoot { root ->
+            // an Erlang home keeps releases and usr beside bin and lib
+            val home = File(root, "erlang")
+            assertTrue(File(home, "bin").mkdirs())
+            assertTrue(File(home, "lib/stdlib-7.0/ebin").mkdirs())
+            assertTrue(File(home, "releases/29").mkdirs())
+            assertTrue(File(home, "usr/include").mkdirs())
+
+            for (child in listOf("bin", "lib", "releases")) {
+                assertEquals(
+                    "selecting $child should resolve to its parent",
+                    home.path,
+                    SdkHomePaths.adjustSelectedSdkHome(File(home, child).path, "erlang")
+                )
+            }
+        }
+    }
+
+    fun `test usr is not treated as a home child`() {
+        withTempRoot { root ->
+            // /usr is an install prefix in its own right; stepping up from it would reach the
+            // filesystem root and lose the distribution install underneath it
+            val usr = File(root, "usr")
+            val home = installedUnderPrefix(usr, "elixir")
+
+            assertEquals(home.path, SdkHomePaths.adjustSelectedSdkHome(usr.path, "elixir"))
+        }
+    }
+
+    fun `test choosing an unrelated bin or src still steps up`() {
+        withTempRoot { root ->
+            // documents the cost of matching on name alone: an unrelated child resolves to its
+            // parent, which the chooser then rejects as an invalid home
+            val unrelated = File(root, "some/project/src")
+            assertTrue(unrelated.mkdirs())
+
+            assertEquals(
+                File(root, "some/project").path,
+                SdkHomePaths.adjustSelectedSdkHome(unrelated.path, "elixir")
+            )
+        }
+    }
+
+    fun `test choosing a file is left alone`() {
+        withTempRoot { root ->
+            val file = File(root, "elixir.txt")
+            assertTrue(file.createNewFile())
+
+            assertEquals(file.path, SdkHomePaths.adjustSelectedSdkHome(file.path, "elixir"))
+        }
+    }
+
+    fun `test choosing a missing path is left alone`() {
+        withTempRoot { root ->
+            val missing = File(root, "absent")
+            assertEquals(missing.path, SdkHomePaths.adjustSelectedSdkHome(missing.path, "elixir"))
+        }
+    }
+
+    fun `test choosing a filesystem root is left alone`() {
+        val root = File(File("/").absolutePath)
+        // parentFile is null here; the fallback must return the selection rather than throw
+        assertEquals(
+            SdkHomePaths.toolHomePath(root, "elixir").path,
+            SdkHomePaths.adjustSelectedSdkHome(root.path, "elixir")
+        )
+    }
+
     // ========== Version managers ==========
 
     private fun assertFindsVersionedHome(

--- a/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
+++ b/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
@@ -1,7 +1,9 @@
 package org.elixir_lang.sdk
 
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.util.Version
 import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.jps.shared.sdk.SdkPaths
 import java.io.File
 import java.nio.file.Paths
 
@@ -107,16 +109,6 @@ class SdkHomeScanTest : PlatformTestCase() {
             SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, "elixir") { null }
 
             assertEmpty(homePathByVersion.values)
-        }
-    }
-
-    private fun withTempRoot(body: (File) -> Unit) {
-        val root = FileUtil.createTempDirectory("sdkHome", null)
-
-        try {
-            body(root)
-        } finally {
-            FileUtil.delete(root)
         }
     }
 
@@ -256,6 +248,51 @@ class SdkHomeScanTest : PlatformTestCase() {
         assertNotNull(config.nixTransform)
         assertNotNull(config.kerlTransform)
         assertNotNull(config.travisCIKerlTransform)
+    }
+
+    // ========== Dispatch ==========
+
+    fun `test homePathByVersion wires the version managers into the scan`() {
+        withTempRoot { home ->
+            assertTrue(File(home, "${SdkPaths.ASDF_INSTALLS_PATH_FROM_HOME}/elixir/1.20.3").mkdirs())
+            assertTrue(File(home, "${SdkPaths.MISE_POSIX_PATH_FROM_HOME}/elixir/1.19.5").mkdirs())
+            assertTrue(
+                File(home, "${SdkPaths.ELIXIR_INSTALL_INSTALLS_PATH_FROM_HOME}/elixir/1.18.4").mkdirs()
+            )
+
+            val found = withUserHome(home.path) {
+                SdkHomeScan.homePathByVersion(null, createElixirConfig())
+            }
+
+            // One scan, one source list: a source that stops being wired in fails here rather than
+            // going missing on whichever platform nobody checked.
+            assertTrue(
+                "expected asdf, mise and elixir-install homes, got ${found.values}",
+                found.keys.map { it.version }
+                    .containsAll(listOf(Version(1, 20, 3), Version(1, 19, 5), Version(1, 18, 4)))
+            )
+        }
+    }
+
+    private fun withTempRoot(body: (File) -> Unit) {
+        val root = FileUtil.createTempDirectory("sdkHome", null)
+
+        try {
+            body(root)
+        } finally {
+            FileUtil.delete(root)
+        }
+    }
+
+    private fun <T> withUserHome(userHome: String, body: () -> T): T {
+        val previous = System.getProperty("user.home")
+        System.setProperty("user.home", userHome)
+
+        try {
+            return body()
+        } finally {
+            if (previous != null) System.setProperty("user.home", previous)
+        }
     }
 
     // ========== Helper Methods ==========

--- a/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
+++ b/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
@@ -56,14 +56,14 @@ class SdkHomeScanTest : PlatformTestCase() {
 
     fun `test elixir linux system home paths`() {
         assertEquals(
-            listOf("/usr/local/lib/elixir", "/usr/lib/elixir"),
+            listOf("/usr/local/lib/elixir", "/usr/lib/elixir", "/usr/lib64/elixir"),
             SdkHomePaths.linuxSystemHomePaths("elixir")
         )
     }
 
     fun `test erlang linux system home paths`() {
         assertEquals(
-            listOf("/usr/local/lib/erlang", "/usr/lib/erlang"),
+            listOf("/usr/local/lib/erlang", "/usr/lib/erlang", "/usr/lib64/erlang"),
             SdkHomePaths.linuxSystemHomePaths("erlang")
         )
     }
@@ -112,6 +112,16 @@ class SdkHomeScanTest : PlatformTestCase() {
         }
     }
 
+    private fun withTempRoot(body: (File) -> Unit) {
+        val root = FileUtil.createTempDirectory("sdkHome", null)
+
+        try {
+            body(root)
+        } finally {
+            FileUtil.delete(root)
+        }
+    }
+
     // ========== Transform Behavior Tests ==========
 
     fun `test both tools resolve a prefix with the same rule`() {
@@ -128,49 +138,6 @@ class SdkHomeScanTest : PlatformTestCase() {
             assertEquals(
                 File(erlangPrefix, "lib/erlang"),
                 createErlangConfig().toolHome(erlangPrefix)
-            )
-        }
-    }
-
-    fun `test toolHomePath descends into the nested home`() {
-        withTempRoot { root ->
-            // make install PREFIX=<prefix>, the layout Homebrew has produced since 2024-09-22
-            val prefix = File(root, "elixir/1.18.0")
-            assertTrue(File(prefix, "lib/elixir/bin").mkdirs())
-            assertTrue(File(prefix, "lib/elixir/lib/elixir/ebin").mkdirs())
-            assertTrue(File(prefix, "bin").mkdirs())
-
-            assertEquals(
-                FileUtil.toSystemIndependentName(File(prefix, "lib/elixir").absolutePath),
-                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
-            )
-        }
-    }
-
-    fun `test toolHomePath keeps the prefix for the pre-2024 layout`() {
-        withTempRoot { root ->
-            // bin.install plus per-app lib/<app>/ebin: lib/elixir exists but has no bin of its own
-            val prefix = File(root, "elixir/1.17.3")
-            assertTrue(File(prefix, "bin").mkdirs())
-            assertTrue(File(prefix, "lib/elixir/ebin").mkdirs())
-            assertTrue(File(prefix, "lib/eex/ebin").mkdirs())
-
-            assertEquals(
-                "the prefix is already the home; descending would break installs predating 2024-09-22",
-                FileUtil.toSystemIndependentName(prefix.absolutePath),
-                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
-            )
-        }
-    }
-
-    fun `test toolHomePath keeps the prefix when there is no lib at all`() {
-        withTempRoot { root ->
-            val prefix = File(root, "elixir/1.18.0")
-            assertTrue(File(prefix, "bin").mkdirs())
-
-            assertEquals(
-                FileUtil.toSystemIndependentName(prefix.absolutePath),
-                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
             )
         }
     }
@@ -263,6 +230,248 @@ class SdkHomeScanTest : PlatformTestCase() {
 
         assertNotNull(config.kerlTransform)
         assertNotNull(config.travisCIKerlTransform)
+    }
+
+    // ========== /usr/share, version-scoped (Fedora, RHEL) ==========
+
+    fun `test mergeSystemShare discovers a versioned home`() {
+        withTempRoot { root ->
+            val home = File(root, "elixir/1.20.3")
+            assertTrue("could not create $home", home.mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeSystemShare(homePathByVersion, "elixir", root.absolutePath)
+
+            val key = homePathByVersion.keys.single()
+            assertEquals(Version(1, 20, 3), key.version)
+            assertEquals("1.20.3", key.qualifier)
+            assertNull("a system install is not attributed to an installer", key.source)
+            assertEquals(
+                FileUtil.toSystemIndependentName(home.absolutePath),
+                FileUtil.toSystemIndependentName(homePathByVersion.getValue(key))
+            )
+        }
+    }
+
+    fun `test mergeSystemShare finds every version side by side`() {
+        withTempRoot { root ->
+            assertTrue(File(root, "elixir/1.19.5").mkdirs())
+            assertTrue(File(root, "elixir/1.20.3").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeSystemShare(homePathByVersion, "elixir", root.absolutePath)
+
+            assertEquals(
+                setOf(Version(1, 19, 5), Version(1, 20, 3)),
+                homePathByVersion.keys.map { it.version }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeSystemShare ignores a non-version directory`() {
+        withTempRoot { root ->
+            // Fedora puts Erlang's ERL_LIBS at /usr/share/erlang/lib, which is not an SDK home.
+            assertTrue(File(root, "erlang/lib").mkdirs())
+            assertTrue(File(root, "erlang/28.1").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeSystemShare(homePathByVersion, "erlang", root.absolutePath)
+
+            assertEquals(
+                setOf(FileUtil.toSystemIndependentName(File(root, "erlang/28.1").absolutePath)),
+                homePathByVersion.values.map { FileUtil.toSystemIndependentName(it) }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeSystemShare ignores another tool`() {
+        withTempRoot { root ->
+            assertTrue(File(root, "erlang/28.1").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeSystemShare(homePathByVersion, "elixir", root.absolutePath)
+
+            assertEmpty(homePathByVersion.values)
+        }
+    }
+
+    fun `test mergeSystemShare tolerates a missing share root`() {
+        withTempRoot { root ->
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeSystemShare(homePathByVersion, "elixir", File(root, "absent").absolutePath)
+
+            assertEmpty(homePathByVersion.values)
+        }
+    }
+
+    // ========== Homebrew version prefix ==========
+
+    fun `test toolHomePath descends into the nested home`() {
+        withTempRoot { root ->
+            // make install PREFIX=<prefix>, the layout Homebrew has produced since 2024-09-22
+            val prefix = File(root, "elixir/1.18.0")
+            assertTrue(File(prefix, "lib/elixir/bin").mkdirs())
+            assertTrue(File(prefix, "lib/elixir/lib/elixir/ebin").mkdirs())
+            assertTrue(File(prefix, "bin").mkdirs())
+
+            assertEquals(
+                FileUtil.toSystemIndependentName(File(prefix, "lib/elixir").absolutePath),
+                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
+            )
+        }
+    }
+
+    fun `test toolHomePath keeps the prefix for the pre-2024 layout`() {
+        withTempRoot { root ->
+            // bin.install plus per-app lib/<app>/ebin: lib/elixir exists but has no bin of its own
+            val prefix = File(root, "elixir/1.17.3")
+            assertTrue(File(prefix, "bin").mkdirs())
+            assertTrue(File(prefix, "lib/elixir/ebin").mkdirs())
+            assertTrue(File(prefix, "lib/eex/ebin").mkdirs())
+
+            assertEquals(
+                "the prefix is already the home; descending would break installs predating 2024-09-22",
+                FileUtil.toSystemIndependentName(prefix.absolutePath),
+                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
+            )
+        }
+    }
+
+    fun `test toolHomePath keeps the prefix when there is no lib at all`() {
+        withTempRoot { root ->
+            val prefix = File(root, "elixir/1.18.0")
+            assertTrue(File(prefix, "bin").mkdirs())
+
+            assertEquals(
+                FileUtil.toSystemIndependentName(prefix.absolutePath),
+                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
+            )
+        }
+    }
+
+    fun `test homebrewCellarPaths names every prefix Homebrew uses`() {
+        val cellars = SdkHomePaths.homebrewCellarPaths("/home/me") { it }
+
+        // Nothing else asserts which roots the scan reaches, so dropping one here is invisible.
+        assertEquals(
+            listOf(
+                "/usr/local/Cellar",
+                "/opt/homebrew/Cellar",
+                "/home/linuxbrew/.linuxbrew/Cellar",
+                "/home/me/.linuxbrew/Cellar"
+            ).map { FileUtil.toSystemIndependentName(it) },
+            cellars.map { FileUtil.toSystemIndependentName(it) }
+        )
+    }
+
+    fun `test homebrewCellarPaths maps every root through the reader`() {
+        // A distribution root, not a UNC path: `File` keeps a leading `//` only on Windows, so a
+        // UNC-shaped root would assert the home-derived Cellar differently on each OS.
+        val cellars = SdkHomePaths.homebrewCellarPaths("/mnt/distro/home/me") { "/mnt/distro$it" }
+
+        assertEquals(
+            "a WSL scan must reach the same roots through its own mapping",
+            listOf(
+                "/mnt/distro/usr/local/Cellar",
+                "/mnt/distro/opt/homebrew/Cellar",
+                "/mnt/distro/home/linuxbrew/.linuxbrew/Cellar",
+                "/mnt/distro/home/me/.linuxbrew/Cellar"
+            ),
+            cellars.map { FileUtil.toSystemIndependentName(it) }
+        )
+    }
+
+    fun `test homebrewCellarPaths drops roots the reader cannot reach`() {
+        val cellars = SdkHomePaths.homebrewCellarPaths(null) { null }
+
+        assertEmpty(cellars)
+    }
+
+    fun `test mergeHomebrew scans every explicit cellar`() {
+        withTempRoot { root ->
+            val intel = File(root, "usr/local/Cellar")
+            val linuxbrew = File(root, "home/linuxbrew/.linuxbrew/Cellar")
+            assertTrue(File(intel, "elixir/1.17.3/bin").mkdirs())
+            assertTrue(File(linuxbrew, "elixir/1.18.4/bin").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeHomebrew(
+                homePathByVersion, "elixir", { SdkHomePaths.toolHomePath(it, "elixir") },
+                listOf(intel.path, linuxbrew.path)
+            )
+
+            assertEquals(
+                "Homebrew on Linux and WSL uses a .linuxbrew prefix, not a macOS one",
+                setOf(Version(1, 17, 3), Version(1, 18, 4)),
+                homePathByVersion.keys.map { it.version }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeHomebrew tolerates a cellar that does not exist`() {
+        withTempRoot { root ->
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeHomebrew(
+                homePathByVersion, "elixir", { it }, listOf(File(root, "absent").path)
+            )
+
+            assertEmpty(homePathByVersion.values)
+        }
+    }
+
+    fun `test mergeHomebrew finds version-pinned formulae`() {
+        withTempRoot { root ->
+            val cellar = File(root, "Cellar")
+            // erlang@25..28 are real homebrew-core formulae and live beside the unpinned one
+            assertTrue(File(cellar, "erlang/28.1.2/lib/erlang/bin").mkdirs())
+            assertTrue(File(cellar, "erlang@26/26.2.5/lib/erlang/bin").mkdirs())
+            assertTrue(File(cellar, "erlang@27/27.3.4/lib/erlang/bin").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeHomebrew(
+                homePathByVersion, "erlang", { File(it, "lib/erlang") }, listOf(cellar.path)
+            )
+
+            assertEquals(
+                "a pinned Erlang is how an OTP release is held for a given Elixir",
+                setOf(Version(28, 1, 2), Version(26, 2, 5), Version(27, 3, 4)),
+                homePathByVersion.keys.map { it.version }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeHomebrew keeps every version of one formula`() {
+        withTempRoot { root ->
+            val cellar = File(root, "Cellar")
+            // Homebrew keeps superseded versions until brew cleanup runs
+            assertTrue(File(cellar, "elixir/1.18.4/lib/elixir/bin").mkdirs())
+            assertTrue(File(cellar, "elixir/1.19.5/lib/elixir/bin").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeHomebrew(
+                homePathByVersion, "elixir", { SdkHomePaths.toolHomePath(it, "elixir") },
+                listOf(cellar.path)
+            )
+
+            assertEquals(
+                setOf(Version(1, 18, 4), Version(1, 19, 5)),
+                homePathByVersion.keys.map { it.version }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeHomebrew does not confuse another tool with a pinned prefix`() {
+        withTempRoot { root ->
+            val cellar = File(root, "Cellar")
+            assertTrue(File(cellar, "erlang@27/27.3.4/lib/erlang/bin").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeHomebrew(
+                homePathByVersion, "elixir", { it }, listOf(cellar.path)
+            )
+
+            assertEmpty(homePathByVersion.values)
+        }
     }
 
     // ========== Version managers ==========
@@ -402,16 +611,6 @@ class SdkHomeScanTest : PlatformTestCase() {
                 found.keys.map { it.version }
                     .containsAll(listOf(Version(1, 20, 3), Version(1, 19, 5), Version(1, 18, 4)))
             )
-        }
-    }
-
-    private fun withTempRoot(body: (File) -> Unit) {
-        val root = FileUtil.createTempDirectory("sdkHome", null)
-
-        try {
-            body(root)
-        } finally {
-            FileUtil.delete(root)
         }
     }
 

--- a/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
+++ b/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
@@ -114,42 +114,65 @@ class SdkHomeScanTest : PlatformTestCase() {
 
     // ========== Transform Behavior Tests ==========
 
-    fun `test null homebrewTransform uses identity`() {
-        val config = createElixirConfig()
-        // Kotlin lambdas use invoke(), not apply()
-        val transform: (File) -> File = config.homebrewTransform ?: { it }
-        val testFile = File("/test")
-        assertSame(testFile, transform(testFile))
+    fun `test both tools resolve a prefix with the same rule`() {
+        withTempRoot { root ->
+            val elixirPrefix = File(root, "elixir/1.20.3")
+            val erlangPrefix = File(root, "erlang/29.0.5")
+            assertTrue(File(elixirPrefix, "lib/elixir/bin").mkdirs())
+            assertTrue(File(erlangPrefix, "lib/erlang/bin").mkdirs())
+
+            assertEquals(
+                File(elixirPrefix, "lib/elixir"),
+                createElixirConfig().toolHome(elixirPrefix)
+            )
+            assertEquals(
+                File(erlangPrefix, "lib/erlang"),
+                createErlangConfig().toolHome(erlangPrefix)
+            )
+        }
     }
 
-    fun `test null nixTransform uses identity`() {
-        val config = createElixirConfig()
-        // Kotlin lambdas use invoke(), not apply()
-        val transform: (File) -> File = config.nixTransform ?: { it }
-        val testFile = File("/nix/store/test")
-        assertSame(testFile, transform(testFile))
+    fun `test toolHomePath descends into the nested home`() {
+        withTempRoot { root ->
+            // make install PREFIX=<prefix>, the layout Homebrew has produced since 2024-09-22
+            val prefix = File(root, "elixir/1.18.0")
+            assertTrue(File(prefix, "lib/elixir/bin").mkdirs())
+            assertTrue(File(prefix, "lib/elixir/lib/elixir/ebin").mkdirs())
+            assertTrue(File(prefix, "bin").mkdirs())
+
+            assertEquals(
+                FileUtil.toSystemIndependentName(File(prefix, "lib/elixir").absolutePath),
+                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
+            )
+        }
     }
 
-    fun `test erlang homebrewTransform adds lib slash erlang`() {
-        val config = createErlangConfig()
-        assertNotNull(config.homebrewTransform)
+    fun `test toolHomePath keeps the prefix for the pre-2024 layout`() {
+        withTempRoot { root ->
+            // bin.install plus per-app lib/<app>/ebin: lib/elixir exists but has no bin of its own
+            val prefix = File(root, "elixir/1.17.3")
+            assertTrue(File(prefix, "bin").mkdirs())
+            assertTrue(File(prefix, "lib/elixir/ebin").mkdirs())
+            assertTrue(File(prefix, "lib/eex/ebin").mkdirs())
 
-        val versionPath = File("/usr/local/Cellar/erlang/27.0")
-        val expected = File("/usr/local/Cellar/erlang/27.0/lib/erlang")
-        val result = config.homebrewTransform!!(versionPath)
-
-        assertEquals(expected, result)
+            assertEquals(
+                "the prefix is already the home; descending would break installs predating 2024-09-22",
+                FileUtil.toSystemIndependentName(prefix.absolutePath),
+                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
+            )
+        }
     }
 
-    fun `test erlang nixTransform adds lib slash erlang`() {
-        val config = createErlangConfig()
-        assertNotNull(config.nixTransform)
+    fun `test toolHomePath keeps the prefix when there is no lib at all`() {
+        withTempRoot { root ->
+            val prefix = File(root, "elixir/1.18.0")
+            assertTrue(File(prefix, "bin").mkdirs())
 
-        val versionPath = File("/nix/store/xyz-erlang-27")
-        val expected = File("/nix/store/xyz-erlang-27/lib/erlang")
-        val result = config.nixTransform!!(versionPath)
-
-        assertEquals(expected, result)
+            assertEquals(
+                FileUtil.toSystemIndependentName(prefix.absolutePath),
+                FileUtil.toSystemIndependentName(SdkHomePaths.toolHomePath(prefix, "elixir").absolutePath)
+            )
+        }
     }
 
     fun `test erlang kerlTransform is identity`() {
@@ -215,16 +238,12 @@ class SdkHomeScanTest : PlatformTestCase() {
             nixPattern = SdkHomePaths.nixPattern("test"),
             windowsDefaultPath = null,
             windows32BitPath = null,
-            homebrewTransform = null,
-            nixTransform = null,
             kerlTransform = null,
             travisCIKerlTransform = null,
             elixirInstallScriptDirName = "test"
         )
 
         assertEquals("test", config.toolName)
-        assertNull(config.homebrewTransform)
-        assertNull(config.nixTransform)
         assertNull(config.kerlTransform)
         assertNull(config.travisCIKerlTransform)
     }
@@ -237,15 +256,11 @@ class SdkHomeScanTest : PlatformTestCase() {
             nixPattern = SdkHomePaths.nixPattern("test"),
             windowsDefaultPath = "C:\\test",
             windows32BitPath = "C:\\test32",
-            homebrewTransform = testTransform,
-            nixTransform = testTransform,
             kerlTransform = testTransform,
             travisCIKerlTransform = testTransform,
             elixirInstallScriptDirName = "test"
         )
 
-        assertNotNull(config.homebrewTransform)
-        assertNotNull(config.nixTransform)
         assertNotNull(config.kerlTransform)
         assertNotNull(config.travisCIKerlTransform)
     }
@@ -302,8 +317,6 @@ class SdkHomeScanTest : PlatformTestCase() {
         nixPattern = SdkHomePaths.nixPattern("elixir"),
         windowsDefaultPath = "C:\\Program Files (x86)\\Elixir",
         windows32BitPath = "C:\\Program Files\\Elixir",
-        homebrewTransform = null,
-        nixTransform = null,
         kerlTransform = null,
         travisCIKerlTransform = null,
         elixirInstallScriptDirName = "elixir"
@@ -314,8 +327,6 @@ class SdkHomeScanTest : PlatformTestCase() {
         nixPattern = SdkHomePaths.nixPattern("erlang"),
         windowsDefaultPath = "C:\\Program Files\\erl9.0",
         windows32BitPath = null,
-        homebrewTransform = { File(it, "lib/erlang") },
-        nixTransform = { File(it, "lib/erlang") },
         kerlTransform = { it },
         travisCIKerlTransform = { it },
         elixirInstallScriptDirName = "otp"

--- a/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
+++ b/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
@@ -265,6 +265,122 @@ class SdkHomeScanTest : PlatformTestCase() {
         assertNotNull(config.travisCIKerlTransform)
     }
 
+    // ========== Version managers ==========
+
+    private fun assertFindsVersionedHome(
+        installsFromHome: String,
+        merge: (MutableMap<SdkHomeKey, String>, String) -> Unit,
+    ) {
+        withTempRoot { home ->
+            val installed = File(home, "$installsFromHome/elixir/1.20.3")
+            assertTrue("could not create $installed", installed.mkdirs())
+            // a sibling tool must not be picked up for elixir
+            assertTrue(File(home, "$installsFromHome/erlang/29.0.5").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            merge(homePathByVersion, home.path)
+
+            assertEquals(
+                setOf(FileUtil.toSystemIndependentName(installed.absolutePath)),
+                homePathByVersion.values.map { FileUtil.toSystemIndependentName(it) }.toSet()
+            )
+            assertEquals(Version(1, 20, 3), homePathByVersion.keys.single().version)
+        }
+    }
+
+    fun `test mergeASDF finds an installed version`() {
+        assertFindsVersionedHome(SdkPaths.ASDF_INSTALLS_PATH_FROM_HOME) { map, home ->
+            SdkHomePaths.mergeASDF(map, "elixir", home)
+        }
+    }
+
+    fun `test mergeMise finds an installed version`() {
+        assertFindsVersionedHome(SdkPaths.MISE_POSIX_PATH_FROM_HOME) { map, home ->
+            SdkHomePaths.mergeMise(map, "elixir", home)
+        }
+    }
+
+    fun `test mergeMise finds a Windows-layout install`() {
+        assertFindsVersionedHome(SdkPaths.MISE_WINDOWS_PATH_FROM_HOME) { map, home ->
+            SdkHomePaths.mergeMise(map, "elixir", home)
+        }
+    }
+
+    fun `test mergeElixirInstallScript finds an installed version`() {
+        assertFindsVersionedHome(SdkPaths.ELIXIR_INSTALL_INSTALLS_PATH_FROM_HOME) { map, home ->
+            SdkHomePaths.mergeElixirInstallScript(map, "elixir", home)
+        }
+    }
+
+    fun `test a version manager attributes the source it came from`() {
+        withTempRoot { home ->
+            assertTrue(File(home, "${SdkPaths.ASDF_INSTALLS_PATH_FROM_HOME}/elixir/1.20.3").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeASDF(homePathByVersion, "elixir", home.path)
+
+            assertEquals(SdkPaths.SOURCE_NAME_ASDF, homePathByVersion.keys.single().source)
+        }
+    }
+
+    fun `test a version manager tolerates a missing install root`() {
+        withTempRoot { home ->
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeASDF(homePathByVersion, "elixir", File(home, "absent").path)
+
+            assertEmpty(homePathByVersion.values)
+        }
+    }
+
+    // ========== Nix store ==========
+
+    fun `test mergeNixStore finds a derivation and reads its version`() {
+        withTempRoot { store ->
+            assertTrue(File(store, "abc123-elixir-1.20.3").mkdirs())
+            assertTrue(File(store, "def456-erlang-29.0.5").mkdirs())
+            assertTrue(File(store, "ghi789-elixir-nodots").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeNixStore(
+                homePathByVersion, SdkHomePaths.nixPattern("elixir"), { it }, store.path
+            )
+
+            val key = homePathByVersion.keys.single()
+            assertEquals(Version(1, 20, 3), key.version)
+            assertEquals(SdkPaths.SOURCE_NAME_NIX, key.source)
+        }
+    }
+
+    fun `test mergeNixStore applies the prefix rule to a derivation`() {
+        withTempRoot { store ->
+            val derivation = File(store, "abc123-erlang-29.0.5")
+            assertTrue(File(derivation, "lib/erlang/bin").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeNixStore(
+                homePathByVersion, SdkHomePaths.nixPattern("erlang"),
+                { SdkHomePaths.toolHomePath(it, "erlang") }, store.path
+            )
+
+            assertEquals(
+                setOf(FileUtil.toSystemIndependentName(File(derivation, "lib/erlang").absolutePath)),
+                homePathByVersion.values.map { FileUtil.toSystemIndependentName(it) }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeNixStore tolerates a missing store`() {
+        withTempRoot { root ->
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeNixStore(
+                homePathByVersion, SdkHomePaths.nixPattern("elixir"), { it },
+                File(root, "absent").path
+            )
+
+            assertEmpty(homePathByVersion.values)
+        }
+    }
+
     // ========== Dispatch ==========
 
     fun `test homePathByVersion wires the version managers into the scan`() {

--- a/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
+++ b/tests/org/elixir_lang/sdk/SdkHomeScanTest.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.sdk
 
+import com.intellij.openapi.util.io.FileUtil
 import org.elixir_lang.PlatformTestCase
 import java.io.File
 import java.nio.file.Paths
@@ -51,16 +52,72 @@ class SdkHomeScanTest : PlatformTestCase() {
         assertNull("Erlang uses same path for 32-bit", config.windows32BitPath)
     }
 
-    fun `test elixir config linux paths`() {
-        val config = createElixirConfig()
-        assertEquals("/usr/local/lib/elixir", config.linuxDefaultPath)
-        assertEquals("/usr/lib/elixir", config.linuxMintPath)
+    fun `test elixir linux system home paths`() {
+        assertEquals(
+            listOf("/usr/local/lib/elixir", "/usr/lib/elixir"),
+            SdkHomePaths.linuxSystemHomePaths("elixir")
+        )
     }
 
-    fun `test erlang config linux paths`() {
-        val config = createErlangConfig()
-        assertEquals("/usr/local/lib/erlang", config.linuxDefaultPath)
-        assertEquals("/usr/lib/erlang", config.linuxMintPath)
+    fun `test erlang linux system home paths`() {
+        assertEquals(
+            listOf("/usr/local/lib/erlang", "/usr/lib/erlang"),
+            SdkHomePaths.linuxSystemHomePaths("erlang")
+        )
+    }
+
+    fun `test mergeLinuxSystemHomePaths adds only directories that exist`() {
+        withTempRoot { root ->
+            val present = File(root, "usr/lib/elixir")
+            assertTrue("could not create $present", present.mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, "elixir") { File(root, it).path }
+
+            // /usr/local/lib/elixir was a candidate too, but was never created.
+            assertEquals(
+                setOf(FileUtil.toSystemIndependentName(present.absolutePath)),
+                homePathByVersion.values.map { FileUtil.toSystemIndependentName(it) }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeLinuxSystemHomePaths covers every candidate`() {
+        withTempRoot { root ->
+            val candidates = SdkHomePaths.linuxSystemHomePaths("elixir")
+            candidates.forEach { assertTrue(File(root, it).mkdirs()) }
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, "elixir") { File(root, it).path }
+
+            assertEquals(
+                "every path linuxSystemHomePaths names must be scanned",
+                candidates.map { FileUtil.toSystemIndependentName(File(root, it).absolutePath) }.toSet(),
+                homePathByVersion.values.map { FileUtil.toSystemIndependentName(it) }.toSet()
+            )
+        }
+    }
+
+    fun `test mergeLinuxSystemHomePaths skips an unreachable path`() {
+        withTempRoot { root ->
+            assertTrue(File(root, "usr/lib/elixir").mkdirs())
+
+            val homePathByVersion = mutableMapOf<SdkHomeKey, String>()
+            // A WSL distribution that cannot map the path returns null, as convertLinuxPathToWindowsUnc does.
+            SdkHomePaths.mergeLinuxSystemHomePaths(homePathByVersion, "elixir") { null }
+
+            assertEmpty(homePathByVersion.values)
+        }
+    }
+
+    private fun withTempRoot(body: (File) -> Unit) {
+        val root = FileUtil.createTempDirectory("sdkHome", null)
+
+        try {
+            body(root)
+        } finally {
+            FileUtil.delete(root)
+        }
     }
 
     // ========== Transform Behavior Tests ==========
@@ -164,8 +221,6 @@ class SdkHomeScanTest : PlatformTestCase() {
         val config = SdkHomeScan.Config(
             toolName = "test",
             nixPattern = SdkHomePaths.nixPattern("test"),
-            linuxDefaultPath = "/test",
-            linuxMintPath = "/test",
             windowsDefaultPath = null,
             windows32BitPath = null,
             homebrewTransform = null,
@@ -188,8 +243,6 @@ class SdkHomeScanTest : PlatformTestCase() {
         val config = SdkHomeScan.Config(
             toolName = "test",
             nixPattern = SdkHomePaths.nixPattern("test"),
-            linuxDefaultPath = "/test",
-            linuxMintPath = "/test",
             windowsDefaultPath = "C:\\test",
             windows32BitPath = "C:\\test32",
             homebrewTransform = testTransform,
@@ -210,8 +263,6 @@ class SdkHomeScanTest : PlatformTestCase() {
     private fun createElixirConfig() = SdkHomeScan.Config(
         toolName = "elixir",
         nixPattern = SdkHomePaths.nixPattern("elixir"),
-        linuxDefaultPath = "/usr/local/lib/elixir",
-        linuxMintPath = "/usr/lib/elixir",
         windowsDefaultPath = "C:\\Program Files (x86)\\Elixir",
         windows32BitPath = "C:\\Program Files\\Elixir",
         homebrewTransform = null,
@@ -224,8 +275,6 @@ class SdkHomeScanTest : PlatformTestCase() {
     private fun createErlangConfig() = SdkHomeScan.Config(
         toolName = "erlang",
         nixPattern = SdkHomePaths.nixPattern("erlang"),
-        linuxDefaultPath = "/usr/local/lib/erlang",
-        linuxMintPath = "/usr/lib/erlang",
         windowsDefaultPath = "C:\\Program Files\\erl9.0",
         windows32BitPath = null,
         homebrewTransform = { File(it, "lib/erlang") },


### PR DESCRIPTION
## Summary

Elixir and Erlang SDKs installed by several standard packagers were never auto-detected, and one of the layouts could not be selected by hand either. This adds the missing layouts, makes the scan and the file chooser agree on which directory is a home, and replaces the per-source and per-OS special cases that let the gaps open.

Every layout below was read from the packaging that produces it — Elixir's own `Makefile`, the Homebrew formula, the Gentoo ebuild, the Fedora spec, Debian's `rules` — rather than inferred.

## What was missing

| Layout | Produced by | Before |
|---|---|---|
| `/usr/lib64/<tool>` | Gentoo (both tools), Fedora (Erlang) | not scanned |
| `/usr/share/elixir/<version>` | Fedora, RHEL | not scanned |
| `/opt/homebrew/Cellar` | Homebrew on Apple Silicon | not scanned |
| `/home/linuxbrew/.linuxbrew/Cellar` | Homebrew on Linux and WSL | not scanned on any platform |
| `<Cellar>/erlang@25`…`@28` | version-pinned formulae | not scanned |
| `~/.elixir-install/installs` on macOS | the official installer script | not scanned on macOS |

## Prefix versus home

`make install PREFIX=<prefix>` puts the home in `<prefix>/lib/<tool>` and leaves only symlinks in `<prefix>/bin`, so a prefix is not a home. Homebrew, Nix, kiex, `/usr` and `/usr/local` are all that shape, and each was handled by its own transform — two of which were `null` for Elixir. That is why Homebrew Elixir has not been detected since Homebrew switched to the `install` target on 2024-09-22 (#3670).

One rule replaces all of them, distinguishing the two shapes by whether the nested directory has a `bin` of its own — a home always does, a bare OTP application directory never does — so installs predating the Homebrew change keep working.

The file chooser now applies the same rule. Previously auto-detection normalised a prefix and the chooser did not, which is what "even after manually showing the plugin the correct paths" meant on #3670. Erlang had no adjustment at all; it inherited the platform default, which returns the selection unchanged.

## Bug found along the way

The scanned version was read from the home path *after* the prefix adjustment, so every Homebrew Erlang was keyed on the literal string `erlang` rather than its version and sorted as unknown. It now comes from the version directory the source named.

## Structure

The per-OS source lists are gone. They were an optimisation worth roughly 25 `isDirectory` calls — a root belonging to another OS simply does not exist — and they are how macOS lost `elixir-install` and how the WSL list drifted from the Linux one. There is now one list, parameterised by how a POSIX path is reached: identity on the host, a UNC mapping into a distribution. Three gates are kept because they earn it — WSL (50–200 ms per path through the Plan 9 redirector), kerl (spawns a subprocess), and the Windows install path (meaningless without a drive letter).

Installer roots are named once, in the module the JPS build process and the IDE can both see, so the scan and `detectSource` can no longer disagree.

## Testing

245 tests in `org.elixir_lang.sdk` and `org.elixir_lang.jps` (196 before). Every new rule was mutation-checked — the path list, `/usr/share`, the prefix rule, pinned formulae, the version fix, the chooser, the Cellar roots and the dispatch all fail when the behaviour they describe is removed.

Specs were also backfilled for asdf, mise, elixir-install and Nix, which had none: the only prior reference was a smoke test that skipped itself when the machine had no mise install.

Verified end to end against a real Linuxbrew install under WSL — `elixir 1.20.3`, `erlang 29.0.5` and `erlang@28 28.5.0.5` detected, paired, and used to run `mix deps` from the IDE.

Not verified on hardware: macOS and Nix layouts are read from packaging, not observed. `mergeKerl`, `mergeTravisCIKerl`, `mergeWindowsInstallerPath` and the WSL branch remain untested — each needs an injectable seam that is out of scope here.

Refs #312, #3670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SarGXKUMwb7D7QyoC9ZehK
