### PR TITLE
fix: parameter hints that appear, and describe the function you are calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,12 +94,10 @@
   - **A trailing comma in a call's argument list no longer breaks the rest of the file.** Typing
     `foo(a,)` on the way to the next argument used to discard the enclosing definition and everything
     after it, taking parameter hints with it. Applies to `foo(a,)`, `Mod.fun(a,)` and `fun.(a,)`.
-  - **Pressing Enter after a comma now indents to the argument column** rather than back to the
-    enclosing statement, matching `mix format`.
-  - **Pressing Enter inside empty parentheses now indents the caret where an argument goes.** With an
-    argument already present the caret lined up under the argument column, but with the parentheses
-    empty there was no argument block to indent against, so it fell back to the enclosing statement
-    and landed at the start of the line. Refs
+  - **Pressing Enter after a delimiter now indents the caret where an element goes** rather than back
+    to the enclosing statement: after `[`, `{`, `%{`, `%S{`, `<<` and `Foo.{`, after a comma, after
+    `->` in a clause, after the `rescue`, `after`, `else` and `catch` keywords, and inside empty
+    parentheses. Every column is the one `mix format` produces. Refs
     [#799](https://github.com/KronicDeth/intellij-elixir/issues/799).
 
 - [#3925](https://github.com/KronicDeth/intellij-elixir/pull/3925) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@
     after it, taking parameter hints with it. Applies to `foo(a,)`, `Mod.fun(a,)` and `fun.(a,)`.
   - **Parameter hints no longer describe functions you are not calling.** `Enum.reduce` listed eight
     signatures, including `reduce_while`'s. Each arity of the called function still gets its own hint.
+  - **Parameter hints now appear when a completion is accepted.** Accepting a name from the completion
+    popup left the caret between the inserted parentheses with no hint there.
   - **Pressing Enter after a delimiter now indents the caret where an element goes** rather than back
     to the enclosing statement: after `[`, `{`, `%{`, `%S{`, `<<` and `Foo.{`, after a comma, after
     `->` in a clause, after the `rescue`, `after`, `else` and `catch` keywords, and inside empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@
 ### Bug Fixes
 
 - [#3934](https://github.com/KronicDeth/intellij-elixir/pull/3934) [@sh41](https://github.com/sh41)
+  - **A trailing comma in a call's argument list no longer breaks the rest of the file.** Typing
+    `foo(a,)` on the way to the next argument used to discard the enclosing definition and everything
+    after it, taking parameter hints with it. Applies to `foo(a,)`, `Mod.fun(a,)` and `fun.(a,)`.
   - **Pressing Enter inside empty parentheses now indents the caret where an argument goes.** With an
     argument already present the caret lined up under the argument column, but with the parentheses
     empty there was no argument block to indent against, so it fell back to the enclosing statement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@
 
 ### Bug Fixes
 
+- [#3934](https://github.com/KronicDeth/intellij-elixir/pull/3934) [@sh41](https://github.com/sh41)
+  - **Pressing Enter inside empty parentheses now indents the caret where an argument goes.** With an
+    argument already present the caret lined up under the argument column, but with the parentheses
+    empty there was no argument block to indent against, so it fell back to the enclosing statement
+    and landed at the start of the line. Refs
+    [#799](https://github.com/KronicDeth/intellij-elixir/issues/799).
+
 - [#3925](https://github.com/KronicDeth/intellij-elixir/pull/3925) [@sh41](https://github.com/sh41)
   - **A console path written with backslashes now links on Windows.** A compile error prints the
     path the way the platform writes it, while the virtual file system holds forward slashes, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
   - **A trailing comma in a call's argument list no longer breaks the rest of the file.** Typing
     `foo(a,)` on the way to the next argument used to discard the enclosing definition and everything
     after it, taking parameter hints with it. Applies to `foo(a,)`, `Mod.fun(a,)` and `fun.(a,)`.
+  - **Parameter hints no longer describe functions you are not calling.** `Enum.reduce` listed eight
+    signatures, including `reduce_while`'s. Each arity of the called function still gets its own hint.
   - **Pressing Enter after a delimiter now indents the caret where an element goes** rather than back
     to the enclosing statement: after `[`, `{`, `%{`, `%S{`, `<<` and `Foo.{`, after a comma, after
     `->` in a clause, after the `rescue`, `after`, `else` and `catch` keywords, and inside empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
   - **A trailing comma in a call's argument list no longer breaks the rest of the file.** Typing
     `foo(a,)` on the way to the next argument used to discard the enclosing definition and everything
     after it, taking parameter hints with it. Applies to `foo(a,)`, `Mod.fun(a,)` and `fun.(a,)`.
+  - **Pressing Enter after a comma now indents to the argument column** rather than back to the
+    enclosing statement, matching `mix format`.
   - **Pressing Enter inside empty parentheses now indents the caret where an argument goes.** With an
     argument already present the caret lined up under the argument column, but with the parentheses
     empty there was no argument block to indent against, so it fell back to the enclosing statement

--- a/gen/org/elixir_lang/parser/ElixirParser.java
+++ b/gen/org/elixir_lang/parser/ElixirParser.java
@@ -506,6 +506,84 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
+  // OPENING_PARENTHESIS callParenthesesArgumentsBody? CLOSING_PARENTHESIS
+  public static boolean callParenthesesArguments(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArguments")) return false;
+    if (!nextTokenIs(b, OPENING_PARENTHESIS)) return false;
+    boolean r, p;
+    Marker m = enter_section_(b, l, _NONE_, PARENTHESES_ARGUMENTS, null);
+    r = consumeToken(b, OPENING_PARENTHESIS);
+    p = r; // pin = 1
+    r = r && report_error_(b, callParenthesesArguments_1(b, l + 1));
+    r = p && consumeToken(b, CLOSING_PARENTHESIS) && r;
+    exit_section_(b, l, m, r, p, null);
+    return r || p;
+  }
+
+  // callParenthesesArgumentsBody?
+  private static boolean callParenthesesArguments_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArguments_1")) return false;
+    callParenthesesArgumentsBody(b, l + 1);
+    return true;
+  }
+
+  /* ********************************************************** */
+  // unqualifiedNoParenthesesManyArgumentsCall |
+  //                                          keywords |
+  //                                          parenthesesPositionalArguments (infixComma keywords)?
+  static boolean callParenthesesArgumentsBody(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArgumentsBody")) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _NONE_);
+    r = unqualifiedNoParenthesesManyArgumentsCall(b, l + 1);
+    if (!r) r = keywords(b, l + 1);
+    if (!r) r = callParenthesesArgumentsBody_2(b, l + 1);
+    exit_section_(b, l, m, r, false, ElixirParser::callParenthesesArgumentsBodyRecoverWhile);
+    return r;
+  }
+
+  // parenthesesPositionalArguments (infixComma keywords)?
+  private static boolean callParenthesesArgumentsBody_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArgumentsBody_2")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = parenthesesPositionalArguments(b, l + 1);
+    r = r && callParenthesesArgumentsBody_2_1(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // (infixComma keywords)?
+  private static boolean callParenthesesArgumentsBody_2_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArgumentsBody_2_1")) return false;
+    callParenthesesArgumentsBody_2_1_0(b, l + 1);
+    return true;
+  }
+
+  // infixComma keywords
+  private static boolean callParenthesesArgumentsBody_2_1_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArgumentsBody_2_1_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = infixComma(b, l + 1);
+    r = r && keywords(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  /* ********************************************************** */
+  // &COMMA
+  static boolean callParenthesesArgumentsBodyRecoverWhile(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "callParenthesesArgumentsBodyRecoverWhile")) return false;
+    if (!nextTokenIs(b, COMMA)) return false;
+    boolean r;
+    Marker m = enter_section_(b, l, _AND_);
+    r = consumeToken(b, COMMA);
+    exit_section_(b, l, m, r, false, null);
+    return r;
+  }
+
+  /* ********************************************************** */
   // capturePrefixOperator <<captureArgument>> numeric
   public static boolean captureNumericOperation(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "captureNumericOperation")) return false;
@@ -2150,44 +2228,44 @@ public class ElixirParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // CALL parenthesesArguments parenthesesArguments?
+  // CALL callParenthesesArguments callParenthesesArguments?
   public static boolean matchedParenthesesArguments(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedParenthesesArguments")) return false;
     if (!nextTokenIs(b, CALL)) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = consumeToken(b, CALL);
-    r = r && parenthesesArguments(b, l + 1);
+    r = r && callParenthesesArguments(b, l + 1);
     r = r && matchedParenthesesArguments_2(b, l + 1);
     exit_section_(b, m, MATCHED_PARENTHESES_ARGUMENTS, r);
     return r;
   }
 
-  // parenthesesArguments?
+  // callParenthesesArguments?
   private static boolean matchedParenthesesArguments_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedParenthesesArguments_2")) return false;
-    parenthesesArguments(b, l + 1);
+    callParenthesesArguments(b, l + 1);
     return true;
   }
 
   /* ********************************************************** */
-  // dotInfixOperator parenthesesArguments parenthesesArguments?
+  // dotInfixOperator callParenthesesArguments callParenthesesArguments?
   public static boolean maxDotCall(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "maxDotCall")) return false;
     if (!nextTokenIs(b, DOT_OPERATOR)) return false;
     boolean r;
     Marker m = enter_section_(b, l, _LEFT_, MATCHED_DOT_CALL, null);
     r = dotInfixOperator(b, l + 1);
-    r = r && parenthesesArguments(b, l + 1);
+    r = r && callParenthesesArguments(b, l + 1);
     r = r && maxDotCall_2(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
 
-  // parenthesesArguments?
+  // callParenthesesArguments?
   private static boolean maxDotCall_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "maxDotCall_2")) return false;
-    parenthesesArguments(b, l + 1);
+    callParenthesesArguments(b, l + 1);
     return true;
   }
 
@@ -3885,22 +3963,22 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // dotInfixOperator parenthesesArguments parenthesesArguments?
+  // dotInfixOperator callParenthesesArguments callParenthesesArguments?
   private static boolean matchedDotCall_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedDotCall_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = dotInfixOperator(b, l + 1);
-    r = r && parenthesesArguments(b, l + 1);
+    r = r && callParenthesesArguments(b, l + 1);
     r = r && matchedDotCall_0_2(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }
 
-  // parenthesesArguments?
+  // callParenthesesArguments?
   private static boolean matchedDotCall_0_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "matchedDotCall_0_2")) return false;
-    parenthesesArguments(b, l + 1);
+    callParenthesesArguments(b, l + 1);
     return true;
   }
 
@@ -4334,23 +4412,23 @@ public class ElixirParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // dotInfixOperator parenthesesArguments parenthesesArguments? doBlockMaybe
+  // dotInfixOperator callParenthesesArguments callParenthesesArguments? doBlockMaybe
   private static boolean unmatchedDotCall_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedDotCall_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = dotInfixOperator(b, l + 1);
