### PR TITLE
fix(formatter): flatten an access expression on a map update's left side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@
 
 ### Bug Fixes
 
+- [#3948](https://github.com/KronicDeth/intellij-elixir/pull/3948) [@sh41](https://github.com/sh41)
+  - **Auto-Indent Lines and paste no longer throw on a map update with a literal on the left**, such
+    as `%{%{a} | k: 1}`.
+
 - [#3934](https://github.com/KronicDeth/intellij-elixir/pull/3934) [@sh41](https://github.com/sh41)
   - **A trailing comma in a call's argument list no longer breaks the rest of the file.** Typing
     `foo(a,)` on the way to the next argument used to discard the enclosing definition and everything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,6 @@
 
 ### Enhancements
 
-- [#3947](https://github.com/KronicDeth/intellij-elixir/pull/3947) [@sh41](https://github.com/sh41)
-  - **Large integer literals in a decompiled BEAM now show their real value.** Anything nine bytes or
-    wider had been decoded wrongly since 2018, and on some files the Code tab threw
-    `ArrayIndexOutOfBoundsException` instead of opening.
-
-- [#3946](https://github.com/KronicDeth/intellij-elixir/pull/3946) [@sh41](https://github.com/sh41)
-  - **Configuring an Elixir SDK no longer crashes PhpStorm, WebStorm and the other small IDEs** when
-    another installed plugin registers a root type of its own. Opening the SDK editor threw
-    `Root type class ... JavadocOrderRootType not found`.
-
 - [#3925](https://github.com/KronicDeth/intellij-elixir/pull/3925) [@sh41](https://github.com/sh41)
   - **File and line are now linked inside an inspected stack trace.** A crash report often carries
     its trace as a term rather than a formatted trace, putting each frame's location in a keyword
@@ -103,6 +93,14 @@
 - [#3948](https://github.com/KronicDeth/intellij-elixir/pull/3948) [@sh41](https://github.com/sh41)
   - **Auto-Indent Lines and paste no longer throw on a map update with a literal on the left**, such
     as `%{%{a} | k: 1}`.
+
+- [#3947](https://github.com/KronicDeth/intellij-elixir/pull/3947) [@sh41](https://github.com/sh41)
+  - **Large integer literals in a decompiled BEAM now show their real value**, and the Code tab no
+    longer throws on some files.
+
+- [#3946](https://github.com/KronicDeth/intellij-elixir/pull/3946) [@sh41](https://github.com/sh41)
+  - **Configuring an Elixir SDK no longer crashes PhpStorm, WebStorm and the other small IDEs** when
+    another plugin registers a root type of its own.
 
 - [#3934](https://github.com/KronicDeth/intellij-elixir/pull/3934) [@sh41](https://github.com/sh41)
   - **A trailing comma in a call's argument list no longer breaks the rest of the file.** Typing

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -1508,7 +1508,11 @@ public class Block extends AbstractBlock implements BlockEx {
                         leftOperand[0] = false;
                     } else {
                         if (leftOperand[0]) {
-                            blockList.add(buildChild(child, operandWrap));
+                            if (childElementType == ACCESS_EXPRESSION) {
+                                blockList.addAll(buildAccessExpressionChildren(child, operandWrap));
+                            } else {
+                                blockList.add(buildChild(child, operandWrap));
+                            }
                         } else {
                             blockList.addAll(
                                     buildMapTailArgumentsChildChildren(

--- a/tests/org/elixir_lang/formatter/MapUpdateAccessExpressionTest.kt
+++ b/tests/org/elixir_lang/formatter/MapUpdateAccessExpressionTest.kt
@@ -1,0 +1,78 @@
+package org.elixir_lang.formatter
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.codeStyle.CodeStyleManager
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Regression tests for https://github.com/KronicDeth/intellij-elixir/issues/1075,
+ * "accessExpressions should be flattened with buildAccessExpressionChildren".
+ *
+ * `Block`'s constructor asserts it is never handed an `ACCESS_EXPRESSION` - those are flattened
+ * through `buildAccessExpressionChildren` instead - and `Block.java` checks for that everywhere it
+ * builds a child. `buildMapUpdateArgumentsChildren` missed the check on its **left** operand, the map
+ * being updated. The tail side, after the pipe, was always fine: it goes through
+ * `buildMapTailArgumentsChildChildren`, whose keyword pairs do check.
+ *
+ * Two things kept this hidden for eight years:
+ *
+ * - The left operand is an `ACCESS_EXPRESSION` for a literal or an aggregate - an alias, a map,
+ *   list or tuple literal, a string, atom or number, an anonymous function, or anything
+ *   parenthesised. It is something else for the shapes reached for first: a bare name is a
+ *   `MATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL`, `a.b` a `MATCHED_QUALIFIED_NO_ARGUMENTS_CALL`,
+ *   `a[:b]` a `MATCHED_UNQUALIFIED_BRACKET_OPERATION`, `f(a)` a
+ *   `MATCHED_UNQUALIFIED_PARENTHESES_CALL`, `@attr` a `MATCHED_AT_OPERATION`.
+ * - It fires through `adjustLineIndent` - what a paste and Auto-Indent Lines use, and what the
+ *   reported stack trace came through - but **not** through a whole-file `reformat`, which is what
+ *   the existing formatter fixtures exercise.
+ */
+class MapUpdateAccessExpressionTest : PlatformTestCase() {
+    private val prefix = "defmodule M do\n  def f(a, b) do\n    "
+
+    private fun adjustLineIndent(body: String): String {
+        myFixture.configureByText("a.ex", "$prefix$body\n  end\nend\n")
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            CodeStyleManager.getInstance(project).adjustLineIndent(myFixture.file, prefix.length + 1)
+        }
+
+        return myFixture.file.text
+    }
+
+    private fun assertIndentLeavesUnchanged(body: String) =
+        assertEquals("$prefix$body\n  end\nend\n", adjustLineIndent(body))
+
+    /** The reported crash. */
+    fun testParenthesisedLeftOperandOfAMapUpdate() = assertIndentLeavesUnchanged("%{(a) | k: 1}")
+
+    /** Same construct with a struct name in front. */
+    fun testParenthesisedLeftOperandOfAStructUpdate() = assertIndentLeavesUnchanged("%User{(a) | k: 1}")
+
+    /** A parenthesised expression rather than a parenthesised name. */
+    fun testParenthesisedExpressionAsLeftOperand() = assertIndentLeavesUnchanged("%{(a || b) | k: 1}")
+
+    /** A literal or aggregate on the left takes the same path. */
+    fun testAliasLeftOperand() = assertIndentLeavesUnchanged("%{Foo | k: 1}")
+
+    fun testMapLiteralLeftOperand() = assertIndentLeavesUnchanged("%{%{a} | k: 1}")
+
+    fun testListLiteralLeftOperand() = assertIndentLeavesUnchanged("%{[a] | k: 1}")
+
+    fun testTupleLiteralLeftOperand() = assertIndentLeavesUnchanged("%{{a} | k: 1}")
+
+    fun testAtomLeftOperand() = assertIndentLeavesUnchanged("%{:atom | k: 1}")
+
+    fun testAnonymousFunctionLeftOperand() = assertIndentLeavesUnchanged("%{fn -> a end | k: 1}")
+
+    /** Controls: shapes that parse as something other than an access expression. */
+
+    fun testBareNameLeftOperand() = assertIndentLeavesUnchanged("%{a | k: 1}")
+
+    fun testDottedLeftOperand() = assertIndentLeavesUnchanged("%{a.b | k: 1}")
+
+    fun testBracketLeftOperand() = assertIndentLeavesUnchanged("%{a[:b] | k: 1}")
+
+    fun testParenthesesCallLeftOperand() = assertIndentLeavesUnchanged("%{f(a) | k: 1}")
+
+    fun testModuleAttributeLeftOperand() = assertIndentLeavesUnchanged("%{@attr | k: 1}")
+}


### PR DESCRIPTION
`Block`'s constructor asserts it is never handed an `ACCESS_EXPRESSION`, and `Block.java` checks for that everywhere it builds a child. `buildMapUpdateArgumentsChildren` missed it on the left operand. The tail side was always fine — it goes through `buildMapTailArgumentsChildChildren`, whose keyword pairs check.

Hidden since 2018 because:

- the left operand is an `ACCESS_EXPRESSION` only for a literal or aggregate — an alias, a map/list/tuple literal, a string, atom or number, an anonymous function, or anything parenthesised. The shapes anyone reaches for first are something else: a bare name is `MATCHED_UNQUALIFIED_NO_ARGUMENTS_CALL`, `a.b` `MATCHED_QUALIFIED_NO_ARGUMENTS_CALL`, `a[:b]` `MATCHED_UNQUALIFIED_BRACKET_OPERATION`, `f(a)` `MATCHED_UNQUALIFIED_PARENTHESES_CALL`, `@attr` `MATCHED_AT_OPERATION`;
- it fires through `adjustLineIndent` (paste, Auto-Indent Lines — where the reported trace came from), not through a whole-file `reformat`, which is what the existing fixtures use.

Most of the affected shapes are not valid Elixir — `%{1 | k: 1}` means nothing — but they are states you type through, and the editor has to survive them.

Test covers the nine access-expression shapes and five controls. All nine fail against the unfixed source with the reported assertion; all five controls pass either way.

Fixes #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)