### PR TITLE
build(quoter): let two checkouts run tests at once, and stop a missing daemon costing the whole suite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,6 +187,16 @@ val quoterAvailabilityFile: RegularFile = quoterUnzippedPath.file("quoter-availa
 // Opts back in to a hard failure at releaseQuoter, for debugging the quoter itself.
 val quoterRequired: Boolean = providers.gradleProperty("quoterRequired").getOrElse("false").toBoolean()
 val quoterTmpPath: Directory = cachePath.dir("quoter_tmp_$quoterRefSlug")
+// Distributed Erlang node names for the quoter daemon and for the test JVM that talks to it. Erlang
+// registers a node by name with the machine-wide epmd, and epmd allows exactly one node per name - so
+// with a fixed name a second checkout starting its own quoter gets "the name intellij_elixir@127.0.0.1
+// seems to be in use by another Erlang node" and exits 0, which `startQuoter` reports as the daemon
+// dying immediately. Deriving both names from the checkout path lets worktrees run tests concurrently.
+// Unset (a plain `java -jar` of the plugin, or any non-test use) the plugin falls back to the original
+// literals, so nothing outside the build changes.
+val quoterNodeToken: String = rootDir.absolutePath.lowercase().hashCode().toUInt().toString(16)
+val quoterNodeName: String = "intellij_elixir_$quoterNodeToken@127.0.0.1"
+val quoterClientNodeName: String = "intellij_elixir_client_$quoterNodeToken@127.0.0.1"
 // hex/rebar + fetched deps are cached under the project (used by the quoter mix build).
 val mixHomePath: Directory = cachePath.dir("mix_home")
 val mixArchivesPath: Directory = cachePath.dir("mix_archives")
@@ -884,6 +894,7 @@ val quoterService = gradle.sharedServices.registerIfAbsent("quoter", QuoterServi
     parameters {
         executable.set(quoterExe)
         tmpDir.set(quoterTmpPath)
+        nodeName.set(quoterNodeName)
     }
 }
 
@@ -963,6 +974,14 @@ tasks.named<Test>("test") {
     // 28 s with 1.13.4/OTP-25's results.
     inputs.property("elixirVersion", expectedElixirVersion)
     inputs.property("otpVersion", expectedOtpVersion)
+
+    // The test JVM has to dial the same node the daemon registered, and register its own node under a
+    // name no other checkout is using either - two test JVMs collide exactly as two daemons do.
+    // Declared as inputs so a rename invalidates the task rather than reporting the old run's results.
+    systemProperty("elixir.quoter.remoteNode", quoterNodeName)
+    systemProperty("elixir.quoter.localNode", quoterClientNodeName)
+    inputs.property("quoterNodeName", quoterNodeName)
+    inputs.property("quoterClientNodeName", quoterClientNodeName)
 
     // The parsing tests are JUnit 3 (com.intellij.testFramework.ParsingTestCase -> TestCase),
     // discovered by the JUnit 4 runner.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,6 +184,9 @@ val quoterExe: RegularFile = quoterUnzippedPath.file(quoterReleaseExecutablePath
 // tasks. Beside the release it describes, so it is keyed on the Elixir/OTP pair like the rest of that
 // tree; in the shared cache root it would describe whichever pair built last.
 val quoterAvailabilityFile: RegularFile = quoterUnzippedPath.file("quoter-availability.properties")
+// Written by `startQuoter` rather than `releaseQuoter`: whether the daemon actually came up, which is
+// a different question from whether it compiled, and the one the tests care about.
+val quoterStartedFile: RegularFile = quoterUnzippedPath.file("quoter-started.properties")
 // Opts back in to a hard failure at releaseQuoter, for debugging the quoter itself.
 val quoterRequired: Boolean = providers.gradleProperty("quoterRequired").getOrElse("false").toBoolean()
 val quoterTmpPath: Directory = cachePath.dir("quoter_tmp_$quoterRefSlug")
@@ -922,6 +925,8 @@ val startQuoter = tasks.register<StartQuoterTask>("startQuoter") {
     dependsOn(releaseQuoter)
 
     availabilityFile.set(quoterAvailabilityFile)
+    startedFile.set(quoterStartedFile)
+    required.set(quoterRequired)
 }
 
 registerResolveExternalDependenciesTasksForAllProjects()
@@ -954,8 +959,13 @@ tasks.named<Test>("test") {
 
     val sdkProps = sdkPropertiesFile
     val quoterAvailability = quoterAvailabilityFile.asFile
+    val quoterStarted = quoterStartedFile.asFile
     doFirst {
-        environment(elixirTestEnvironment(sdkProps.get().asFile, quoterAvailability))
+        // `startQuoter` writes the start marker every run and copies the build marker's reason when it
+        // skips, so where it exists it is the later and more complete answer. Falling back to the build
+        // marker keeps `-x startQuoter` working.
+        val effective = if (quoterStarted.isFile) quoterStarted else quoterAvailability
+        environment(elixirTestEnvironment(sdkProps.get().asFile, effective))
     }
 
     // QUOTER_AVAILABLE reaches the test JVM through that doFirst, so - as with the versions below -
@@ -963,6 +973,11 @@ tasks.named<Test>("test") {
     // reports the other run's results. Optional: `-x releaseQuoter` leaves no marker.
     inputs.file(quoterAvailability)
         .withPropertyName("quoterAvailability")
+        .withPathSensitivity(PathSensitivity.NONE)
+        .optional(true)
+
+    inputs.file(quoterStarted)
+        .withPropertyName("quoterStarted")
         .withPathSensitivity(PathSensitivity.NONE)
         .optional(true)
 

--- a/buildSrc/src/main/kotlin/platform/posix/PosixQuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/platform/posix/PosixQuoterPlatform.kt
@@ -17,6 +17,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         logger: Logger
     ): Process? {
         logger.lifecycle("Starting Quoter daemon (POSIX - detached)...")
@@ -24,7 +25,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         val startOutput = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(executable.absolutePath, "daemon")
-            environment(getReleaseEnvironment(releaseTmp))
+            environment(getReleaseEnvironment(releaseTmp, releaseName))
             standardOutput = startOutput
             errorOutput = startOutput
             isIgnoreExitValue = true
@@ -44,6 +45,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         process: Process?,
         logger: Logger
     ): Pair<Boolean, String> {
@@ -51,7 +53,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         val errorStream = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(executable.absolutePath, "pid")
-            environment(getReleaseEnvironment(releaseTmp))
+            environment(getReleaseEnvironment(releaseTmp, releaseName))
             standardOutput = pidOutput
             errorOutput = errorStream
             isIgnoreExitValue = true
@@ -71,6 +73,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         process: Process?,
         logger: Logger
     ) {
@@ -79,7 +82,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         val stopOutput = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(executable.absolutePath, "stop")
-            environment(getReleaseEnvironment(releaseTmp))
+            environment(getReleaseEnvironment(releaseTmp, releaseName))
             standardOutput = stopOutput
             errorOutput = stopOutput
             isIgnoreExitValue = true

--- a/buildSrc/src/main/kotlin/platform/windows/WindowsQuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/platform/windows/WindowsQuoterPlatform.kt
@@ -53,6 +53,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         logger: Logger
     ): Process {
         logger.lifecycle("Starting Quoter daemon (Windows - managed process)...")
@@ -64,7 +65,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         val pb = ProcessBuilder(windowsExecutable.absolutePath, "start")
 
         // Set environment variables
-        pb.environment().putAll(getReleaseEnvironment(releaseTmp))
+        pb.environment().putAll(getReleaseEnvironment(releaseTmp, releaseName))
 
         logger.debug("Environment: ${pb.environment().filterKeys { it.startsWith("RELEASE_") }}")
 
@@ -117,6 +118,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         process: Process?,
         logger: Logger
     ): Pair<Boolean, String> {
@@ -133,7 +135,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         val errorStream = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(windowsExecutable.absolutePath, "pid")
-            environment(getReleaseEnvironment(releaseTmp))
+            environment(getReleaseEnvironment(releaseTmp, releaseName))
             standardOutput = pidOutput
             errorOutput = errorStream
             isIgnoreExitValue = true
@@ -165,6 +167,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         process: Process?,
         logger: Logger
     ) {
@@ -178,7 +181,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
             val stopError = ByteArrayOutputStream()
             val result = execOps.exec {
                 commandLine(windowsExecutable.absolutePath, "stop")
-                environment(getReleaseEnvironment(releaseTmp))
+                environment(getReleaseEnvironment(releaseTmp, releaseName))
                 standardOutput = stopOutput
                 errorOutput = stopError
                 isIgnoreExitValue = true

--- a/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
@@ -24,6 +24,7 @@ interface QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         logger: Logger
     ): Process?
 
@@ -40,6 +41,7 @@ interface QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         process: Process?,
         logger: Logger
     ): Pair<Boolean, String>
@@ -56,6 +58,7 @@ interface QuoterPlatform {
         execOps: ExecOperations,
         executable: File,
         releaseTmp: File?,
+        releaseName: String,
         process: Process?,
         logger: Logger
     )
@@ -75,14 +78,25 @@ fun createQuoterPlatform(platform: Platform): QuoterPlatform {
 }
 
 /**
+ * The node name used when no per-checkout name is supplied - the value this was hardcoded to before
+ * the name became configurable, so a caller that does not pass one behaves exactly as before.
+ */
+const val DEFAULT_QUOTER_NODE_NAME = "intellij_elixir@127.0.0.1"
+
+/**
  * Returns the standard environment variables for Quoter daemon.
  * Used by all platform implementations.
+ *
+ * [releaseName] is the distributed Erlang node name the daemon registers with the machine-wide epmd.
+ * It has to differ per checkout: epmd allows one node per name, so a second checkout starting a quoter
+ * under the same name gets "the name ... seems to be in use by another Erlang node" and exits 0, which
+ * the build reports as the daemon dying immediately.
  */
-fun getReleaseEnvironment(releaseTmp: File?): Map<String, String> {
+fun getReleaseEnvironment(releaseTmp: File?, releaseName: String = DEFAULT_QUOTER_NODE_NAME): Map<String, String> {
     return buildMap {
         put("RELEASE_COOKIE", "intellij_elixir")
         put("RELEASE_DISTRIBUTION", "name")
-        put("RELEASE_NAME", "intellij_elixir@127.0.0.1")
+        put("RELEASE_NAME", releaseName)
         releaseTmp?.let { put("RELEASE_TMP", it.absolutePath) }
     }
 }

--- a/buildSrc/src/main/kotlin/quoter/QuoterService.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterService.kt
@@ -5,6 +5,7 @@ import platform.logPlatformDetection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.process.ExecOperations
@@ -29,6 +30,12 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
 
         /** Temporary directory for quoter runtime files */
         val tmpDir: DirectoryProperty
+
+        /**
+         * Distributed Erlang node name the daemon registers with the machine-wide epmd. Per checkout,
+         * so two worktrees can run tests at the same time - see [quoter.DEFAULT_QUOTER_NODE_NAME].
+         */
+        val nodeName: Property<String>
     }
 
     @get:Inject
@@ -60,13 +67,14 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
     private fun startDaemon() {
         val executable = parameters.executable.get().asFile
         val releaseTmp = parameters.tmpDir.orNull?.asFile
+        val nodeName = parameters.nodeName.getOrElse(DEFAULT_QUOTER_NODE_NAME)
         val maxAttempts = 20
 
         logPlatformDetection(logger)
-        logger.lifecycle("Starting Quoter daemon: ${executable.absolutePath}")
+        logger.lifecycle("Starting Quoter daemon: ${executable.absolutePath} as $nodeName")
 
         // Start the daemon (platform-specific)
-        process = quoterPlatform.startDaemon(execOps, executable, releaseTmp, logger)
+        process = quoterPlatform.startDaemon(execOps, executable, releaseTmp, nodeName, logger)
 
         // Wait for daemon to be ready (both platforms use RPC 'pid' command)
         logger.lifecycle("Waiting for Quoter daemon to be ready...")
@@ -75,7 +83,7 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
             Thread.sleep(1000)
 
             val (isRunning, pidOutput) = quoterPlatform.checkStatus(
-                execOps, executable, releaseTmp, process, logger
+                execOps, executable, releaseTmp, nodeName, process, logger
             )
 
             if (isRunning) {
@@ -93,7 +101,7 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
         // leaks and holds the distributed node name, making every subsequent start fail with
         // "name ... in use by another Erlang node".
         logger.warn("Quoter daemon did not become ready; stopping the spawned process to avoid a leak.")
-        quoterPlatform.stopDaemon(execOps, executable, releaseTmp, process, logger)
+        quoterPlatform.stopDaemon(execOps, executable, releaseTmp, nodeName, process, logger)
         process = null
 
         throw RuntimeException("Quoter daemon failed to start after $maxAttempts attempts.")
@@ -104,10 +112,11 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
 
         val executable = parameters.executable.get().asFile
         val releaseTmp = parameters.tmpDir.orNull?.asFile
+        val nodeName = parameters.nodeName.getOrElse(DEFAULT_QUOTER_NODE_NAME)
 
         logger.lifecycle("Shutting down Quoter daemon...")
 
-        quoterPlatform.stopDaemon(execOps, executable, releaseTmp, process, logger)
+        quoterPlatform.stopDaemon(execOps, executable, releaseTmp, nodeName, process, logger)
 
         logger.lifecycle("Quoter daemon shutdown complete")
     }

--- a/buildSrc/src/main/kotlin/quoter/tasks/StartQuoterTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/StartQuoterTask.kt
@@ -6,7 +6,9 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -28,17 +30,56 @@ abstract class StartQuoterTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.NONE)
     abstract val availabilityFile: RegularFileProperty
 
+    /**
+     * The outcome of the *start*, as opposed to [availabilityFile], which records the outcome of the
+     * *build*. Written every run, and authoritative for the test task: a quoter that built fine but
+     * could not start is just as absent, from a test's point of view, as one that never compiled.
+     */
+    @get:OutputFile
+    abstract val startedFile: RegularFileProperty
+
+    /**
+     * Opts back in to a hard failure here, matching `releaseQuoter`'s own flag: with it set, a quoter
+     * that cannot start fails the build instead of marking itself unavailable. Both halves answer the
+     * same question - "is a missing quoter tolerable?" - so one flag governs both.
+     */
+    @get:Input
+    abstract val required: Property<Boolean>
+
     @TaskAction
     fun start() {
         val availability = QuoterAvailability.readFrom(availabilityFile.get().asFile)
+        val startedFile = startedFile.get().asFile
 
         // Nothing was built for this pair, so skip the start rather than spend the service's retries
         // discovering that. Tests that need the daemon fail with this reason; the rest run as usual.
         if (availability != null && !availability.available) {
             logger.lifecycle("Quoter daemon not started - ${availability.reason}")
+            availability.writeTo(startedFile)
             return
         }
 
-        quoterService.get().ensureStarted()
+        // A daemon that will not start is not a reason to fail the build. Only the tests that quote
+        // through it need it; every other test in the suite is unaffected, and failing here runs none
+        // of them - which is what used to happen when a second checkout held the distributed node
+        // name, or when the release script exited 0 without starting. Record the reason and let the
+        // test task decide, exactly as it already does for a quoter that would not compile.
+        try {
+            quoterService.get().ensureStarted()
+            QuoterAvailability.AVAILABLE.writeTo(startedFile)
+        } catch (exception: Exception) {
+            val reason = "quoter daemon failed to start: ${exception.message ?: exception.toString()}"
+            QuoterAvailability.unavailable(reason).writeTo(startedFile)
+
+            if (required.getOrElse(false)) {
+                throw exception
+            }
+
+            logger.warn("Quoter daemon not started - $reason")
+            logger.warn(
+                "Tests that quote through the daemon will fail with that reason; the rest of the suite " +
+                    "still runs. Pass -PquoterRequired=true to fail the build here instead."
+            )
+        }
     }
 }

--- a/src/org/elixir_lang/IntellijElixir.java
+++ b/src/org/elixir_lang/IntellijElixir.java
@@ -9,11 +9,23 @@ import java.io.IOException;
  */
 public class IntellijElixir {
     private static OtpNode localNode = null;
-    public static final String REMOTE_NODE = "intellij_elixir@127.0.0.1";
+
+    /**
+     * Both node names are overridable because Erlang registers a distributed node by name with the
+     * machine-wide epmd, which allows one node per name. With the names fixed, two checkouts running
+     * tests at once collide: the second quoter exits with "the name ... seems to be in use by another
+     * Erlang node", and so would the second test JVM's own node. The build sets these per checkout;
+     * unset, both fall back to the literals used before they were configurable.
+     */
+    public static final String REMOTE_NODE =
+            System.getProperty("elixir.quoter.remoteNode", "intellij_elixir@127.0.0.1");
+
+    private static final String LOCAL_NODE =
+            System.getProperty("elixir.quoter.localNode", "intellij-elixir@127.0.0.1");
 
     public static OtpNode getLocalNode() throws IOException {
         if (localNode == null) {
-            localNode = new OtpNode("intellij-elixir@127.0.0.1", "intellij_elixir");
+            localNode = new OtpNode(LOCAL_NODE, "intellij_elixir");
         }
 
         return localNode;


### PR DESCRIPTION
Two independent build problems, found while running the test suite from a second worktree.

## A fixed Erlang node name stops a second checkout running any test

Erlang registers a distributed node by name with the machine-wide `epmd`, which allows exactly one node per name. Two names were hardcoded — the quoter daemon's `RELEASE_NAME` (`intellij_elixir@127.0.0.1`) and the test JVM's own node in `IntellijElixir.getLocalNode` (`intellij-elixir@127.0.0.1`) — so a second checkout could start neither.

The symptom gave nothing away. The release script prints

```
Protocol 'inet_tcp': the name intellij_elixir@127.0.0.1 seems to be in use by another Erlang node
```

and then **exits 0**, so the build reported only `Windows quoter process died immediately (exit code 0)`: a clean exit code, no mention of a name clash. Confirmed by running `bin/intellij_elixir start` by hand with the same `RELEASE_*` environment while another checkout's daemon was up.

Both names are now derived from the checkout path and threaded through `QuoterService`'s parameters to the platform implementations. Deliberately not a system property: two worktrees can share one Gradle daemon, which is exactly the case a global property would clobber. The test task passes them to the test JVM and declares them as inputs, so a rename invalidates the task rather than reporting the previous run's results. Unset, both fall back to the literals they had before, so a plain build and any non-test use of `IntellijElixir` are unchanged.

Verified by running two worktrees' test tasks concurrently: this one came up as `intellij_elixir_8bbaebb7@127.0.0.1` and passed while another checkout's daemon held the old fixed name.

## A daemon that will not start should not cost the whole suite

`releaseQuoter` already treats a quoter that would not *compile* as a marker rather than a build failure, so a pair whose quoter cannot be built still runs every test that needs no quoter. A quoter that built fine but would not *start* took a different path: `QuoterService` threw, `startQuoter` failed, and the build stopped before a single test ran. From a test's point of view the two cases are identical — the daemon is absent either way — and only the parser tests that quote through it care.

`startQuoter` now writes its own marker recording the outcome of the start, and that marker is what the test task reads. It carries `releaseQuoter`'s reason when the build was the thing that failed, its own when the start was, and `available=true` otherwise, so one file answers "is there a daemon, and if not why not" without the reader consulting two and deciding. The fallback to `releaseQuoter`'s marker remains for the `-x startQuoter` case.

`-PquoterRequired=true` now covers this half too; it previously opted back in to a hard failure for a build failure only, which left the flag half-answering its own question.

Verified by holding the daemon's node name with another checkout's binary, so this checkout's release stayed valid and only the start could fail:

- without the flag — `Quoter daemon not started - quoter daemon failed to start: Windows quoter process died immediately (exit code 0)`, then `CallDefinitionHeadTest`'s 3 tests pass and the build succeeds
- with the flag — `Execution failed for task ':startQuoter' > Windows quoter process died immediately (exit code 0)`

## Not addressed

Concurrent builds across worktrees still contend over the shared Gradle artifact-transform directory holding the unpacked IDE and its JBR, which surfaces as `Unable to delete directory ...transforms/<hash>` or `UnsatisfiedLinkError: no freetype in system library path`. That is a separate problem and is untouched here — parallel builds are no longer blocked by Erlang, but they are not yet safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