-    r = r && parenthesesArguments(b, l + 1);
+    r = r && callParenthesesArguments(b, l + 1);
     r = r && unmatchedDotCall_0_2(b, l + 1);
     r = r && doBlockMaybe(b, l + 1);
     exit_section_(b, m, null, r);
     return r;
   }
 
-  // parenthesesArguments?
+  // callParenthesesArguments?
   private static boolean unmatchedDotCall_0_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "unmatchedDotCall_0_2")) return false;
-    parenthesesArguments(b, l + 1);
+    callParenthesesArguments(b, l + 1);
     return true;
   }
 

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -1399,6 +1399,34 @@ parenthesesArguments ::= OPENING_PARENTHESIS
                            ]
                          }
 
+/*
+ * `parenthesesArguments`, committed once the opening parenthesis is read.  Used wherever the
+ * parentheses are a call's argument list - after a `CALL` token, and after a `.` in a dot call -
+ * because an argument list that does not parse there is a half-typed call rather than something to
+ * back out of.  Uncommitted, the failure detaches the arguments from the call and propagates out
+ * through `stabBody` and `stab` until the enclosing `do` block and every expression after it are lost.
+ *
+ * `stabParenthesesSignature` keeps the uncommitted rule: it relies on backing out of an argument-list
+ * reading when it meets `->`, as in `(peerName :: charlist(), fingerprint() -> boolean())`.
+ *
+ * Recovery eats only the comma left over after the arguments read, because an argument list with a
+ * trailing comma before the `)` is an ordinary state to type through.  Newlines inside parentheses
+ * are whitespace rather than `EOL` tokens, so a multi-line list needs nothing more.  Anything else
+ * stops it: recovering as far as the next `)` anywhere in the file would pull the expressions after
+ * an unclosed parenthesis into its argument list, and eating the end of line would leave the
+ * expression after it with no separator to start from.
+ */
+callParenthesesArguments ::= OPENING_PARENTHESIS callParenthesesArgumentsBody? CLOSING_PARENTHESIS
+                             {
+                               elementType = parenthesesArguments
+                               pin = 1
+                             }
+private callParenthesesArgumentsBody ::= unqualifiedNoParenthesesManyArgumentsCall |
+                                         keywords |
+                                         parenthesesPositionalArguments (infixComma keywords)?
+                                         { recoverWhile = callParenthesesArgumentsBodyRecoverWhile }
+private callParenthesesArgumentsBodyRecoverWhile ::= &COMMA
+
 // call_args_no_parens_one
 noParenthesesOneArgument ::= noParenthesesKeywords | // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L417
                              unqualifiedNoParenthesesManyArgumentsCall | // @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L419
@@ -1431,7 +1459,7 @@ noParenthesesOneArgument ::= noParenthesesKeywords | // @see https://github.com/
                                ]
                              }
 
-matchedParenthesesArguments ::= CALL parenthesesArguments parenthesesArguments? // @see https://github.com/elixir-lang/elixir/blob/39b6789a8625071e149f0a7347ca7a2111f7c8f2/lib/elixir/src/elixir_parser.yrl#L254-255
+matchedParenthesesArguments ::= CALL callParenthesesArguments callParenthesesArguments? // @see https://github.com/elixir-lang/elixir/blob/39b6789a8625071e149f0a7347ca7a2111f7c8f2/lib/elixir/src/elixir_parser.yrl#L254-255
 
 /*
  * Dot (Anonymous function) Call Operation
@@ -1439,7 +1467,7 @@ matchedParenthesesArguments ::= CALL parenthesesArguments parenthesesArguments? 
  * @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L403
  */
 
-matchedDotCall ::= matchedExpression dotInfixOperator parenthesesArguments parenthesesArguments?
+matchedDotCall ::= matchedExpression dotInfixOperator callParenthesesArguments callParenthesesArguments?
                    {
                      implements = [
                        "org.elixir_lang.psi.DotCall<org.elixir_lang.psi.stub.MatchedDotCall>"
@@ -1751,7 +1779,7 @@ private associationInfixOperator ::= ASSOCIATION_OPERATOR
 containerAssociationOperation ::= containerExpression associationInfixOperator containerExpression
                                   { implements = "org.elixir_lang.psi.AssociationOperation" methods = [quote] }
 
-left maxDotCall ::= dotInfixOperator parenthesesArguments parenthesesArguments?
+left maxDotCall ::= dotInfixOperator callParenthesesArguments callParenthesesArguments?
                     { elementType = matchedDotCall }
 
 left maxQualifiedAlias ::= dotInfixOperator alias
@@ -2276,7 +2304,7 @@ private doBlockMaybe ::= doBlock?
  * @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L403
  */
 
-unmatchedDotCall ::= unmatchedExpression dotInfixOperator parenthesesArguments parenthesesArguments? doBlockMaybe
+unmatchedDotCall ::= unmatchedExpression dotInfixOperator callParenthesesArguments callParenthesesArguments? doBlockMaybe
                      {
                        implements = "org.elixir_lang.psi.DotCall<org.elixir_lang.psi.stub.UnmatchedDotCall>"
                        mixin = "org.elixir_lang.psi.impl.NamedStubbedPsiElementBase<org.elixir_lang.psi.stub.UnmatchedDotCall>"

--- a/src/org/elixir_lang/code_insight/ParameterInfo.kt
+++ b/src/org/elixir_lang/code_insight/ParameterInfo.kt
@@ -42,10 +42,16 @@ class ParameterInfo : ParameterInfoHandler<Arguments, Any> {
                 }
             }
 
-            // Deduplicate by (name, arity), preferring bare function heads (no do block)
-            // over implementation clauses.  Uses arity-aware grouping so that
-            // genuinely different arities (e.g. foo/1 vs foo/2) each get their own hint.
-            val itemToShowList = preferFunctionHeadsByArity(allClauses)
+            /* Deduplicate by (name, arity), preferring bare function heads (no do block) over
+               implementation clauses, and keep only the function actually being called - resolution also
+               returns functions the name is a prefix of, so `reduce` would otherwise be described by
+               `reduce_while` as well.
+
+               The references are resolved as incomplete code so that a call whose arguments are not typed
+               yet resolves at all, which is exactly when the hint is wanted: resolving them completely
+               collapses `foo/1` and `foo/2` to a single arity, and does not drop the prefix matches
+               either. Both halves were measured. */
+            val itemToShowList = preferFunctionHeadsByArity(allClauses, call.functionName())
 
             if (itemToShowList.isNotEmpty()) {
                 context.itemsToShow = itemToShowList.toTypedArray()

--- a/src/org/elixir_lang/code_insight/PreferFunctionHead.kt
+++ b/src/org/elixir_lang/code_insight/PreferFunctionHead.kt
@@ -33,14 +33,19 @@ fun preferFunctionHeads(clauses: Iterable<Call>): Map<String, Call> =
  *
  * Use for parameter info where each arity should appear as a separate hint.
  *
+ * @param name keeps only the clauses defining that function, or every clause when `null` because the
+ * caller has no name to match on. Resolution returns more than the function called: a call to `reduce`
+ * also resolves `reduce_while`, whether or not the reference is resolved as incomplete code, so a hint
+ * built from the results unfiltered describes functions the user is not calling.
  * @return a list of best representative clauses, one per name+arity combination
  */
-fun preferFunctionHeadsByArity(clauses: Iterable<Call>): List<Call> =
+fun preferFunctionHeadsByArity(clauses: Iterable<Call>, name: String?): List<Call> =
     clauses
         .mapNotNull { call ->
             CallDefinitionClause.nameArityInterval(call, ResolveState.initial())
                 ?.let { it to call }
         }
+        .filter { (nameArityInterval, _) -> name == null || nameArityInterval.name == name }
         .groupBy({ it.first }, { it.second })
         .map { (_, group) -> preferFunctionHead(group) }
 

--- a/src/org/elixir_lang/code_insight/completion/insert_handler/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/completion/insert_handler/CallDefinitionClause.java
@@ -1,5 +1,6 @@
 package org.elixir_lang.code_insight.completion.insert_handler;
 
+import com.intellij.codeInsight.AutoPopupController;
 import com.intellij.codeInsight.completion.InsertHandler;
 import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.lookup.LookupElement;
@@ -42,6 +43,14 @@ public class CallDefinitionClause implements InsertHandler<LookupElement> {
             context.getDocument().insertString(tailOffset, "()");
             // + 1 to put between the `(`  and `)`
             context.getEditor().getCaretModel().moveToOffset(tailOffset + 1);
+
+            /* The caret now sits where the first argument goes, but nothing has asked for the parameter
+               hint: an open lookup consumes the keystroke that accepted the completion, so the platform's
+               typed handler - which asks on every `(` and `,` - never runs. Ask here, as the completion
+               that inserted the parentheses. */
+            AutoPopupController
+                    .getInstance(context.getProject())
+                    .autoPopupParameterInfo(context.getEditor(), null);
         }
     }
 }

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -2298,17 +2298,18 @@ public class Block extends AbstractBlock implements BlockEx {
             }
         }
 
-        return indentInContainer(container.getElementType());
+        return indentInContainer(container);
     }
 
     /**
-     * The indent an element of {@code containerElementType} written on its own line takes.
+     * The indent an element of {@code container} written on its own line takes.
      *
      * @return {@code null} when the container is not one whose elements indent, such as the argument list of a call
      * written without parentheses.
      */
     @Nullable
