### PR TITLE
fix: decode compact-term extended integer lengths per the BEAM format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Enhancements
 
+- [#3947](https://github.com/KronicDeth/intellij-elixir/pull/3947) [@sh41](https://github.com/sh41)
+  - **Large integer literals in a decompiled BEAM now show their real value.** Anything nine bytes or
+    wider had been decoded wrongly since 2018, and on some files the Code tab threw
+    `ArrayIndexOutOfBoundsException` instead of opening.
+
 - [#3925](https://github.com/KronicDeth/intellij-elixir/pull/3925) [@sh41](https://github.com/sh41)
   - **File and line are now linked inside an inspected stack trace.** A crash report often carries
     its trace as a term rather than a formatted trace, putting each frame's location in a keyword

--- a/src/org/elixir_lang/beam/term/Term.kt
+++ b/src/org/elixir_lang/beam/term/Term.kt
@@ -146,8 +146,24 @@ fun value(fullTag: UnsignedByte, data: ByteArray, offset: Int): Pair<Any, ByteCo
                 bits7to5.shl(8).or(lowByte)
             }
             bits7to5 == 0b111 -> {
-                val (byteCount, byteCountByteCount) = unsignedByte(data[internalOffset])
-                internalOffset += byteCountByteCount
+                // The 3-bit length field encodes byte lengths 2 through 8 directly, as
+                // `bits7to5 + 2` in the branch below. 7 is an escape: the length does not fit,
+                // so it follows as its own compact term, and the real length is that value plus
+                // 9 - the next length the direct form cannot express. See decode_int_length/2
+                // in OTP's lib/compiler/src/beam_disasm.erl, which imitates
+                // get_erlang_integer() in beam_load.c.
+                val (lengthTag, lengthTagByteCount) = unsignedByte(data[internalOffset])
+                internalOffset += lengthTagByteCount
+
+                val (length, lengthByteCount) = value(lengthTag, data, internalOffset)
+                internalOffset += lengthByteCount
+
+                val byteCount = when (length) {
+                    is Int -> length + 9
+                    else -> throw IllegalArgumentException(
+                        "Extended integer length is not a small integer (${length.javaClass} $length)"
+                    )
+                }
 
                 val value = ByteSubarray(data, internalOffset, byteCount)
                 internalOffset += byteCount

--- a/tests/org/elixir_lang/beam/term/ExtendedLengthIntegerTest.kt
+++ b/tests/org/elixir_lang/beam/term/ExtendedLengthIntegerTest.kt
@@ -1,0 +1,70 @@
+package org.elixir_lang.beam.term
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression tests for https://github.com/KronicDeth/intellij-elixir/issues/1052,
+ * "ByteSubarray.get ArrayIndexOutOfBoundsException for 0".
+ *
+ * A compact-term integer whose tag has bits 7-5 set to `0b111` does not carry its byte length in
+ * those bits - they are an escape. The length follows as its own compact term, and the real length
+ * is that value plus 9, the next length the direct `bits7to5 + 2` form cannot express. See
+ * `decode_int_length/2` in OTP's `lib/compiler/src/beam_disasm.erl`, which imitates
+ * `get_erlang_integer()` in `beam_load.c`.
+ *
+ * The plugin read the byte after the tag as the length directly, with neither the nested decode nor
+ * the `+ 9`. On the reported input that byte is a nested tag of `0x00`, which was taken as a length
+ * of zero, and `Integer.from`'s unconditional `toLong()` then read byte 0 of an empty subarray.
+ *
+ * `0b1111_1001` is the tag under test: `001` selects Integer, bit 3 set leaves the 4-bit inline
+ * form, bit 4 set leaves the 11-bit form, and bits 7-5 `111` selects the escape.
+ */
+class ExtendedLengthIntegerTest {
+    private val extendedLengthIntegerTag = 0b1111_1001.toByte()
+
+    /** A nested length term of `0x00` is `{u, 0}`, so the integer is 9 bytes, not 0. */
+    @Test
+    fun nestedLengthOfZeroMeansNineBytes() {
+        val data = byteArrayOf(extendedLengthIntegerTag, 0x00) +
+                byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 42)
+
+        val (term, byteCount) = Term.from(data, 0, true)
+
+        assertEquals(42L, (term as Integer).long)
+        assertEquals("tag + nested length + 9 value bytes", 11, byteCount)
+    }
+
+    /** `{u, 1}` is 10 bytes. The nested term is a plain 4-bit inline value, so still one byte. */
+    @Test
+    fun nestedLengthOfOneMeansTenBytes() {
+        val data = byteArrayOf(extendedLengthIntegerTag, 0b0001_0000.toByte()) +
+                byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 7)
+
+        val (term, byteCount) = Term.from(data, 0, true)
+
+        assertEquals(7L, (term as Integer).long)
+        assertEquals(12, byteCount)
+    }
+
+    /**
+     * The direct form, unchanged by the fix and already correct: `bits7to5` of 0 through 6 mean
+     * byte lengths 2 through 8.
+     */
+    @Test
+    fun directLengthsAreBitsSevenToFivePlusTwo() {
+        for (bits7to5 in 0..6) {
+            val tag = ((bits7to5 shl 5) or 0b1_1001).toByte()
+            val expectedLength = bits7to5 + 2
+            val data = ByteArray(1 + expectedLength).also {
+                it[0] = tag
+                it[expectedLength] = 5
+            }
+
+            val (term, byteCount) = Term.from(data, 0, true)
+
+            assertEquals("bits7to5=$bits7to5", 5L, (term as Integer).long)
+            assertEquals("bits7to5=$bits7to5", 1 + expectedLength, byteCount)
+        }
+    }
+}


### PR DESCRIPTION
A compact-term integer's byte length lives in bits 7-5 of the tag as `bits7to5 + 2`, covering 2-8. A value of 7 is an escape: the length follows as its own compact term, and the real length is that value **+ 9**.

The plugin read the byte after the tag as the length directly — no nested decode, no `+ 9`. So:

- every integer literal of 9+ bytes decoded to the wrong value, silently, since 2018;
- in #1052 the byte after the tag is a nested length tag of `0x00`, read as length zero, giving a zero-length `ByteSubarray` that `Integer.from`'s `toLong()` then indexed — `ArrayIndexOutOfBoundsException(0)`. Zero is unrepresentable in a valid file, so this was never a corrupt-file case.

Ported from `decode_int_length/2` in OTP's `beam_disasm.erl`, which `Term.kt` already links the spec for. The direct-length branch already matched and is unchanged.

Test covers nested lengths 0 and 1 plus the direct form. Both extended-length cases fail against the unfixed source.

Fixes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)