### PR TITLE
fix: gate on written argument count where the code reads written arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@
 
 ### Bug Fixes
 
+- [#3951](https://github.com/KronicDeth/intellij-elixir/pull/3951) [@sh41](https://github.com/sh41)
+  - **`defstruct do ... end` and `defexception do ... end` no longer crash the structure view.** Both
+    were gated on the arity Elixir resolves, which counts a `do` block as an argument even though
+    nothing is actually written inside the call - so the structure view then asserted on an argument
+    list that was empty. Fixes [#2107](https://github.com/KronicDeth/intellij-elixir/issues/2107) and
+    [#1095](https://github.com/KronicDeth/intellij-elixir/issues/1095).
+  - **A piped `defdelegate` with a `do` block no longer throws while resolving variables.** Same
+    resolved-arity-vs-written-arity mismatch as above, reached through `defdelegate`'s own gate.
+
 - [#3948](https://github.com/KronicDeth/intellij-elixir/pull/3948) [@sh41](https://github.com/sh41)
   - **Auto-Indent Lines and paste no longer throw on a map update with a literal on the left**, such
     as `%{%{a} | k: 1}`.

--- a/src/org/elixir_lang/psi/Exception.kt
+++ b/src/org/elixir_lang/psi/Exception.kt
@@ -3,6 +3,7 @@ package org.elixir_lang.psi
 import com.intellij.openapi.util.Pair
 import org.elixir_lang.NameArity
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.call.finalArity
 import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.call.name.Module
 
@@ -15,9 +16,11 @@ object Exception {
             MESSAGE
     )
 
+    // finalArity, not resolvedFinalArity via isCalling(..., 1) - getChildren() reads finalArguments().
+
     @JvmStatic
     fun `is`(call: Call): Boolean {
-        return call.isCalling(Module.KERNEL, Function.DEFEXCEPTION, 1)
+        return call.isCalling(Module.KERNEL, Function.DEFEXCEPTION) && call.finalArity() == 1
     }
 
     fun isCallback(nameArity: Pair<String, Int>): Boolean =

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -160,6 +160,16 @@ private fun Call.computeCallableReference(): PsiReference? =
  *
  * @return [Call.primaryArguments]
  */
+/**
+ * How many arguments are written inside this call, unlike [CallImpl.resolvedFinalArity] which also
+ * counts a `do` block and a piped-in value. Gate on this before reading [finalArguments].
+ *
+ * An extension, matching [finalArguments]'s style, not because it must be - a default method would
+ * work fine here too.
+ */
+@RequiresReadLock
+fun Call.finalArity(): Int? = secondaryArity() ?: primaryArity()
+
 @RequiresReadLock
 fun Call.finalArguments(): Array<PsiElement>? = try {
     (secondaryArguments() ?: primaryArguments())?.map { it!! }?.toTypedArray()
@@ -814,6 +824,7 @@ object CallImpl {
     @Contract(pure = true)
     @JvmStatic
     fun resolvedFinalArity(call: Call): Int = call.resolvedSecondaryArity() ?: call.resolvedPrimaryArity() ?: 0
+
 
     @RequiresReadLock
     @Contract(pure = true)

--- a/src/org/elixir_lang/structure_view/element/Delegation.kt
+++ b/src/org/elixir_lang/structure_view/element/Delegation.kt
@@ -14,6 +14,7 @@ import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function
 import org.elixir_lang.psi.call.name.Module
 import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.call.finalArity
 import org.elixir_lang.psi.impl.call.keywordArgument
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.structure_view.element.CallDefinitionClause.Companion.enclosingModular
@@ -125,7 +126,10 @@ class Delegation(private val modular: Modular, call: Call) : Element<Call?>(call
             }
 
         @JvmStatic
-        fun `is`(call: Call): Boolean = call.isCalling(Module.KERNEL, Function.DEFDELEGATE, 2)
+        // finalArity, not resolvedFinalArity via isCalling(..., 2) - callDefinitionHeadCallList() reads
+        // finalArguments() and indexes it.
+        fun `is`(call: Call): Boolean =
+            call.isCalling(Module.KERNEL, Function.DEFDELEGATE) && call.finalArity() == 2
 
         @RequiresReadLock
         fun fromCall(call: Call): org.elixir_lang.structure_view.element.Delegation? =

--- a/src/org/elixir_lang/structure_view/element/structure/Structure.java
+++ b/src/org/elixir_lang/structure_view/element/structure/Structure.java
@@ -19,6 +19,7 @@ import static org.elixir_lang.psi.call.name.Function.DEFSTRUCT;
 import static org.elixir_lang.psi.call.name.Module.KERNEL;
 import static org.elixir_lang.psi.impl.PsiElementImplKt.stripAccessExpression;
 import static org.elixir_lang.psi.impl.call.CallImplKt.finalArguments;
+import static org.elixir_lang.psi.impl.call.CallImplKt.finalArity;
 
 public class Structure extends Element<Call> {
     /*
@@ -42,8 +43,9 @@ public class Structure extends Element<Call> {
         return elementDescription;
     }
 
+    // finalArity, not resolvedFinalArity via isCalling(..., 1) - getChildren() reads finalArguments().
     public static boolean is(Call call) {
-        return call.isCalling(KERNEL, DEFSTRUCT, 1);
+        return call.isCalling(KERNEL, DEFSTRUCT) && Integer.valueOf(1).equals(finalArity(call));
     }
 
     /*

--- a/tests/org/elixir_lang/structure_view/element/DelegationShapeTest.kt
+++ b/tests/org/elixir_lang/structure_view/element/DelegationShapeTest.kt
@@ -1,0 +1,55 @@
+package org.elixir_lang.structure_view.element
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.structure_view.element.Delegation.Companion.callDefinitionHeadCallList
+import com.intellij.psi.util.PsiTreeUtil
+
+// If Delegation.is accepts a call, reading its head list must not throw - callDefinitionHeadCallList()
+// is also on the variable-resolution path, not just the structure view.
+class DelegationShapeTest : BasePlatformTestCase() {
+    private data class Shape(val label: String, val source: String)
+
+    private fun failureFor(shape: Shape): String? {
+        myFixture.configureByText("delegation_${shape.label}.ex", shape.source)
+
+        return PsiTreeUtil
+            .findChildrenOfType(myFixture.file as ElixirFile, Call::class.java)
+            .filter { call -> Delegation.`is`(call) }
+            .firstNotNullOfOrNull { call ->
+                try {
+                    callDefinitionHeadCallList(call)
+                    null
+                } catch (throwable: Throwable) {
+                    "${shape.label}: ${throwable.javaClass.name}: ${throwable.message} @ " +
+                        throwable.stackTrace.take(2).joinToString(" <- ") {
+                            "${it.className}.${it.methodName}(${it.fileName}:${it.lineNumber})"
+                        }
+                }
+            }
+    }
+
+    fun testAcceptedDelegationShapesReadTheirHeadListWithoutThrowing() {
+        val shapes = listOf(
+            // The ordinary forms, as controls.
+            Shape("to", "defmodule A do\n  defdelegate foo(a), to: B\nend\n"),
+            Shape("to_as", "defmodule A do\n  defdelegate foo(a), to: B, as: :bar\nend\n"),
+            Shape("list", "defmodule A do\n  defdelegate [foo(a), bar(b)], to: B\nend\n"),
+            // A do block and a pipe each raise the resolved arity without writing an argument, so these
+            // are the shapes where the gate's count and the body's count come apart.
+            Shape("do_block", "defmodule A do\n  defdelegate foo(a) do\n    :ok\n  end\nend\n"),
+            Shape("piped", "defmodule A do\n  x |> defdelegate(foo(a))\nend\n"),
+            Shape("piped_do_block", "defmodule A do\n  x |> defdelegate do\n    :ok\n  end\nend\n"),
+            Shape("bare_do_block", "defmodule A do\n  defdelegate do\n    :ok\n  end\nend\n"),
+        )
+
+        val failures = shapes.mapNotNull { shape -> failureFor(shape) }
+
+        assertEquals(
+            "reading the head list threw for:\n" + failures.joinToString("\n"),
+            emptyList<String>(),
+            failures,
+        )
+    }
+}

--- a/tests/org/elixir_lang/structure_view/element/structure/StructureChildrenShapeTest.kt
+++ b/tests/org/elixir_lang/structure_view/element/structure/StructureChildrenShapeTest.kt
@@ -1,0 +1,66 @@
+package org.elixir_lang.structure_view.element.structure
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.structure_view.Model
+
+// Drives defstruct/defexception shapes through the structure view, none of which may throw.
+class StructureChildrenShapeTest : BasePlatformTestCase() {
+    private data class Shape(val label: String, val source: String)
+
+    // Recurses because getChildren() is where the crash lives, not just the root's own children.
+    private fun walk(element: StructureViewTreeElement) {
+        for (child in element.children) {
+            if (child is StructureViewTreeElement) {
+                walk(child)
+            }
+        }
+    }
+
+    private fun failureFor(shape: Shape): String? =
+        try {
+            myFixture.configureByText("issue_2107_${shape.label}.ex", shape.source)
+            walk(Model(myFixture.file as ElixirFile, null).root)
+            null
+        } catch (throwable: Throwable) {
+            "${shape.label}: ${throwable.javaClass.name}: ${throwable.message} @ " +
+                throwable.stackTrace.take(3).joinToString(" <- ") { "${it.className}.${it.methodName}(${it.fileName}:${it.lineNumber})" }
+        }
+
+    fun testStructureAndExceptionShapesDoNotThrowOutOfTheTreeWalk() {
+        val shapes = listOf(
+            // defstruct - the shape Structure was written for, as a control.
+            Shape("defstruct_list", "defmodule A do\n  defstruct [:a, :b]\nend\n"),
+            Shape("defstruct_keywords", "defmodule A do\n  defstruct a: 1, b: 2\nend\n"),
+            Shape("defstruct_no_parens_single", "defmodule A do\n  defstruct :a\nend\n"),
+            Shape("defstruct_parens", "defmodule A do\n  defstruct([:a])\nend\n"),
+            Shape("defstruct_empty_list", "defmodule A do\n  defstruct []\nend\n"),
+            Shape("defstruct_qualified", "defmodule A do\n  Kernel.defstruct([:a])\nend\n"),
+            // defexception - the path that hands a non-defstruct call to Structure.
+            Shape("defexception_list", "defmodule A do\n  defexception [:message]\nend\n"),
+            Shape("defexception_keywords", "defmodule A do\n  defexception message: \"boom\"\nend\n"),
+            Shape("defexception_parens", "defmodule A do\n  defexception([:message])\nend\n"),
+            Shape("defexception_empty_list", "defmodule A do\n  defexception []\nend\n"),
+            Shape("defexception_qualified", "defmodule A do\n  Kernel.defexception([:message])\nend\n"),
+            // do-block forms, where resolvedFinalArity and finalArguments are most likely to diverge.
+            Shape("defexception_do_block", "defmodule A do\n  defexception do\n    :ok\n  end\nend\n"),
+            Shape("defstruct_do_block", "defmodule A do\n  defstruct do\n    :ok\n  end\nend\n"),
+            Shape(
+                "defexception_list_and_do_block",
+                "defmodule A do\n  defexception [:message] do\n    :ok\n  end\nend\n",
+            ),
+            // Incomplete source, which the structure view sees while it is being typed.
+            Shape("defexception_bare", "defmodule A do\n  defexception\nend\n"),
+            Shape("defstruct_bare", "defmodule A do\n  defstruct\nend\n"),
+        )
+
+        val failures = shapes.mapNotNull { shape -> failureFor(shape) }
+
+        assertEquals(
+            "structure view tree walk threw for:\n" + failures.joinToString("\n"),
+            emptyList<String>(),
+            failures,
+        )
+    }
+}


### PR DESCRIPTION
Fixes #2107
Fixes #1095

Two crashes with one cause: a gate that asks how many arguments *Elixir passes*, in front of a body that reads how many arguments were *written*.

## The two counts

The codebase has a deliberate ladder — `primaryArguments` → `primaryArity` → `resolvedPrimaryArity`, and the same for secondary. `resolved` means "adjusted for what Elixir actually passes", which is a real distinction, because two pieces of syntax put an argument somewhere other than the argument list:

```elixir
defstruct do ... end      # sugar for defstruct([do: ...]) — arity 1, nothing written inside the call
x |> foo(y)               # means foo(x, y) — arity 2, only y written inside foo
```

In the PSI the do block is a sibling of the argument list and the piped value belongs to the arrow, not the call, so neither can appear in `primaryArguments()` without inventing structure. Both counts are correct; they measure different things.

The combined row was missing its middle rung. There was `finalArguments` and `resolvedFinalArity` but no `finalArity`, so code wanting the written count reached for `resolvedFinalArity` — the only member named *Final* — and got a number that counts the do block and the pipe.

## What broke

`Structure.is` admitted `defstruct do ... end` on `isCalling(KERNEL, DEFSTRUCT, 1)`, and `Structure.getChildren` then asserted on a `finalArguments` that was null, at `Structure.java:73` — the line #2107's title names. #1095 reaches the same line the same way; its title says NPE because `Call.finalArguments` catches a `NullPointerException`, logs it and returns null, which trips the same assert. Which of the two a reader sees depends only on whether `-ea` was set.

`org.elixir_lang.psi.Exception.is` is the same confusion one step removed: it gates `defexception` on the resolved arity and `Exception.getChildren` hands that call straight to `Structure`.

Auditing every other consumer of `resolvedFinalArity` for the same shape turned up one more, not previously filed: `Delegation.is` gated on `isCalling(KERNEL, DEFDELEGATE, 2)` while `callDefinitionHeadCallList` did `finalArguments()!!` and indexed `[0]`, so `x |> defdelegate do ... end` threw NPE. That one is reachable from variable resolution, not only from an expanding tree.

## The fix

`Call.finalArity()` — `secondaryArity() ?: primaryArity()`, the same two accessors `finalArguments` uses in the same order, so the two cannot drift. Declared as an extension function rather than a `Call` interface member, matching `finalArguments`'s existing style — an *abstract* interface member would need every generated PSI class under `gen/` to override it, but a Java `default` method would not (verified by adding one and building: no `gen/` change required). Kept as an extension for consistency with `finalArguments`, not because it has to be one.

Three gates switched to it — `Structure.is`, `Exception.is`, `Delegation.is` — because all three read `finalArguments` afterwards.

## Why not reconcile the two functions instead

That was tried first and measured, because it is the obvious fix and it is wrong:

| | tests | failures |
|---|---|---|
| baseline, clean `main` | 6975 | 0 |
| making `finalArguments` include the do block and piped value | 6975 | **287** |
| adding `finalArity` and switching the three gates | 6977 | **0** |

The 287 land in rename, find-usages, goto-declaration, completion and sigil injection — around 43 files read `finalArguments` positionally and encode its narrower meaning, so moving index 0 moves the ground under all of them. The change isn't wrong about Elixir; it's wrong about the code. Adding the rung leaves every existing consumer on the function it already used.

## Left alone deliberately

`Implementation`, `Import` and `UnaliasedName` gate on `resolvedFinalArity` but null- and size-check before indexing, which is why they degrade instead of crashing. `Import` was investigated specifically and measured: no shape exists where its gate admits a call and then loses a written `only:` argument, because `resolvedFinalArity >= finalArity` always. Its only divergence is failing to recognise `import B, only: [...] do ... end`, which doesn't compile anyway — so changing it would alter behaviour only for invalid code.

The rule that generalises, measured rather than assumed: **a gate on `resolvedFinalArity == N` admits calls whose written arity is anywhere in `N-2 ..= N`.** A body that then indexes `finalArguments` unconditionally is a bug; one that checks first is not.

## Tests

Both new tests drive the real code paths over a table of shapes and collect what throws, rather than asserting a mechanism decided in advance — the first two explanations of this bug were both wrong, and only running it settled anything. `StructureChildrenShapeTest` covers 16 `defstruct`/`defexception` shapes; only the do-block-only ones were ever affected. `DelegationShapeTest` pins the contract the callers rely on: if `Delegation.is` accepts a call, reading its head list must not throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