-    private Indent indentInContainer(@NotNull IElementType containerElementType) {
+    private Indent indentInContainer(@NotNull ASTNode container) {
+        IElementType containerElementType = container.getElementType();
         Indent indent;
 
         if (containerElementType == PARENTHESES_ARGUMENTS) {
@@ -2319,8 +2320,7 @@ public class Block extends AbstractBlock implements BlockEx {
                     Indent.getNormalIndent() :
                     Indent.getNormalIndent(true);
         } else if (containerElementType == MAP_UPDATE_ARGUMENTS) {
-            // the pipe takes the first indent and the pairs written after it take a second
-            indent = Indent.getSpaceIndent(2 * indentSize());
+            indent = mapUpdatePairIndent(container);
         } else if (NORMAL_INDENT_CONTAINER_TOKEN_SET.contains(containerElementType)) {
             indent = Indent.getNormalIndent();
         } else {
@@ -2330,8 +2330,113 @@ public class Block extends AbstractBlock implements BlockEx {
         return indent;
     }
 
+    /**
+     * The indent a map update's pairs take: one indent in from the pipe, wherever the pipe sits.
+     *
+     * <p>That is two indents in from the line the map starts on while the map starts a line of its own, but not when
+     * it is written as the value of an enclosing update, because it then begins on that update's continuation line and
+     * its pipe is further right than the line's own indent. Anchoring to the pipe covers both, so the columns follow
+     * {@code mix format} at any nesting depth.
+     *
+     * <p>A space indent is resolved against the indent of the line the answering block starts on, so the pipe's column
+     * has to be re-expressed as a distance from there. It cannot be anchored to the block itself: a map update's block
+     * starts at the {@code %{}, which is to the right of its own pipe, and an indent can never place the caret left of
+     * the block it is relative to.
+     *
+     * @return {@code null} when the pipe or either column cannot be read, so that the caret keeps delegating rather
+     * than landing on a column that was guessed.
+     */
+    @Nullable
+    private Indent mapUpdatePairIndent(@NotNull ASTNode mapUpdateArguments) {
+        ASTNode pipe = mapUpdateArguments.findChildByType(PIPE_INFIX_OPERATOR);
+
+        if (pipe == null) {
+            return null;
+        }
+
+        Integer pipeColumn = column(pipe);
+        Integer lineIndent = lineIndent(myNode);
+
+        if (pipeColumn == null || lineIndent == null) {
+            return null;
+        }
+
+        int spaces = pipeColumn + indentSize() - lineIndent;
+
+        return spaces >= 0 ? Indent.getSpaceIndent(spaces) : null;
+    }
+
+    /** The column {@code node} starts at, or {@code null} when there is no document to measure against. */
+    @Nullable
+    private Integer column(@NotNull ASTNode node) {
+        Document document = document(node.getPsi());
+
+        if (document == null) {
+            return null;
+        }
+
+        int startOffset = node.getStartOffset();
+        int lineStartOffset = document.getLineStartOffset(document.getLineNumber(startOffset));
+
+        return column(document.getCharsSequence(), lineStartOffset, startOffset);
+    }
+
+    /**
+     * The indent of the line {@code node} starts on - the column the whitespace before its first non-blank character
+     * ends at.
+     */
+    @Nullable
+    private Integer lineIndent(@NotNull ASTNode node) {
+        Document document = document(node.getPsi());
+
+        if (document == null) {
+            return null;
+        }
+
+        int lineNumber = document.getLineNumber(node.getStartOffset());
+        int lineStartOffset = document.getLineStartOffset(lineNumber);
+        int lineEndOffset = document.getLineEndOffset(lineNumber);
+        CharSequence text = document.getCharsSequence();
+        int indentEndOffset = lineStartOffset;
+
+        while (indentEndOffset < lineEndOffset && Character.isWhitespace(text.charAt(indentEndOffset))) {
+            indentEndOffset++;
+        }
+
+        return column(text, lineStartOffset, indentEndOffset);
+    }
+
+    /**
+     * The column {@code offset} sits at on the line starting at {@code lineStartOffset}.
+     *
+     * <p>Counting characters would do for a file indented with spaces, but {@link Indent#getSpaceIndent(int)} takes
+     * columns and a tab is worth however many columns it takes to reach the next tab stop, so a file indented with
+     * tabs would place the caret short of where the block it is measured against sits. This is
+     * {@link com.intellij.openapi.editor.ex.util.EditorUtil#calcColumnNumber}'s arithmetic, which there is no editor
+     * to ask for here.
+     */
+    private int column(@NotNull CharSequence text, int lineStartOffset, int offset) {
+        int tabSize = Math.max(tabSize(), 1);
+        int column = 0;
+
+        for (int charOffset = lineStartOffset; charOffset < offset; charOffset++) {
+            column += text.charAt(charOffset) == '\t' ? tabSize - column % tabSize : 1;
+        }
+
+        return column;
+    }
+
     private int indentSize() {
-        return CodeStyle.getIndentOptions(myNode.getPsi().getContainingFile()).INDENT_SIZE;
+        return indentOptions().INDENT_SIZE;
+    }
+
+    private int tabSize() {
+        return indentOptions().TAB_SIZE;
+    }
+
+    @NotNull
+    private CommonCodeStyleSettings.IndentOptions indentOptions() {
+        return CodeStyle.getIndentOptions(myNode.getPsi().getContainingFile());
     }
 
     /**

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -2192,10 +2192,11 @@ public class Block extends AbstractBlock implements BlockEx {
         IElementType elementType = myNode.getElementType();
 
         if (newChildIndex > 0) {
-           childAttributes = precededByOpeningParenthesis(newChildIndex) ?
-                   /* Delegating would hand the platform the opening parenthesis as the block to indent against,
-                      because empty parentheses have no argument block to delegate to. Indent against this call
-                      instead, so the caret lands where an argument would. */
+           childAttributes = precededByArgumentDelimiter(newChildIndex) ?
+                   /* Delegating would hand the platform a delimiter as the block to indent against, and both the
+                      opening parenthesis and the commas are built without an indent of their own, so it would fall
+                      back to the enclosing statement. Indent against this call instead, so the caret lands where an
+                      argument would. */
                    new ChildAttributes(Indent.getNormalIndent(true), null) :
                    DELEGATE_TO_PREV_CHILD;
         } else if (elementType == DO) {
@@ -2216,7 +2217,15 @@ public class Block extends AbstractBlock implements BlockEx {
         return childAttributes;
     }
 
-    private boolean precededByOpeningParenthesis(int newChildIndex) {
+    /**
+     * Whether the caret follows one of the tokens punctuating a parenthesised argument list, which
+     * {@link #buildParenthesesArgumentsChildren} builds without an indent of their own because they sit beside the
+     * argument they punctuate rather than starting a line.
+     *
+     * <p>The comma is recognised by its own parent rather than by this block's element type, because an argument
+     * list's children are flattened into the enclosing call's sub-blocks, so the block being asked is the call.
+     */
+    private boolean precededByArgumentDelimiter(int newChildIndex) {
         List<com.intellij.formatting.Block> subBlocks = getSubBlocks();
 
         if (newChildIndex > subBlocks.size()) {
@@ -2225,8 +2234,20 @@ public class Block extends AbstractBlock implements BlockEx {
 
         com.intellij.formatting.Block previousChild = subBlocks.get(newChildIndex - 1);
 
-        return previousChild instanceof Block &&
-                ((Block) previousChild).myNode.getElementType() == OPENING_PARENTHESIS;
+        if (!(previousChild instanceof Block)) {
+            return false;
+        }
+
+        ASTNode previousNode = ((Block) previousChild).myNode;
+        IElementType previousElementType = previousNode.getElementType();
+
+        if (previousElementType == OPENING_PARENTHESIS) {
+            return true;
+        }
+
+        return previousElementType == COMMA &&
+                previousNode.getTreeParent() != null &&
+                previousNode.getTreeParent().getElementType() == PARENTHESES_ARGUMENTS;
     }
 
     /**

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -62,6 +62,25 @@ public class Block extends AbstractBlock implements BlockEx {
             MATCHED_COMPARISON_OPERATION,
             UNMATCHED_COMPARISON_OPERATION
     );
+    /** The rules a delimiter's container is reached through: a container groups its pairs under a node of its own. */
+    private static final TokenSet DELIMITER_GROUPING_TOKEN_SET = TokenSet.create(
+            ASSOCIATIONS,
+            ASSOCIATIONS_BASE,
+            KEYWORDS,
+            MAP_CONSTRUCTION_ARGUMENTS
+    );
+    /**
+     * The tokens that punctuate a container: the delimiter it opens with, and the commas and {@code ->} between its
+     * elements.
+     */
+    private static final TokenSet DELIMITER_TOKEN_SET = TokenSet.create(
+            COMMA,
+            OPENING_BIT,
+            OPENING_BRACKET,
+            OPENING_CURLY,
+            OPENING_PARENTHESIS,
+            STAB_OPERATOR
+    );
     private static final TokenSet HEREDOC_LINE_TOKEN_SET = TokenSet.create(
             HEREDOC_LINE,
             INTERPOLATED_HEREDOC_LINE,
@@ -124,6 +143,16 @@ public class Block extends AbstractBlock implements BlockEx {
             UNMATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL
     );
     private static final TokenSet NO_PARENTHESES_KEYWORD_PAIR_TOKEN_SET = TokenSet.create(NO_PARENTHESES_KEYWORD_PAIR);
+    /** The containers whose elements sit one indent in from the line the container starts on. */
+    private static final TokenSet NORMAL_INDENT_CONTAINER_TOKEN_SET = TokenSet.create(
+            BIT_STRING,
+            BLOCK_IDENTIFIER,
+            LIST,
+            MAP_ARGUMENTS,
+            MULTIPLE_ALIASES,
+            STAB_INFIX_OPERATOR,
+            TUPLE
+    );
     private static final TokenSet OPERATION_TOKEN_SET = TokenSet.orSet(
             TokenSet.create(
                     MATCHED_ADDITION_OPERATION,
@@ -2192,13 +2221,11 @@ public class Block extends AbstractBlock implements BlockEx {
         IElementType elementType = myNode.getElementType();
 
         if (newChildIndex > 0) {
-           childAttributes = precededByArgumentDelimiter(newChildIndex) ?
-                   /* Delegating would hand the platform a delimiter as the block to indent against, and both the
-                      opening parenthesis and the commas are built without an indent of their own, so it would fall
-                      back to the enclosing statement. Indent against this call instead, so the caret lands where an
-                      argument would. */
-                   new ChildAttributes(Indent.getNormalIndent(true), null) :
-                   DELEGATE_TO_PREV_CHILD;
+            Indent afterDelimiterIndent = indentAfterDelimiter(newChildIndex);
+
+            childAttributes = afterDelimiterIndent != null ?
+                    new ChildAttributes(afterDelimiterIndent, null) :
+                    DELEGATE_TO_PREV_CHILD;
         } else if (elementType == DO) {
             boolean indentRelativeToDirectParent =
                     codeStyleSettings(myNode).ALIGN_UNMATCHED_CALL_DO_BLOCKS ==
@@ -2218,36 +2245,93 @@ public class Block extends AbstractBlock implements BlockEx {
     }
 
     /**
-     * Whether the caret follows one of the tokens punctuating a parenthesised argument list, which
-     * {@link #buildParenthesesArgumentsChildren} builds without an indent of their own because they sit beside the
-     * argument they punctuate rather than starting a line.
+     * The indent to put the caret at when it follows one of the tokens that punctuate a container - the delimiter it
+     * opens with, a comma between its elements, {@code ->} or a block identifier. All of these are built without an
+     * indent of their own, because they sit beside the element they punctuate rather than starting a line, so
+     * delegating to one indents against nothing and the caret falls back to the enclosing statement.
      *
-     * <p>The comma is recognised by its own parent rather than by this block's element type, because an argument
-     * list's children are flattened into the enclosing call's sub-blocks, so the block being asked is the call.
+     * <p>The delimiter is recognised by its own ancestry rather than by this block's element type, because a
+     * container's children are flattened into the enclosing block's sub-blocks: the block being asked after a comma
+     * in an argument list is the call, not the argument list.
+     *
+     * <p>Every column this produces is the one {@code mix format} puts an element at for the same construct.
+     *
+     * @return the indent to answer the delegation with, or {@code null} to keep delegating. A comma in a call written
+     * without parentheses keeps delegating: {@code mix format} aligns what follows it under the first argument in
+     * {@code with a <- one(),} but indents it in {@code import Foo,}, and which of the two applies is decided by the
+     * argument that has not been typed yet.
      */
-    private boolean precededByArgumentDelimiter(int newChildIndex) {
+    @Nullable
+    private Indent indentAfterDelimiter(int newChildIndex) {
         List<com.intellij.formatting.Block> subBlocks = getSubBlocks();
 
         if (newChildIndex > subBlocks.size()) {
-            return false;
+            return null;
         }
 
         com.intellij.formatting.Block previousChild = subBlocks.get(newChildIndex - 1);
 
         if (!(previousChild instanceof Block)) {
-            return false;
+            return null;
         }
 
         ASTNode previousNode = ((Block) previousChild).myNode;
-        IElementType previousElementType = previousNode.getElementType();
+        ASTNode container = previousNode.getTreeParent();
 
-        if (previousElementType == OPENING_PARENTHESIS) {
-            return true;
+        if (container == null) {
+            return null;
         }
 
-        return previousElementType == COMMA &&
-                previousNode.getTreeParent() != null &&
-                previousNode.getTreeParent().getElementType() == PARENTHESES_ARGUMENTS;
+        // a block identifier is a rule rather than a token, so its keyword is the leaf the caret follows
+        boolean afterDelimiter = DELIMITER_TOKEN_SET.contains(previousNode.getElementType()) ||
+                container.getElementType() == BLOCK_IDENTIFIER;
+
+        if (!afterDelimiter) {
+            return null;
+        }
+
+        while (DELIMITER_GROUPING_TOKEN_SET.contains(container.getElementType())) {
+            container = container.getTreeParent();
+
+            if (container == null) {
+                return null;
+            }
+        }
+
+        return indentInContainer(container.getElementType());
+    }
+
+    /**
+     * The indent an element of {@code containerElementType} written on its own line takes.
+     *
+     * @return {@code null} when the container is not one whose elements indent, such as the argument list of a call
+     * written without parentheses.
+     */
+    @Nullable
+    private Indent indentInContainer(@NotNull IElementType containerElementType) {
+        Indent indent;
+
+        if (containerElementType == PARENTHESES_ARGUMENTS) {
+            /* An argument list wraps to the column of the call it belongs to plus one indent, which is where the
+               answering block starts - except in a dot call, where the argument list is the answering block and
+               already starts at the parenthesis. */
+            indent = myNode.getElementType() == PARENTHESES_ARGUMENTS ?
+                    Indent.getNormalIndent() :
+                    Indent.getNormalIndent(true);
+        } else if (containerElementType == MAP_UPDATE_ARGUMENTS) {
+            // the pipe takes the first indent and the pairs written after it take a second
+            indent = Indent.getSpaceIndent(2 * indentSize());
+        } else if (NORMAL_INDENT_CONTAINER_TOKEN_SET.contains(containerElementType)) {
+            indent = Indent.getNormalIndent();
+        } else {
+            indent = null;
+        }
+
+        return indent;
+    }
+
+    private int indentSize() {
+        return CodeStyle.getIndentOptions(myNode.getPsi().getContainingFile()).INDENT_SIZE;
     }
 
     /**

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -2189,10 +2189,16 @@ public class Block extends AbstractBlock implements BlockEx {
     @Override
     public ChildAttributes getChildAttributes(int newChildIndex) {
         ChildAttributes childAttributes;
+        IElementType elementType = myNode.getElementType();
 
         if (newChildIndex > 0) {
-           childAttributes = DELEGATE_TO_PREV_CHILD;
-        } else if (myNode.getElementType() == DO) {
+           childAttributes = precededByOpeningParenthesis(newChildIndex) ?
+                   /* Delegating would hand the platform the opening parenthesis as the block to indent against,
+                      because empty parentheses have no argument block to delegate to. Indent against this call
+                      instead, so the caret lands where an argument would. */
+                   new ChildAttributes(Indent.getNormalIndent(true), null) :
+                   DELEGATE_TO_PREV_CHILD;
+        } else if (elementType == DO) {
             boolean indentRelativeToDirectParent =
                     codeStyleSettings(myNode).ALIGN_UNMATCHED_CALL_DO_BLOCKS ==
                             CodeStyleSettings.UnmatchedCallDoBlockAlignment.CALL.value;
@@ -2208,6 +2214,19 @@ public class Block extends AbstractBlock implements BlockEx {
         }
 
         return childAttributes;
+    }
+
+    private boolean precededByOpeningParenthesis(int newChildIndex) {
+        List<com.intellij.formatting.Block> subBlocks = getSubBlocks();
+
+        if (newChildIndex > subBlocks.size()) {
+            return false;
+        }
+
+        com.intellij.formatting.Block previousChild = subBlocks.get(newChildIndex - 1);
+
+        return previousChild instanceof Block &&
+                ((Block) previousChild).myNode.getElementType() == OPENING_PARENTHESIS;
     }
 
     /**

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_caret_returns.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_caret_returns.ex
@@ -1,0 +1,7 @@
+defmodule ParameterInfo.AutoPopupCaretReturns do
+  def run do
+    add(<caret>)
+  end
+
+  def add(augend, addend), do: augend + addend
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_comma.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_comma.ex
@@ -1,0 +1,7 @@
+defmodule ParameterInfo.AutoPopupComma do
+  def run do
+    add(1<caret>)
+  end
+
+  def add(augend, addend), do: augend + addend
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_completion.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_completion.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.AutoPopupCompletion do
+  def run do
+    ParameterInfo.CompletionRemote.red<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_completion_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_completion_declaration.ex
@@ -1,0 +1,4 @@
+defmodule ParameterInfo.CompletionRemote do
+  def reduce(enumerable, fun), do: {enumerable, fun}
+  def reduce_while(enumerable, acc, fun), do: {enumerable, acc, fun}
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_many_arities_comma.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_many_arities_comma.ex
@@ -1,0 +1,9 @@
+defmodule ParameterInfo.AutoPopupManyAritiesComma do
+  def run do
+    reduce(1<caret>)
+  end
+
+  def reduce(enumerable, fun), do: {enumerable, fun}
+  def reduce(enumerable, acc, fun), do: {enumerable, acc, fun}
+  def reduce(enumerable, acc, transform, fun), do: {enumerable, acc, transform, fun}
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_many_arities_opening_parenthesis.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_many_arities_opening_parenthesis.ex
@@ -1,0 +1,9 @@
+defmodule ParameterInfo.AutoPopupManyAritiesOpeningParenthesis do
+  def run do
+    reduce<caret>
+  end
+
+  def reduce(enumerable, fun), do: {enumerable, fun}
+  def reduce(enumerable, acc, fun), do: {enumerable, acc, fun}
+  def reduce(enumerable, acc, transform, fun), do: {enumerable, acc, transform, fun}
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_opening_parenthesis.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_opening_parenthesis.ex
@@ -1,0 +1,7 @@
+defmodule ParameterInfo.AutoPopupOpeningParenthesis do
+  def run do
+    add<caret>
+  end
+
+  def add(augend, addend), do: augend + addend
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_remote_comma.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_remote_comma.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.AutoPopupRemoteComma do
+  def run do
+    ParameterInfo.Remote.reduce(1<caret>)
+  end
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_remote_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_remote_declaration.ex
@@ -1,0 +1,4 @@
+defmodule ParameterInfo.Remote do
+  def reduce(enumerable, fun), do: {enumerable, fun}
+  def reduce(enumerable, acc, fun), do: {enumerable, acc, fun}
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_remote_opening_parenthesis.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/auto_popup_remote_opening_parenthesis.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.AutoPopupRemoteOpeningParenthesis do
+  def run do
+    ParameterInfo.Remote.reduce<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/prefix_match_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/prefix_match_declaration.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.PrefixMatchDeclaration do
+  def reduce(enumerable, fun), do: {enumerable, fun}
+  def reduce(enumerable, acc, fun), do: {enumerable, acc, fun}
+  def reduce_while(enumerable, acc, fun), do: {enumerable, acc, fun}
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/prefix_match_usage.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/prefix_match_usage.ex
@@ -1,0 +1,5 @@
+defmodule ParameterInfo.PrefixMatchUsage do
+  alias ParameterInfo.PrefixMatchDeclaration
+
+  PrefixMatchDeclaration.reduce(<caret>)
+end

--- a/testData/org/elixir_lang/code_insight/parameter_info/trailing_comma_local_call.ex
+++ b/testData/org/elixir_lang/code_insight/parameter_info/trailing_comma_local_call.ex
@@ -1,0 +1,7 @@
+defmodule ParameterInfo.TrailingCommaLocalCall do
+  def run do
+    add(1,<caret>)
+  end
+
+  def add(augend, addend), do: augend + addend
+end

--- a/tests/org/elixir_lang/code_insight/BehaviouralGestures.kt
+++ b/tests/org/elixir_lang/code_insight/BehaviouralGestures.kt
@@ -2,7 +2,11 @@
 
 package org.elixir_lang.code_insight
 
+import com.intellij.codeInsight.CodeInsightSettings
 import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.impl.LookupImpl
+import com.intellij.codeInsight.hint.ParameterInfoControllerBase
+import com.intellij.codeInsight.hint.ParameterInfoListener
 import com.intellij.find.usages.api.PsiUsage
 import com.intellij.find.usages.api.SearchTarget
 import com.intellij.find.usages.api.UsageOptions
@@ -21,6 +25,8 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiUtilBase
+import com.intellij.testFramework.AutoPopupParameterInfoTestUtil
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
@@ -397,3 +403,149 @@ fun CodeInsightTestFixture.renameTargetsAtCaret(): List<RenameTarget> =
 @Suppress("UnstableApiUsage")
 private fun CodeInsightTestFixture.symbolResolutionFile(project: Project): PsiFile =
     PsiUtilBase.getPsiFileInEditor(editor, project) ?: file
+
+
+
+/**
+ * What the parameter-info popup holds once the IDE has decided to show one: one entry per signature
+ * offered, and which parameter the caret is on.
+ *
+ * A `null` [ParameterInfoPopup] means the IDE never got as far as building a popup at all - the outcome
+ * these gestures exist to tell apart from "the IDE offered me a choice".
+ */
+data class ParameterInfoPopup(val signatures: List<String>, val currentParameterIndex: Int)
+
+/**
+ * Runs [gesture] and returns the parameter-info popup the IDE builds in response, or `null` when it
+ * builds none.
+ *
+ * WHAT THIS CAN AND CANNOT SEE. It cannot see the popup on screen: a headless fixture paints no Swing, so
+ * `ParameterInfoControllerBase.existsWithVisibleHintForEditor` is `false` even for a gesture that
+ * unquestionably shows a hint in a real IDE - measured, not assumed. What it observes instead is that the
+ * platform built and populated a `ParameterInfoController` for the editor, the last step before
+ * `HintManagerImpl.showEditorHint`. A sandbox trace of these same gestures confirmed that remaining step
+ * follows within milliseconds whenever a controller is built, so this is a faithful proxy for the
+ * *decision* to show a hint - but it is a proxy, and a regression that suppressed only the final paint
+ * would not be caught here.
+ *
+ * Both halves are needed, because neither alone is honest. `ParameterInfoListener.hintUpdated` carries the
+ * signatures, but `ParameterInfoController` fires it under `|| isHeadlessEnvironment()`, which
+ * short-circuits the very visibility check the listener is otherwise gated on - so on its own it reports
+ * models the user would never see. `existsForEditor` says a controller was built but not what is in it.
+ *
+ * WHY NOT [org.elixir_lang.code_insight.ParameterInfo] DIRECTLY: the handler-level tests in
+ * `ParameterInfoTest` drive `findElementForParameterInfo`/`showParameterInfo` against a
+ * `MockCreateParameterInfoContext`, whose `showHint` is a no-op. That pins which signatures the handler
+ * *resolves*, a different question from whether the IDE shows anything: the handler resolves the same
+ * signature whether the caret arrived by typing, by accepting a completion, or by being moved back, and
+ * only one of those asks for a popup. The asking happens upstream of the handler - the platform's typed
+ * handler does it for `(` and `,`, and a completion insert handler must do it for an accepted lookup - so
+ * only the real chain tells them apart.
+ *
+ * The chain is asynchronous by design - an alarm, then a pooled-thread read action, then
+ * `performLaterWhenAllCommitted` - so the delay is set to zero and the event queue pumped until the
+ * controller reports. A gesture that asks for no popup never reports, so the wait running out is an
+ * expected outcome rather than a failure, and costs [POPUP_TIMEOUT_SECONDS].
+ */
+fun CodeInsightTestFixture.parameterInfoPopupAfter(gesture: CodeInsightTestFixture.() -> Unit): ParameterInfoPopup? {
+    val settings = CodeInsightSettings.getInstance()
+    val autoPopupWas = settings.AUTO_POPUP_PARAMETER_INFO
+    val delayWas = settings.PARAMETER_INFO_DELAY
+
+    val model = arrayOfNulls<ParameterInfoPopup>(1)
+    val reported = booleanArrayOf(false)
+
+    val listener = object : ParameterInfoListener {
+        override fun hintUpdated(result: ParameterInfoControllerBase.Model) {
+            model[0] = ParameterInfoPopup(
+                result.signatures.map { signature ->
+                    (signature as? ParameterInfoControllerBase.SignatureItem)?.text ?: signature.toString()
+                },
+                result.current
+            )
+            reported[0] = true
+        }
+
+        override fun hintHidden(project: Project) {
+            reported[0] = true
+        }
+    }
+
+    ParameterInfoListener.EP_NAME.point.registerExtension(listener, testRootDisposable)
+
+    try {
+        settings.AUTO_POPUP_PARAMETER_INFO = true
+        settings.PARAMETER_INFO_DELAY = 0
+
+        gesture()
+
+        /* Each stage is waited on with the platform's own helper where one exists, and the queue pumped
+           between them: `AutoPopupParameterInfoTestUtil` alone returns before the hint is built, because
+           the `performLaterWhenAllCommitted` between the alarm and the controller needs the queue pumped
+           to run at all - measured, every case reported nothing without it. */
+        AutoPopupParameterInfoTestUtil.waitForAutoPopup(project)
+
+        try {
+            PlatformTestUtil.waitWithEventsDispatching("", { reported[0] }, POPUP_TIMEOUT_SECONDS)
+        } catch (ignored: AssertionError) {
+            // a gesture that asks for no popup never reports, which is an outcome rather than a failure
+        }
+
+        AutoPopupParameterInfoTestUtil.waitForParameterInfoUpdate(editor)
+    } finally {
+        settings.AUTO_POPUP_PARAMETER_INFO = autoPopupWas
+        settings.PARAMETER_INFO_DELAY = delayWas
+    }
+
+    return if (ParameterInfoControllerBase.existsForEditor(editor)) model[0] else null
+}
+
+private const val POPUP_TIMEOUT_SECONDS = 5
+
+/** Types [charTyped] at the caret, as the user typing an opening parenthesis or a comma does. */
+fun CodeInsightTestFixture.parameterInfoPopupAfterTyping(charTyped: Char): ParameterInfoPopup? =
+    parameterInfoPopupAfter { type(charTyped) }
+
+/**
+ * Accepts the completion candidate named [lookupString] with [completionChar], the way a user finishes a
+ * name from the lookup rather than typing it out.
+ *
+ * The lookup is finished directly rather than by typing the character, because that is what the editor
+ * does: an open lookup consumes the keystroke, so `TypedHandler` - and with it the platform's own
+ * `(`-and-`,` auto-popup - never runs. Typing the character into the fixture instead reaches
+ * `TypedHandler` and quietly exercises the path that already works, which is the difference between a
+ * test that catches this and one that does not.
+ *
+ * The candidate is selected explicitly rather than relying on the lookup's ordering, so the test pins the
+ * popup rather than which candidate happened to sort first. The fixture must offer more than one
+ * candidate, or the lookup auto-inserts and there is nothing to accept.
+ */
+fun CodeInsightTestFixture.parameterInfoPopupAfterAcceptingCompletion(
+    lookupString: String,
+    completionChar: Char = '\t'
+): ParameterInfoPopup? = parameterInfoPopupAfter {
+    val candidates = completeBasic()
+        ?: throw AssertionError("Expected a completion lookup to open, but a single candidate was auto-inserted")
+    val candidate = candidates.firstOrNull { it.lookupString == lookupString }
+        ?: throw AssertionError(
+            "Expected a '$lookupString' completion candidate, got ${candidates.map { it.lookupString }}"
+        )
+
+    (lookup as LookupImpl).currentItem = candidate
+
+    finishLookup(completionChar)
+}
+
+/**
+ * Moves the caret out of the argument list and back to where it started, the way a user who looked
+ * elsewhere and returned does. Nothing is typed, so nothing asks the platform for a popup.
+ */
+fun CodeInsightTestFixture.parameterInfoPopupAfterLeavingAndReturning(): ParameterInfoPopup? {
+    val argumentOffset = caretOffset
+
+    return parameterInfoPopupAfter {
+        editor.caretModel.moveToOffset(0)
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+        editor.caretModel.moveToOffset(argumentOffset)
+    }
+}

--- a/tests/org/elixir_lang/code_insight/ParameterInfoAutoPopupTest.kt
+++ b/tests/org/elixir_lang/code_insight/ParameterInfoAutoPopupTest.kt
@@ -1,0 +1,118 @@
+package org.elixir_lang.code_insight
+
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * The parameter-info popup as the user meets it: typed into, and appearing on its own or not.
+ *
+ * [ParameterInfoTest] pins which signatures the handler resolves, against a context whose `showHint` is a
+ * no-op. That is a different question from whether anything is shown - the handler resolves the same
+ * signature for `add(<caret>)` and `add(1,<caret>)`, yet only one of the two puts a popup on screen. These
+ * tests drive the real typed-handler chain through [parameterInfoPopupAfterTyping] and assert on what
+ * appears.
+ */
+class ParameterInfoAutoPopupTest : PlatformTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/code_insight/parameter_info"
+
+    /** Typing the comma that begins the next argument pops the hint up. This is what #3934 restored. */
+    fun testCommaPopsUpTheHint() {
+        myFixture.configureByFile("auto_popup_comma.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterTyping(',')
+
+        assertNotNull("Typing a comma should pop up the parameter hint", popup)
+        assertEquals(listOf("augend, addend"), popup!!.signatures)
+        assertEquals("The caret is on the second parameter", 1, popup.currentParameterIndex)
+    }
+
+    /**
+     * Typing the opening parenthesis should pop the hint up on the first parameter, the same way the comma
+     * does on the second - the platform's typed handler auto-popups for `(` and `,` alike.
+     */
+    fun testOpeningParenthesisPopsUpTheHint() {
+        myFixture.configureByFile("auto_popup_opening_parenthesis.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterTyping('(')
+
+        assertNotNull("Typing an opening parenthesis should pop up the parameter hint", popup)
+        assertEquals(listOf("augend, addend"), popup!!.signatures)
+        assertEquals("The caret is on the first parameter", 0, popup.currentParameterIndex)
+    }
+
+    /** Several arities means several signatures, which is the shape `Enum.reduce` presents. */
+    fun testCommaPopsUpTheHintWithSeveralSignatures() {
+        myFixture.configureByFile("auto_popup_many_arities_comma.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterTyping(',')
+
+        assertNotNull("Typing a comma should pop up the parameter hint", popup)
+        assertEquals(3, popup!!.signatures.size)
+        assertEquals(1, popup.currentParameterIndex)
+    }
+
+    fun testOpeningParenthesisPopsUpTheHintWithSeveralSignatures() {
+        myFixture.configureByFile("auto_popup_many_arities_opening_parenthesis.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterTyping('(')
+
+        assertNotNull("Typing an opening parenthesis should pop up the parameter hint", popup)
+        assertEquals(3, popup!!.signatures.size)
+        assertEquals(0, popup.currentParameterIndex)
+    }
+
+    /** A call resolved from another file, which is the shape a call into a dependency or the SDK takes. */
+    fun testCommaPopsUpTheHintForACallResolvedInAnotherFile() {
+        myFixture.configureByFiles("auto_popup_remote_comma.ex", "auto_popup_remote_declaration.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterTyping(',')
+
+        assertNotNull("Typing a comma should pop up the parameter hint", popup)
+        assertEquals(2, popup!!.signatures.size)
+        assertEquals(1, popup.currentParameterIndex)
+    }
+
+    fun testOpeningParenthesisPopsUpTheHintForACallResolvedInAnotherFile() {
+        myFixture.configureByFiles("auto_popup_remote_opening_parenthesis.ex", "auto_popup_remote_declaration.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterTyping('(')
+
+        assertNotNull("Typing an opening parenthesis should pop up the parameter hint", popup)
+        assertEquals(2, popup!!.signatures.size)
+        assertEquals(0, popup.currentParameterIndex)
+    }
+
+    /**
+     * Accepting a completion leaves the caret inside the parentheses the insert handler added, and the hint
+     * appears there without the user typing `(` themselves.
+     */
+    fun testAcceptingACompletionPopsUpTheHint() {
+        myFixture.configureByFiles("auto_popup_completion.ex", "auto_popup_completion_declaration.ex")
+
+        val popup = myFixture.parameterInfoPopupAfterAcceptingCompletion("reduce")
+
+        assertEquals(
+            "The insert handler puts the caret where the first argument goes",
+            "ParameterInfo.CompletionRemote.reduce()",
+            myFixture.file.text.lines().first { it.contains("reduce(") }.trim()
+        )
+        assertNotNull("Accepting a completion should pop up the parameter hint", popup)
+        /* `reduce_while` is not offered: the references resolve as incomplete code, which returns every
+           function the name is a prefix of, and only the function being called is kept. */
+        assertEquals(listOf("enumerable, fun"), popup!!.signatures)
+        assertEquals("The caret is on the first parameter", 0, popup.currentParameterIndex)
+    }
+
+    /**
+     * Leaving the argument list and coming back shows nothing. Pinned as the platform's own behaviour, not
+     * as a defect: no character is typed, so nothing asks for a popup, and Java does the same - the hint is
+     * recalled with Ctrl+P.
+     */
+    fun testReturningToTheArgumentListShowsNothing() {
+        myFixture.configureByFile("auto_popup_caret_returns.ex")
+
+        assertNull(
+            "Returning the caret to an argument list should not pop the hint up on its own",
+            myFixture.parameterInfoPopupAfterLeavingAndReturning()
+        )
+    }
+}

--- a/tests/org/elixir_lang/code_insight/ParameterInfoTest.java
+++ b/tests/org/elixir_lang/code_insight/ParameterInfoTest.java
@@ -123,6 +123,31 @@ public class ParameterInfoTest extends PlatformTestCase {
     }
 
     /**
+     * A function whose name another function's name starts with is not described by it.  References are
+     * resolved as incomplete code - which is what lets a call resolve before its arguments are typed, and
+     * so is exactly the state parameter info is wanted in - and that resolves every prefix match too, so
+     * {@code reduce} was described by {@code reduce_while} as well as by its own two arities.
+     */
+    public void testPrefixMatchedFunctionIsNotOffered() {
+        myFixture.configureByFiles("prefix_match_usage.ex", "prefix_match_declaration.ex");
+
+        ParameterInfo handler = new ParameterInfo();
+        CreateParameterInfoContext context = new MockCreateParameterInfoContext(myFixture.getEditor(), myFixture.getFile());
+        Arguments args = handler.findElementForParameterInfo(context);
+
+        assertNotNull("Should find Arguments element at caret", args);
+
+        handler.showParameterInfo(args, context);
+        Object[] items = context.getItemsToShow();
+
+        assertNotNull("Should have parameter info items", items);
+
+        List<String> paramTexts = renderedParameterTexts(handler, args, items);
+        assertEquals("Only reduce's own arities should be offered, got: " + paramTexts,
+                List.of("enumerable, fun", "enumerable, acc, fun"), paramTexts);
+    }
+
+    /**
      * Renders every parameter-info item as its user-visible parameter text (as {@code updateUI}
      * would present in the popup) with the caret on the first parameter.
      *

--- a/tests/org/elixir_lang/code_insight/ParameterInfoTest.java
+++ b/tests/org/elixir_lang/code_insight/ParameterInfoTest.java
@@ -99,6 +99,30 @@ public class ParameterInfoTest extends PlatformTestCase {
     }
 
     /**
+     * Parameter hints are wanted exactly after the comma that begins the next argument, and that is
+     * the moment the source is momentarily invalid.  The malformed argument list used to take the
+     * enclosing definition with it, leaving no Arguments ancestor for the caret to sit in.
+     */
+    public void testTrailingCommaKeepsHint() {
+        myFixture.configureByFile("trailing_comma_local_call.ex");
+
+        ParameterInfo handler = new ParameterInfo();
+        CreateParameterInfoContext context = new MockCreateParameterInfoContext(myFixture.getEditor(), myFixture.getFile());
+        Arguments args = handler.findElementForParameterInfo(context);
+
+        assertNotNull("Should find Arguments element at caret after a trailing comma", args);
+
+        handler.showParameterInfo(args, context);
+        Object[] items = context.getItemsToShow();
+
+        assertNotNull("Should have parameter info items", items);
+
+        List<String> paramTexts = renderedParameterTexts(handler, args, items);
+        assertEquals("A trailing comma should not change which signature is shown, got: " + paramTexts,
+                List.of("augend, addend"), paramTexts);
+    }
+
+    /**
      * Renders every parameter-info item as its user-visible parameter text (as {@code updateUI}
      * would present in the popup) with the caret on the first parameter.
      *

--- a/tests/org/elixir_lang/formatter/ClauseIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ClauseIndentTest.kt
@@ -1,0 +1,64 @@
+package org.elixir_lang.formatter
+
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Pressing Enter after `->` or after a block identifier puts the caret where the clause body goes. Expected columns are
+ * the ones `mix format` produces for the same construct.
+ *
+ * Both are built without an indent of their own, so delegating the caret to them indents against nothing and falls back
+ * to the enclosing statement - the same defect [ContainerElementIndentTest] pins for a container's delimiters.
+ *
+ * These go through the platform's Enter handler rather than a reformat, so [org.elixir_lang.FormattingTest]'s
+ * reformat-based fixtures cannot cover them.
+ */
+class ClauseIndentTest : PlatformTestCase() {
+    private fun assertCaretColumnAfterEnter(code: String, expectedColumn: Int) {
+        myFixture.configureByText("a.ex", code)
+
+        myFixture.type('\n')
+
+        assertEquals(expectedColumn, myFixture.editor.caretModel.logicalPosition.column)
+    }
+
+    private fun inRun(body: String) = "defmodule M do\n  def run do\n$body\n  end\nend\n"
+
+    fun testAfterStabOperatorInCase() =
+        assertCaretColumnAfterEnter(inRun("    case one do\n      :a -><caret>\n        one\n    end"), 8)
+
+    fun testAfterStabOperatorInCond() =
+        assertCaretColumnAfterEnter(inRun("    cond do\n      one -><caret>\n        two\n    end"), 8)
+
+    fun testAfterStabOperatorInReceive() =
+        assertCaretColumnAfterEnter(inRun("    receive do\n      :a -><caret>\n        one\n    end"), 8)
+
+    fun testAfterStabOperatorInAnonymousFunctionWithMultipleClauses() =
+        assertCaretColumnAfterEnter(inRun("    fn\n      :a -><caret>\n        one\n    end"), 8)
+
+    fun testAfterStabOperatorInInlineAnonymousFunction() =
+        assertCaretColumnAfterEnter(inRun("    _f = fn a -><caret>\n      a\n    end"), 6)
+
+    fun testAfterStabOperatorInRescue() =
+        assertCaretColumnAfterEnter(
+            inRun("    try do\n      one\n    rescue\n      e -><caret>\n        two\n    end"),
+            8
+        )
+
+    fun testAfterRescue() =
+        assertCaretColumnAfterEnter(inRun("    try do\n      one\n    rescue<caret>\n      e ->\n        two\n    end"), 6)
+
+    fun testAfterAfter() =
+        assertCaretColumnAfterEnter(inRun("    try do\n      one\n    after<caret>\n      two\n    end"), 6)
+
+    fun testAfterElse() =
+        assertCaretColumnAfterEnter(
+            inRun("    try do\n      one\n    else<caret>\n      :ok ->\n        two\n    end"),
+            6
+        )
+
+    fun testAfterCatch() =
+        assertCaretColumnAfterEnter(
+            inRun("    try do\n      one\n    catch<caret>\n      :exit, _ ->\n        two\n    end"),
+            6
+        )
+}

--- a/tests/org/elixir_lang/formatter/ContainerElementIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ContainerElementIndentTest.kt
@@ -1,5 +1,7 @@
 package org.elixir_lang.formatter
 
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager
+import org.elixir_lang.ElixirFileType
 import org.elixir_lang.PlatformTestCase
 
 /**
@@ -79,6 +81,22 @@ class ContainerElementIndentTest : PlatformTestCase() {
     fun testAfterCommaBetweenMapUpdateAssociations() =
         assertCaretColumnAfterEnter(inRun("    _updated = %{\n      map\n      | :a => 1,<caret>\n    }"), 8)
 
+    /** The pipe's own column moves with nesting, and the pairs stay one indent in from it. */
+    fun testAfterCommaBetweenMapUpdateKeywordPairsNestedInAList() =
+        assertCaretColumnAfterEnter(
+            inRun("    _l = [\n      %{\n        map\n        | one: 1,<caret>\n      }\n    ]"),
+            10
+        )
+
+    /** Written as the value of an outer update, the inner map begins on a continuation line, not its own. */
+    fun testAfterCommaBetweenMapUpdateKeywordPairsNestedInAMapUpdate() =
+        assertCaretColumnAfterEnter(
+            inRun(
+                "    _deep = %{\n      outer\n      | inner: %{\n          map\n          | one: 1,<caret>\n        }\n    }"
+            ),
+            12
+        )
+
     /** A call nested in a list indents from the call, which the parentheses fix already gets right. */
     fun testAfterCommaInCallNestedInList() =
         assertCaretColumnAfterEnter(inRun("    _l = [\n      some_call(\n        one,<caret>\n      )\n    ]"), 8)
@@ -89,5 +107,55 @@ class ContainerElementIndentTest : PlatformTestCase() {
             8
         )
 
+    /**
+     * `mix format` indents a container's elements from the line the container starts on, so a longer name
+     * before it moves nothing. Confirmed by running `mix format` over both widths.
+     */
+    fun testListElementColumnDoesNotVaryWithTheNameBeforeIt() {
+        assertCaretColumnAfterEnter(inRun("    _l = [\n      one,<caret>\n    ]"), 6)
+        assertCaretColumnAfterEnter(inRun("    _a_much_longer_variable_name = [\n      one,<caret>\n    ]"), 6)
+    }
+
+    fun testMapUpdatePairColumnDoesNotVaryWithTheNameBeforeIt() {
+        assertCaretColumnAfterEnter(inRun("    _u = %{\n      map\n      | one: 1,<caret>\n    }"), 8)
+        assertCaretColumnAfterEnter(
+            inRun("    _another_much_longer_name = %{\n      map\n      | one: 1,<caret>\n    }"),
+            8
+        )
+    }
+
     fun testDoBlockBody() = assertCaretColumnAfterEnter("defmodule M do\n  def run do<caret>\n  end\nend\n", 4)
+
+    /**
+     * `mix format` only ever indents with spaces, so the column here is not one it produces: it is the column
+     * [testAfterCommaBetweenMapUpdateKeywordPairs] expects for the same construct, written with a tab per indent
+     * because `Use tab character` is a code style option a user can turn on for Elixir.
+     *
+     * A tab is worth however many columns it takes to reach the next tab stop, so the pipe's column and the indent it
+     * is measured against are read as columns rather than as counts of characters.  Counting characters puts the caret
+     * a column short of the pairs above it.
+     */
+    fun testAfterCommaBetweenMapUpdateKeywordPairsIndentedWithTabs() = withTabIndents {
+        assertCaretColumnAfterEnter("defmodule M do\n\tdef run do\n\t\t_u = %{\n\t\t\tmap\n\t\t\t| one: 1,<caret>\n\t\t}\n\tend\nend\n", 8)
+    }
+
+    private fun withTabIndents(body: () -> Unit) {
+        val settingsManager = CodeStyleSettingsManager.getInstance(project)
+        val settings = settingsManager.currentSettings.clone()
+
+        settings.getIndentOptions(ElixirFileType.INSTANCE).apply {
+            USE_TAB_CHARACTER = true
+            SMART_TABS = false
+            TAB_SIZE = 2
+            INDENT_SIZE = 2
+        }
+
+        settingsManager.setTemporarySettings(settings)
+
+        try {
+            body()
+        } finally {
+            settingsManager.dropTemporarySettings()
+        }
+    }
 }

--- a/tests/org/elixir_lang/formatter/ContainerElementIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ContainerElementIndentTest.kt
@@ -3,17 +3,12 @@ package org.elixir_lang.formatter
 import org.elixir_lang.PlatformTestCase
 
 /**
- * Pressing Enter inside a container puts the caret where an element goes. Expected columns are the ones `mix format`
- * produces for the same construct.
+ * Pressing Enter inside a container puts the caret where an element goes, whether it follows an element or one of the
+ * tokens punctuating the container. Expected columns are the ones `mix format` produces for the same construct.
  *
- * Pinned here is the case that works: after an element, delegating to that element's block inherits a real indent.
- * After a delimiter it does not, and that is fixed for parentheses only - see [ParenthesesArgumentsIndentTest]. Lists,
- * tuples, maps, structs, bit strings, keyword lists, multiple aliases and map updates still put the caret at the
- * enclosing statement instead of the element column.
- *
- * Two fixes for those have been measured and rejected: `Indent.getNormalIndent(true)` resolves against the answering
- * block's own first leaf, which for `_list = [` is the `[` rather than the line, and giving the delimiters an indent
- * where they are built changes reformatting and breaks ten [org.elixir_lang.FormattingTest] fixtures.
+ * A delimiter is built without an indent of its own, so delegating the caret to it indents against nothing and falls
+ * back to the enclosing statement. [org.elixir_lang.formatter.Block.getChildAttributes] answers those positions with
+ * the element's own indent instead.
  *
  * These go through the platform's Enter handler rather than a reformat, so [org.elixir_lang.FormattingTest]'s
  * reformat-based fixtures cannot cover them.
@@ -35,9 +30,64 @@ class ContainerElementIndentTest : PlatformTestCase() {
     fun testAfterElementInCall() =
         assertCaretColumnAfterEnter(inRun("    some_call(\n      one<caret>\n    )"), 6)
 
+    fun testAfterOpeningBracket() =
+        assertCaretColumnAfterEnter(inRun("    _list = [<caret>\n      one\n    ]"), 6)
+
+    fun testAfterCommaInList() =
+        assertCaretColumnAfterEnter(inRun("    _list = [\n      one,<caret>\n    ]"), 6)
+
+    fun testAfterCommaInKeywordList() =
+        assertCaretColumnAfterEnter(inRun("    _list = [\n      a: 1,<caret>\n      b: 2\n    ]"), 6)
+
+    fun testAfterOpeningCurlyOfTuple() =
+        assertCaretColumnAfterEnter(inRun("    _tuple = {<caret>\n      one\n    }"), 6)
+
+    fun testAfterCommaInTuple() =
+        assertCaretColumnAfterEnter(inRun("    _tuple = {\n      one,<caret>\n    }"), 6)
+
+    fun testAfterOpeningCurlyOfMap() =
+        assertCaretColumnAfterEnter(inRun("    _map = %{<caret>\n      one: 1\n    }"), 6)
+
+    fun testAfterCommaBetweenMapKeywordPairs() =
+        assertCaretColumnAfterEnter(inRun("    _map = %{\n      one: 1,<caret>\n    }"), 6)
+
+    fun testAfterCommaBetweenMapAssociations() =
+        assertCaretColumnAfterEnter(inRun("    _map = %{\n      :a => 1,<caret>\n      :b => 2\n    }"), 6)
+
+    fun testAfterOpeningCurlyOfStruct() =
+        assertCaretColumnAfterEnter(inRun("    _struct = %S{<caret>\n      one: 1\n    }"), 6)
+
+    fun testAfterCommaInStruct() =
+        assertCaretColumnAfterEnter(inRun("    _struct = %S{\n      one: 1,<caret>\n    }"), 6)
+
+    fun testAfterOpeningBit() =
+        assertCaretColumnAfterEnter(inRun("    _bits = <<<caret>\n      one\n    >>"), 6)
+
+    fun testAfterCommaInBitString() =
+        assertCaretColumnAfterEnter(inRun("    _bits = <<\n      one,<caret>\n    >>"), 6)
+
+    fun testAfterOpeningCurlyOfMultipleAliases() =
+        assertCaretColumnAfterEnter("defmodule M do\n  alias Foo.{<caret>\n    Bar\n  }\nend\n", 4)
+
+    fun testAfterCommaInMultipleAliases() =
+        assertCaretColumnAfterEnter("defmodule M do\n  alias Foo.{\n    Bar,<caret>\n  }\nend\n", 4)
+
+    /** The pipe takes the first indent, so the pairs written after it take a second. */
+    fun testAfterCommaBetweenMapUpdateKeywordPairs() =
+        assertCaretColumnAfterEnter(inRun("    _updated = %{\n      map\n      | one: 1,<caret>\n    }"), 8)
+
+    fun testAfterCommaBetweenMapUpdateAssociations() =
+        assertCaretColumnAfterEnter(inRun("    _updated = %{\n      map\n      | :a => 1,<caret>\n    }"), 8)
+
     /** A call nested in a list indents from the call, which the parentheses fix already gets right. */
     fun testAfterCommaInCallNestedInList() =
         assertCaretColumnAfterEnter(inRun("    _l = [\n      some_call(\n        one,<caret>\n      )\n    ]"), 8)
+
+    fun testAfterCommaInListNestedInCall() =
+        assertCaretColumnAfterEnter(
+            inRun("    nested_call(\n      one,\n      [\n        two,<caret>\n      ]\n    )"),
+            8
+        )
 
     fun testDoBlockBody() = assertCaretColumnAfterEnter("defmodule M do\n  def run do<caret>\n  end\nend\n", 4)
 }

--- a/tests/org/elixir_lang/formatter/ContainerElementIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ContainerElementIndentTest.kt
@@ -1,0 +1,43 @@
+package org.elixir_lang.formatter
+
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Pressing Enter inside a container puts the caret where an element goes. Expected columns are the ones `mix format`
+ * produces for the same construct.
+ *
+ * Pinned here is the case that works: after an element, delegating to that element's block inherits a real indent.
+ * After a delimiter it does not, and that is fixed for parentheses only - see [ParenthesesArgumentsIndentTest]. Lists,
+ * tuples, maps, structs, bit strings, keyword lists, multiple aliases and map updates still put the caret at the
+ * enclosing statement instead of the element column.
+ *
+ * Two fixes for those have been measured and rejected: `Indent.getNormalIndent(true)` resolves against the answering
+ * block's own first leaf, which for `_list = [` is the `[` rather than the line, and giving the delimiters an indent
+ * where they are built changes reformatting and breaks ten [org.elixir_lang.FormattingTest] fixtures.
+ *
+ * These go through the platform's Enter handler rather than a reformat, so [org.elixir_lang.FormattingTest]'s
+ * reformat-based fixtures cannot cover them.
+ */
+class ContainerElementIndentTest : PlatformTestCase() {
+    private fun assertCaretColumnAfterEnter(code: String, expectedColumn: Int) {
+        myFixture.configureByText("a.ex", code)
+
+        myFixture.type('\n')
+
+        assertEquals(expectedColumn, myFixture.editor.caretModel.logicalPosition.column)
+    }
+
+    private fun inRun(body: String) = "defmodule M do\n  def run do\n$body\n  end\nend\n"
+
+    fun testAfterElementInList() =
+        assertCaretColumnAfterEnter(inRun("    _list = [\n      one<caret>\n    ]"), 6)
+
+    fun testAfterElementInCall() =
+        assertCaretColumnAfterEnter(inRun("    some_call(\n      one<caret>\n    )"), 6)
+
+    /** A call nested in a list indents from the call, which the parentheses fix already gets right. */
+    fun testAfterCommaInCallNestedInList() =
+        assertCaretColumnAfterEnter(inRun("    _l = [\n      some_call(\n        one,<caret>\n      )\n    ]"), 8)
+
+    fun testDoBlockBody() = assertCaretColumnAfterEnter("defmodule M do\n  def run do<caret>\n  end\nend\n", 4)
+}

--- a/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
@@ -94,4 +94,17 @@ class ParenthesesArgumentsIndentTest : PlatformTestCase() {
             6
         )
     }
+
+    /**
+     * A definition head wraps its arguments to the defined function's own column plus one indent, and that
+     * column is fixed by the `defp ` before it rather than by how long the name is. Confirmed by running
+     * `mix format` over both widths.
+     */
+    fun testArgumentColumnDoesNotVaryWithTheFunctionNameLength() {
+        assertCaretColumnAfterEnter("defmodule M do\n  defp a(<caret>) do\n  end\nend\n", 9)
+        assertCaretColumnAfterEnter(
+            "defmodule M do\n  defp a_much_longer_function_name(<caret>) do\n  end\nend\n",
+            9
+        )
+    }
 }

--- a/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
@@ -1,0 +1,44 @@
+package org.elixir_lang.formatter
+
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Pressing Enter inside a call's parentheses puts the caret where an argument goes, whether or not the parentheses
+ * already hold one.
+ *
+ * These go through the platform's Enter handler rather than a reformat, so [FormattingTest]'s reformat-based fixtures
+ * cannot cover them.
+ */
+class ParenthesesArgumentsIndentTest : PlatformTestCase() {
+    private fun assertCaretColumnAfterEnter(code: String, expectedColumn: Int) {
+        myFixture.configureByText("a.ex", code)
+
+        myFixture.type('\n')
+
+        assertEquals(expectedColumn, myFixture.editor.caretModel.logicalPosition.column)
+    }
+
+    fun testEmptyParentheses() {
+        assertCaretColumnAfterEnter("defp visit_file(<caret>) do\nend\n", 7)
+    }
+
+    fun testEmptyParenthesesWithoutDoBlock() {
+        assertCaretColumnAfterEnter("defp visit_file(<caret>)\n", 7)
+    }
+
+    fun testEmptyParenthesesOfIndentedCall() {
+        assertCaretColumnAfterEnter("defp visit_file(path) do\n  other(<caret>)\nend\n", 4)
+    }
+
+    fun testBeforeArgument() {
+        assertCaretColumnAfterEnter("defp visit_file(<caret>path) do\nend\n", 7)
+    }
+
+    fun testAfterComma() {
+        assertCaretColumnAfterEnter("defp visit_file(path,<caret>acc) do\nend\n", 7)
+    }
+
+    fun testAfterLastArgument() {
+        assertCaretColumnAfterEnter("defp visit_file(path<caret>) do\nend\n", 5)
+    }
+}

--- a/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
@@ -41,4 +41,27 @@ class ParenthesesArgumentsIndentTest : PlatformTestCase() {
     fun testAfterLastArgument() {
         assertCaretColumnAfterEnter("defp visit_file(path<caret>) do\nend\n", 5)
     }
+
+    /**
+     * A comma is built without an indent of its own, so delegating to it dropped the caret back to the enclosing
+     * statement. The expected columns are the ones `mix format` produces for the same argument lists: an argument list
+     * broken over lines puts its arguments at the call's own column plus two.
+     */
+    fun testAfterTrailingCommaOnItsOwnLineInACallDefinitionHead() {
+        assertCaretColumnAfterEnter("defmodule M do\n  def foo(\n        path,<caret>\n      ) do\n  end\nend\n", 8)
+    }
+
+    fun testAfterTrailingCommaOnItsOwnLineInACall() {
+        assertCaretColumnAfterEnter(
+            "defmodule M do\n  def run do\n    some_call(\n      path,<caret>\n    )\n  end\nend\n",
+            6
+        )
+    }
+
+    fun testBetweenArgumentsOnTheirOwnLines() {
+        assertCaretColumnAfterEnter(
+            "defmodule M do\n  def run do\n    some_call(\n      path,<caret>\n      acc\n    )\n  end\nend\n",
+            6
+        )
+    }
 }

--- a/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
+++ b/tests/org/elixir_lang/formatter/ParenthesesArgumentsIndentTest.kt
@@ -64,4 +64,34 @@ class ParenthesesArgumentsIndentTest : PlatformTestCase() {
             6
         )
     }
+
+    fun testAfterKeywordPairComma() {
+        assertCaretColumnAfterEnter(
+            "defmodule M do\n  def run do\n    some_call(\n      key: 1,<caret>\n    )\n  end\nend\n",
+            6
+        )
+    }
+
+    /** A call that does not start its own line still wraps its arguments to the call's column plus one indent. */
+    fun testCallThatDoesNotStartItsLine() {
+        assertCaretColumnAfterEnter(
+            "defmodule M do\n  def run do\n    _x =\n      some_call(<caret>\n        one\n      )\n  end\nend\n",
+            8
+        )
+    }
+
+    /**
+     * A dot call's argument list is a block of its own rather than being flattened into the call, so it is already the
+     * block answering the delegation and its arguments indent from the line rather than from the parenthesis.
+     */
+    fun testEmptyParenthesesOfDotCall() {
+        assertCaretColumnAfterEnter("defmodule M do\n  def run do\n    fun.(<caret>)\n  end\nend\n", 6)
+    }
+
+    fun testAfterTrailingCommaInDotCall() {
+        assertCaretColumnAfterEnter(
+            "defmodule M do\n  def run do\n    fun.(\n      one,<caret>\n    )\n  end\nend\n",
+            6
+        )
+    }
 }

--- a/tests/org/elixir_lang/psi/TrailingCommaRecoveryTest.kt
+++ b/tests/org/elixir_lang/psi/TrailingCommaRecoveryTest.kt
@@ -1,0 +1,115 @@
+package org.elixir_lang.psi
+
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.call.Call
+
+/**
+ * A trailing comma in a call's argument list is what the source says for as long as it takes to type the next
+ * argument, so the parse has to survive it. Without recovery inside the parentheses the malformed list takes the call,
+ * the enclosing block and every following expression with it, leaving raw tokens as siblings of the file.
+ */
+class TrailingCommaRecoveryTest : PlatformTestCase() {
+    fun testCallKeepsItsArguments() {
+        val call = outermostCall("foo(a,)\n")
+
+        assertEquals("foo(a,)", call.text)
+        assertNotNull(
+            "The argument list is still an Arguments node",
+            PsiTreeUtil.findChildOfType(call, Arguments::class.java)
+        )
+    }
+
+    fun testEnclosingDefinitionSurvives() {
+        val source = "def run do\n  foo(a,)\nend\n"
+
+        assertEquals(source.trimEnd(), outermostCall(source).text)
+    }
+
+    fun testFollowingDefinitionSurvives() {
+        val source = "defmodule M do\n  def run do\n    foo(a,)\n  end\n\n  def other, do: 1\nend\n"
+        val module = outermostCall(source)
+
+        assertEquals(
+            "The whole module, including the untouched definition after the malformed call",
+            source.trimEnd(),
+            module.text
+        )
+        assertNotNull(
+            "`def other` is still inside the module rather than a sibling of the file",
+            PsiTreeUtil.findChildrenOfType(module, Call::class.java).find { it.text.startsWith("def other") }
+        )
+    }
+
+    /*
+     * A qualified call and a dot call spell the same half-typed state as `foo(a,)`, and their arguments recover the
+     * same way.
+     */
+
+    fun testQualifiedCallKeepsItsArguments() {
+        assertEquals("Mod.fun(a,)", outermostCall("Mod.fun(a,)\n").text)
+    }
+
+    fun testDotCallKeepsItsArguments() {
+        val call = outermostCall("fun.(a,)\n")
+
+        assertEquals("fun.(a,)", call.text)
+        assertNotNull(
+            "The argument list is still an Arguments node",
+            PsiTreeUtil.findChildOfType(call, Arguments::class.java)
+        )
+    }
+
+    fun testEnclosingDefinitionSurvivesADotCall() {
+        val source = "def run do\n  fun.(a,)\nend\n"
+
+        assertEquals(source.trimEnd(), outermostCall(source).text)
+    }
+
+    fun testFollowingDefinitionSurvivesADotCall() {
+        val source = "defmodule M do\n  def run do\n    fun.(a,)\n  end\n\n  def other, do: 1\nend\n"
+
+        assertEquals(
+            "The whole module, including the untouched definition after the malformed dot call",
+            source.trimEnd(),
+            outermostCall(source).text
+        )
+    }
+
+    /**
+     * A newline inside parentheses is whitespace rather than a token of its own, so recovery reaches the `)` on the
+     * next line without being allowed to eat anything but the comma.
+     */
+    fun testTrailingCommaBeforeAClosingParenthesisOnItsOwnLine() {
+        val source = "foo(\n  a,\n)\n"
+
+        assertEquals(source.trimEnd(), outermostCall(source).text)
+    }
+
+    /**
+     * Recovery stops at the first token that is not the comma it was written for.  Reading on to the next `)`
+     * anywhere in the file pulled whatever followed an unclosed parenthesis into its argument list, and eating the
+     * end of line left the expression after it with no separator to start from.
+     */
+    fun testUnclosedParenthesesDoNotSwallowTheFollowingCall() {
+        val file: PsiFile = myFixture.configureByText("unclosed.exs", "foo(a b\nbar(1)\n")
+
+        assertEquals(
+            "The unclosed argument list ends with the line its parenthesis was opened on",
+            "foo(a b",
+            PsiTreeUtil.findChildOfType(file, Call::class.java)!!.text
+        )
+        assertNotNull(
+            "`bar(1)` is still a call of the file rather than tokens inside `foo`'s argument list",
+            file.children.filterIsInstance<Call>().find { it.text == "bar(1)" }
+        )
+    }
+
+    private fun outermostCall(source: String): Call {
+        val file: PsiFile = myFixture.configureByText("trailing_comma.ex", source)
+
+        return PsiTreeUtil.findChildOfType(file, Call::class.java)
+            ?: throw AssertionError("No call parsed from:\n$source")
+    }
+}


### PR DESCRIPTION
Parameter hints now appear on their own, where before they mostly did not. Accepting a function from the completion popup shows them immediately:

<img width="387" height="176" alt="image" src="https://github.com/user-attachments/assets/532bc6a6-485d-4291-9aa1-c51165644cb9" />

and so does typing the comma that begins the next argument:

<img width="412" height="168" alt="image" src="https://github.com/user-attachments/assets/6205c5da-aa4d-42bb-b9d7-fae26bec8e4c" />

Refs [#799](https://github.com/KronicDeth/intellij-elixir/issues/799).

## The hints

Three things stood between the caret and a hint.

**The comma destroyed the parse.** `foo(a,)` is what the source says until the next argument is typed, and the parse discarded the enclosing definition and everything after it, so nothing walking up from the caret found a call. The call forms of `parenthesesArguments` now commit at the opening parenthesis and recover to the closing one; `stabParenthesesSignature` keeps the uncommitted rule, which it needs to back out when it meets `->`.

**Accepting a completion asked for nothing.** An open lookup consumes the keystroke that accepted it, so the platform's typed handler — which asks for a hint on every `(` and `,` — never runs. The insert handler that adds the parentheses now asks, as Java's does.

**The hint described the wrong functions.** A call to `reduce` also resolves `reduce_while`, and every prefix match was listed beside the real function — eight signatures for `Enum.reduce`, now two.

## Indent fixes riding along

Pressing Enter after a delimiter put the caret back at the enclosing statement: a delimiter carries no indent of its own, so `DELEGATE_TO_PREV_CHILD` had nothing to indent against. `getChildAttributes` now answers with the indent an element takes — after `[`, `{`, `%{`, `%S{`, `<<`, `Foo.{`, a comma, `->` in a clause, the `rescue`/`after`/`else`/`catch` keywords, in `fun.(`, and inside empty parentheses. Nothing in the block model changed, so no `FormattingTest` fixture moved.

## Testing

`./gradlew.bat :test` — 6968 green. Every indent column comes from running `mix format` on the same source. The popup tests drive the real chain rather than the handler alone, because the handler resolves the same signature however the caret arrives; each fix was confirmed to go red without it.

## Not covered

- A trailing comma in a **no-parentheses** call (`some_call one,`) still de-structures the file — no closing delimiter to recover to.
- The caret after a comma in a no-parentheses call keeps delegating: `mix format` aligns after `with a <- one(),` but indents after `import Foo,`, decided by an argument not yet typed.
- Placing the caret in an existing argument list shows nothing until something is typed — the platform's own behaviour, recalled with Ctrl+P.

## What #799 asked for

- **Caret in empty parentheses** — done, and widened to every delimiter.
- **Configurable indent for definition-head parentheses** — deliberately not built. `mix format` decides it non-configurably, and decides it the way the plugin already behaved; the plugin defaults to `mix format` on reformat, so the setting would be unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
