### PR TITLE
fix(completion): stop repeating a bare parameter's name as tail text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
 
 ### Bug Fixes
 
+- [#3924](https://github.com/KronicDeth/intellij-elixir/pull/3924) [@sh41](https://github.com/sh41)
+  - **Variable completion no longer shows a parameter's name twice.** A parameter that is not bound
+    by a match is its own enclosing match, so the match appended after the name only repeated it.
+    Variables bound by a match still show that match, which is what makes the tail text useful.
+    Fixes [#496](https://github.com/KronicDeth/intellij-elixir/issues/496).
+
 - [#3923](https://github.com/KronicDeth/intellij-elixir/pull/3923) [@sh41](https://github.com/sh41)
   - **Homebrew Erlang SDKs no longer report an unknown version.** The version was read from the
     home path after the Homebrew layout adjustment had been applied, so every Homebrew Erlang was

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/Variable.java
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/Variable.java
@@ -51,12 +51,19 @@ public class Variable extends com.intellij.codeInsight.lookup.LookupElementRende
         presentation.setIcon(icon(psiElement));
         presentation.setItemTextForeground(color(psiElement));
 
+        PsiElement enclosingMatch = enclosingMatch(psiElement);
+
+        /* A bare parameter is its own enclosing match, so the tail would only repeat the item text.
+           See https://github.com/KronicDeth/intellij-elixir/issues/496 */
+        if (enclosingMatch == psiElement) {
+            return;
+        }
+
         /* Add a space between variable name and match.
            See https://github.com/KronicDeth/intellij-elixir/issues/506 */
         presentation.appendTailText(" ", false);
 
         TextRange psiElementTextRange = psiElement.getTextRange();
-        PsiElement enclosingMatch = enclosingMatch(psiElement);
         TextRange enclosingMatchTextRange = enclosingMatch.getTextRange();
         String enclosingMatchText = enclosingMatch.getText();
 

--- a/testData/org/elixir_lang/code_insight/lookup/element_renderer/variable/issue_496.ex
+++ b/testData/org/elixir_lang/code_insight/lookup/element_renderer/variable/issue_496.ex
@@ -1,0 +1,7 @@
+defmodule Issue496 do
+  def deposit(%{amount: amount} = account, count) do
+    total = 1
+
+    t<caret>
+  end
+end

--- a/tests/org/elixir_lang/code_insight/lookup/element_renderer/VariableTest.kt
+++ b/tests/org/elixir_lang/code_insight/lookup/element_renderer/VariableTest.kt
@@ -1,0 +1,70 @@
+package org.elixir_lang.code_insight.lookup.element_renderer
+
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementPresentation
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Characterises the *tail text* of variable completion, which nothing else asserts:
+ * `psi/scope/variable/VariantsTest` checks only which names are offered, never how one renders.
+ *
+ * [Variable] appends the enclosing match after the name so a completion item shows where the
+ * variable was bound. That is useful when there is a match to show, and redundant when there is
+ * not - a bare parameter is its own enclosing match, so the name would render twice. Both halves
+ * are pinned here; dropping the second would let a later cleanup delete the useful case.
+ */
+class VariableTest : PlatformTestCase() {
+    fun testBareParameterHasNoRedundantTailText() {
+        val presentation = presentationOf("count")
+
+        assertEquals("count", presentation.itemText)
+        assertEquals(
+            "A bare parameter is its own enclosing match, so repeating it as tail text just shows " +
+                    "the name twice, got: ${presentation.tailFragments}",
+            "",
+            presentation.tailText.orEmpty().trim()
+        )
+    }
+
+    fun testMatchedParameterKeepsItsMatchAsTailText() {
+        val presentation = presentationOf("account")
+
+        assertEquals("account", presentation.itemText)
+        assertEquals(
+            "A parameter bound by a match must still show that match, got: ${presentation.tailFragments}",
+            "%{amount: amount} = account",
+            presentation.tailText.orEmpty().trim()
+        )
+    }
+
+    fun testMatchedVariableKeepsItsMatchAsTailText() {
+        val presentation = presentationOf("total")
+
+        assertEquals("total", presentation.itemText)
+        assertEquals(
+            "A variable bound by a match must still show that match, got: ${presentation.tailFragments}",
+            "total = 1",
+            presentation.tailText.orEmpty().trim()
+        )
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/lookup/element_renderer/variable"
+
+    /**
+     * Drives the real completion popup and renders the element offered for [name], so the assertions
+     * run against what a user sees rather than a hand-built lookup element.
+     */
+    private fun presentationOf(name: String): LookupElementPresentation {
+        myFixture.configureByFile("issue_496.ex")
+        myFixture.complete(CompletionType.BASIC)
+
+        val elements = myFixture.lookupElements
+        assertNotNull("Completion not shown", elements)
+
+        val element = elements!!.firstOrNull { it.lookupString == name }
+        assertNotNull("$name was not offered, got: ${elements.map { it.lookupString }}", element)
+
+        return LookupElementPresentation.renderElement(element!!)
+    }
+}


### PR DESCRIPTION
## Summary

Variable completion showed a parameter's name twice: once as the item, once again as tail text. Reported in #496 in 2016 with a screenshot, and the fix was agreed in that thread the same day — it was just never made.

## Cause

`Variable`, the lookup element renderer, appends the enclosing match after the name so an item shows where the variable was bound. That is genuinely useful when there is a match to show:

```elixir
total = 1          # completion offers:  total   total = 1
```

The append was unconditional, and `enclosingMatch` returns the element itself when the parent is neither an `InMatch` nor a `Match`. A parameter not bound by a match is therefore its own enclosing match, so the prefix and suffix around it are both empty and the "match" appended is just the name again:

```elixir
def deposit(count)  # completion offered:  count   count
```

This is exactly what @KronicDeth described on the issue at the time — *"for parameters, it just so happens that it is the same"* — and the guard both he and @mbriggs settled on, hide when lhs = rhs while still showing the declaration when there is a match, is what this adds.

## Testing

`VariableTest` is new, because nothing pinned the tail text before it: `psi/scope/variable/VariantsTest` asserts only which names are offered, never how one renders. It drives the real completion popup and renders the offered element, so the assertions run against what a user sees.

Three cases, and the last two matter as much as the first:

| Fixture binding | Asserted |
|---|---|
| `count` — bare parameter | no tail text |
| `%{amount: amount} = account` — parameter bound by a match | tail is still `%{amount: amount} = account` |
| `total = 1` — local bound by a match | tail is still `total = 1` |

Without the second and third, a later cleanup could delete the case the tail text exists for and no test would notice.

The first test was written before the change and failed with the reported defect:

```
expected:<[]> but was:<[count]>
got: [TextFragment{text=' '}, TextFragment{text='count'}]
```

The other two passed before the change as well as after, which is the evidence the guard does not touch the useful case. All 38 tests in `org.elixir_lang.code_insight` pass.

Refs #496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)