### PR TITLE
fix: guard JavadocOrderRootType behind isSmallIde in erlang_dependent.Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Enhancements
 
+- [#3946](https://github.com/KronicDeth/intellij-elixir/pull/3946) [@sh41](https://github.com/sh41)
+  - **Configuring an Elixir SDK no longer crashes PhpStorm, WebStorm and the other small IDEs** when
+    another installed plugin registers a root type of its own. Opening the SDK editor threw
+    `Root type class ... JavadocOrderRootType not found`.
+
 - [#3925](https://github.com/KronicDeth/intellij-elixir/pull/3925) [@sh41](https://github.com/sh41)
   - **File and line are now linked inside an inspected stack trace.** A crash report often carries
     its trace as a term rather than a formatted trace, putting each frame's location in a keyword

--- a/src/org/elixir_lang/sdk/erlang_dependent/Type.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/Type.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.projectRoots.AdditionalDataConfigurable
 import com.intellij.openapi.projectRoots.SdkAdditionalData
 import com.intellij.openapi.projectRoots.impl.DependentSdkType
 import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
-import com.intellij.openapi.roots.JavadocOrderRootType
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.Ref
@@ -48,7 +47,12 @@ abstract class Type protected constructor(name: String) : DependentSdkType(name)
     }
 
     override fun isRootTypeApplicable(type: OrderRootType): Boolean {
-        return type === OrderRootType.CLASSES || type === OrderRootType.SOURCES || type === JavadocOrderRootType.getInstance()
+        // Small IDEs do not register JavadocOrderRootType, so calling getInstance() there throws.
+        // documentationRootType() returns null instead. See
+        // https://github.com/KronicDeth/intellij-elixir/issues/976.
+        return type === OrderRootType.CLASSES ||
+                type === OrderRootType.SOURCES ||
+                type === org.elixir_lang.sdk.Type.documentationRootType()
     }
 
     override fun saveAdditionalData(additionalData: SdkAdditionalData, additional: Element) {

--- a/tests/org/elixir_lang/sdk/erlang_dependent/RootTypeApplicableTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang_dependent/RootTypeApplicableTest.kt
@@ -1,0 +1,100 @@
+package org.elixir_lang.sdk.erlang_dependent
+
+import com.intellij.openapi.roots.JavadocOrderRootType
+import com.intellij.openapi.roots.OrderRootType
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.ProcessOutput
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import org.elixir_lang.sdk.erlang.Type as ErlangSdkType
+
+/**
+ * Regression tests for https://github.com/KronicDeth/intellij-elixir/issues/976.
+ *
+ * On a small IDE - PhpStorm, WebStorm, RubyMine and friends - `JavadocOrderRootType` is not
+ * registered, so `JavadocOrderRootType.getInstance()` throws
+ * `AssertionError: Root type class com.intellij.openapi.roots.JavadocOrderRootType not found`.
+ * `org.elixir_lang.sdk.erlang.Type` has routed around that through
+ * [org.elixir_lang.sdk.Type.documentationRootType] since the SDK code was converted to Kotlin, but
+ * [org.elixir_lang.sdk.erlang_dependent.Type] - which [ElixirSdkType] inherits from without
+ * overriding the method - kept calling `getInstance()` directly, and
+ * `org.elixir_lang.facet.sdk.Editor.showTabForType` calls it once per registered `OrderRootType`
+ * whenever the SDK editor panel is built.
+ *
+ * These tests cannot reproduce the `AssertionError` itself: tests run on the full platform (`IC`/`IU`),
+ * where `getInstance()` resolves fine. What they pin is that the *guarded* path is taken - on a small
+ * IDE the documentation root type is not applicable, which is only true if `getInstance()` was never
+ * consulted. Small-IDE-ness is forced through [ProcessOutput.isSmallIdeOverride], the test seam added
+ * for exactly this purpose.
+ */
+class RootTypeApplicableTest : PlatformTestCase() {
+    @Throws(Exception::class)
+    override fun tearDown() {
+        try {
+            ProcessOutput.isSmallIdeOverride = null
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    /**
+     * The regression itself. Before the fix this returned `true`, because the inherited
+     * `isRootTypeApplicable` compared against `JavadocOrderRootType.getInstance()` unconditionally.
+     */
+    fun testJavadocRootTypeIsNotApplicableToElixirSdkOnSmallIde() {
+        ProcessOutput.isSmallIdeOverride = true
+
+        assertFalse(
+            "the Javadoc root type must not be applicable on a small IDE - reaching it means " +
+                    "JavadocOrderRootType.getInstance() was called, which throws there",
+            ElixirSdkType.instance.isRootTypeApplicable(JavadocOrderRootType.getInstance())
+        )
+    }
+
+    /**
+     * The Elixir SDK inherits `isRootTypeApplicable` from `erlang_dependent.Type`, so the two must
+     * agree. This is the invariant the issue's title asks for: the dependent type gets the same
+     * protected access the Erlang type already had.
+     */
+    fun testElixirAndErlangSdkTypesAgreeOnSmallIde() {
+        ProcessOutput.isSmallIdeOverride = true
+
+        val javadocRootType = JavadocOrderRootType.getInstance()
+
+        assertEquals(
+            "erlang_dependent.Type and erlang.Type must guard the documentation root type the same way",
+            ErlangSdkType.instance.isRootTypeApplicable(javadocRootType),
+            ElixirSdkType.instance.isRootTypeApplicable(javadocRootType)
+        )
+    }
+
+    /**
+     * The guard must not cost the documentation tab on a full IDE, where the root type does exist.
+     */
+    fun testJavadocRootTypeStaysApplicableOnFullIde() {
+        ProcessOutput.isSmallIdeOverride = false
+
+        assertTrue(
+            "the Javadoc root type is registered on a full IDE and must stay applicable there",
+            ElixirSdkType.instance.isRootTypeApplicable(JavadocOrderRootType.getInstance())
+        )
+    }
+
+    /**
+     * `CLASSES` and `SOURCES` are platform-wide and unaffected by IDE size; the guard must leave them
+     * alone.
+     */
+    fun testClassesAndSourcesStayApplicableRegardlessOfIdeSize() {
+        for (smallIde in listOf(true, false)) {
+            ProcessOutput.isSmallIdeOverride = smallIde
+
+            assertTrue(
+                "CLASSES must be applicable with isSmallIde=$smallIde",
+                ElixirSdkType.instance.isRootTypeApplicable(OrderRootType.CLASSES)
+            )
+            assertTrue(
+                "SOURCES must be applicable with isSmallIde=$smallIde",
+                ElixirSdkType.instance.isRootTypeApplicable(OrderRootType.SOURCES)
+            )
+        }
+    }
+}


### PR DESCRIPTION
`JavadocOrderRootType.getInstance()` throws on small IDEs, where the root type isn't registered. `sdk.erlang.Type` has routed around it via `documentationRootType()` for a while; `sdk.erlang_dependent.Type` never did, and `sdk.elixir.Type` inherits from it. `facet.sdk.Editor.showTabForType` calls it once per registered root type, so any plugin contributing its own root type hits it.

The file already imported `ProcessOutput.isSmallIde` and used it elsewhere.

Test uses `isSmallIdeOverride` (added in 61c01b33c) to force small-IDE behaviour, and pins that the guarded path is taken — it can't reproduce the `AssertionError` itself, since tests run on the full platform. Both guard assertions fail against the unfixed code.

Fixes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)