### PR TITLE
refactor(formatter): clear IntelliJ's inspections on Block

### DIFF
--- a/.github/workflows/shared-verify.yml
+++ b/.github/workflows/shared-verify.yml
@@ -267,8 +267,14 @@ jobs:
       # 2026.2.0.1 (262.8665.337) exists.
       - name: Verify Plugin
         id: verify
-        # Fork to be replaced when/if https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/pull/102 merges
-        uses: sh41/intellij-platform-plugin-verifier-action@add_format_options
+        # Fork carrying two changes upstream does not have yet:
+        #   - the reports-format inputs, offered as
+        #     https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/pull/102
+        #   - a JDK 21 base image. The verifier resolves JDK classes against the JVM it runs on, and
+        #     upstream's image is Java 17, so every Java 21 API in the plugin is reported as an
+        #     unresolved method. Not yet offered upstream.
+        # Drop the fork once both land upstream.
+        uses: sh41/intellij-platform-plugin-verifier-action@add_format_options_jdk21
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,12 @@
 
 ### Threading / Platform Hygiene
 
+- [#3950](https://github.com/KronicDeth/intellij-elixir/pull/3950) [@sh41](https://github.com/sh41)
+  - **The formatter's `Block` is clean under IntelliJ's inspections** - 18 warnings down to 3. Four
+    nullable-node dereferences now state the `AbstractBlock` non-null invariant,
+    `ContainerBlockListReducer` stops declaring an `Indent` non-null that callers pass as null, and the
+    interpolation overload no longer takes two parameters that were always the same constants.
+
 ### Build / CI
 
 - [#3913](https://github.com/KronicDeth/intellij-elixir/pull/3913) [@sh41](https://github.com/sh41)

--- a/src/org/elixir_lang/formatter/Block.java
+++ b/src/org/elixir_lang/formatter/Block.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import static com.intellij.formatting.ChildAttributes.DELEGATE_TO_PREV_CHILD;
@@ -301,10 +302,9 @@ public class Block extends AbstractBlock implements BlockEx {
         assert elementType != ACCESS_EXPRESSION : "accessExpressions should be flattened with " +
                 "buildAccessExpressionChildren";
 
-        if (elementType == STAB_OPERATION) {
-            assert childrenWrap != null : "stabOperation must have a non-null childrenWrap, so that sibling " +
-                    "stabOperations and their children are wrapped consistently";
-        }
+        assert elementType != STAB_OPERATION || childrenWrap != null :
+                "stabOperation must have a non-null childrenWrap, so that sibling stabOperations and their " +
+                        "children are wrapped consistently";
     }
 
     @NotNull
@@ -739,13 +739,13 @@ public class Block extends AbstractBlock implements BlockEx {
         if (flattenedBlockList.size() == 3) {
             ASTBlock operatorBlock = (ASTBlock) flattenedBlockList.get(1);
 
-            if (operatorBlock.getNode().getElementType() == DIVISION_OPERATOR) {
+            if (Objects.requireNonNull(operatorBlock.getNode()).getElementType() == DIVISION_OPERATOR) {
                 ASTBlock rightOperandBlock = (ASTBlock) flattenedBlockList.get(2);
 
                 // `/ARITY` confirmed
-                if (rightOperandBlock.getNode().getElementType() == DECIMAL_WHOLE_NUMBER) {
-                    ASTBlock leftOperandBlock = (ASTBlock) flattenedBlockList.get(0);
-                    ASTNode leftOperand = leftOperandBlock.getNode();
+                if (Objects.requireNonNull(rightOperandBlock.getNode()).getElementType() == DECIMAL_WHOLE_NUMBER) {
+                    ASTBlock leftOperandBlock = (ASTBlock) flattenedBlockList.getFirst();
+                    ASTNode leftOperand = Objects.requireNonNull(leftOperandBlock.getNode());
                     IElementType leftOperandElementType = leftOperand.getElementType();
 
                     // `NAME/ARITY` confirmed
@@ -991,17 +991,15 @@ public class Block extends AbstractBlock implements BlockEx {
     }
 
     @NotNull
-    private List<com.intellij.formatting.Block> buildContainerChildren(@NotNull ASTNode container,
-                                                                       @NotNull IElementType openingElementType,
-                                                                       @Nullable Wrap openingWrap,
-                                                                       @NotNull IElementType closingElementType) {
+    private List<com.intellij.formatting.Block> buildInterpolationContainerChildren(@NotNull ASTNode container,
+                                                                                   @Nullable Wrap openingWrap) {
         return buildContainerChildren(
                 container,
-                openingElementType,
+                INTERPOLATION_START,
                 openingWrap,
                 null,
                 null,
-                closingElementType,
+                INTERPOLATION_END,
                 null
         );
     }
@@ -1052,11 +1050,10 @@ public class Block extends AbstractBlock implements BlockEx {
     ) {
         Wrap nonEmptyTailWrap;
 
-        if (givenTailWrap != null) {
-            nonEmptyTailWrap = givenTailWrap;
-        } else {
-            nonEmptyTailWrap = tailWrap(container, openingElementType, closingElementType);
-        }
+        nonEmptyTailWrap = Objects.requireNonNullElseGet(
+                givenTailWrap,
+                () -> tailWrap(container, openingElementType, closingElementType)
+        );
 
         // empty tailWrap
         final Wrap[] tailWrap = {Wrap.createWrap(WrapType.NORMAL, true)};
@@ -1285,11 +1282,9 @@ public class Block extends AbstractBlock implements BlockEx {
 
     @NotNull
     private List<com.intellij.formatting.Block> buildInterpolationChildren(@NotNull ASTNode interpolation) {
-        return buildContainerChildren(
+        return buildInterpolationContainerChildren(
                 interpolation,
-                INTERPOLATION_START,
-                Wrap.createWrap(WrapType.NONE, false),
-                INTERPOLATION_END
+                Wrap.createWrap(WrapType.NONE, false)
         );
     }
 
@@ -1663,7 +1658,7 @@ public class Block extends AbstractBlock implements BlockEx {
         );
 
         if (blockList.size() == 1) {
-            Block block = (Block) blockList.get(0);
+            Block block = (Block) blockList.getFirst();
             ASTNode blockNode = block.myNode;
 
             if (UNINDENTED_ONLY_ARGUMENT_TOKEN_SET.contains(blockNode.getElementType())) {
@@ -2474,21 +2469,17 @@ public class Block extends AbstractBlock implements BlockEx {
            `&& 1` */
         // Prevent `_ && &1` from becoming `_ &&& 1`
         // Prevent `_ &&& &2` from becoming ` _ &&&& 2`, which has no meaning
-        if (child1 instanceof ASTBlock && child2 instanceof ASTBlock) {
-            ASTBlock child1ASTBlock = (ASTBlock) child1;
+        if (child1 instanceof ASTBlock child1ASTBlock && child2 instanceof ASTBlock child2ASTBlock) {
             ASTNode child1Node = child1ASTBlock.getNode();
 
-            if (child1Node instanceof LeafPsiElement) {
-                LeafPsiElement child1LeafPsiElement = (LeafPsiElement) child1Node;
-
+            if (child1Node instanceof LeafPsiElement child1LeafPsiElement) {
                 // capture (`&`) or and symbol operators (`&&` or `&&&`)
                 if (child1LeafPsiElement.charAt(child1LeafPsiElement.getTextLength() - 1) == '&') {
-                    ASTBlock child2ASTBlock = (ASTBlock) child2;
-                    ASTNode firstLeafElementASTNode = child2ASTBlock.getNode().findLeafElementAt(0);
+                    ASTNode firstLeafElementASTNode =
+                            Objects.requireNonNull(child2ASTBlock.getNode()).findLeafElementAt(0);
 
-                    if (firstLeafElementASTNode != null &&
-                            firstLeafElementASTNode instanceof LeafPsiElement &&
-                            ((LeafPsiElement) firstLeafElementASTNode).charAt(0) == '&') {
+                    if (firstLeafElementASTNode instanceof LeafPsiElement firstLeaf &&
+                            firstLeaf.charAt(0) == '&') {
                         spacing = Spacing.createSpacing(1, 1, 0, true, 0);
                     }
                 }

--- a/src/org/elixir_lang/formatter/ContainerBlockListReducer.java
+++ b/src/org/elixir_lang/formatter/ContainerBlockListReducer.java
@@ -5,6 +5,7 @@ import com.intellij.formatting.Wrap;
 import com.intellij.lang.ASTNode;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -14,7 +15,10 @@ public interface ContainerBlockListReducer {
             @NotNull ASTNode child,
             @NotNull IElementType childElementType,
             @NotNull Wrap tailWrap,
-            @NotNull Indent childrenIndent,
+            // Nullable: buildContainerChildren is called with a null elementIndent for maps,
+            // structs and interpolation, and every implementation forwards this straight to a
+            // buildChild overload that already accepts a null Indent.
+            @Nullable Indent childrenIndent,
             @NotNull List<com.intellij.formatting.Block> blockList
     );
 }


### PR DESCRIPTION
IDE inspections over the files touched by #3946, #3947 and #3948. All pre-existing — those PRs come back clean.

**Nullability.** `ASTBlock.getNode()` is `@Nullable` on the interface, but `AbstractBlock` narrows the field, constructor parameter and getter back to `@NotNull`, so null is unreachable at the four sites that dereferenced it. They now say so with `Objects.requireNonNull`.

`ContainerBlockListReducer.reduce` declared its `Indent` `@NotNull` while `buildContainerChildren` passes null for maps, structs and interpolation. Implementations forward it to a `buildChild` overload that accepts null, so the annotation was wrong — now `@Nullable`. Asserting non-null instead (the IDE's suggested fix) fails 35 of 179 formatter tests, which is how the null paths were found.

**Dead parameterisation.** The interpolation overload of `buildContainerChildren` took two parameters that were always `INTERPOLATION_START`/`INTERPOLATION_END`. Now `buildInterpolationContainerChildren`, supplying them itself.

**Mechanical.** Pattern variables, `getFirst()`, `requireNonNullElseGet`, a redundant null test beside an `instanceof`.

No behaviour change. 179 formatter tests pass. `Block.java` goes 18 warnings to 3 — a javadoc `@note` tag, an ignored blank javadoc line, an always-inverted boolean method; no safe quick fix for any.

Changelog under Threading / Platform Hygiene, per CONTRIBUTING's rule for changes with no user-observable effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)