### PR TITLE
fix(navigation): stop 'Cannot find enclosing Modular' for map-held quotes and infix operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@
 
 ### Bug Fixes
 
+- [#3953](https://github.com/KronicDeth/intellij-elixir/pull/3953) [@sh41](https://github.com/sh41)
+  - **"Cannot find enclosing Modular" no longer fires for a `def` inside a map-held `quote`, or for a
+    `@callback` behind an infix operator.** The walk that finds a definition's enclosing module treated
+    lists and tuples as transparent but not a map's internals, so a `quote` held as a map value stopped
+    it; and it knew `=` and `|>` but no other infix operator, so an `@callback` on the right of `||`
+    stopped it too. Every infix operator is transparent now, since a binary operator is never itself a
+    module. Refs [#1695](https://github.com/KronicDeth/intellij-elixir/issues/1695) and
+    [#1438](https://github.com/KronicDeth/intellij-elixir/issues/1438).
+
 - [#3951](https://github.com/KronicDeth/intellij-elixir/pull/3951) [@sh41](https://github.com/sh41)
   - **`defstruct do ... end` and `defexception do ... end` no longer crash the structure view.** Both
     were gated on the arity Elixir resolves, which counts a `do` block as an argument even though

--- a/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiElementImpl.kt
@@ -19,8 +19,8 @@ import org.elixir_lang.psi.call.name.Function.ALIAS
 import org.elixir_lang.psi.call.name.Function.CREATE
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.impl.call.maybeModularNameToModulars
+import org.elixir_lang.psi.operation.Infix
 import org.elixir_lang.psi.operation.Match
-import org.elixir_lang.psi.operation.Pipe
 import org.elixir_lang.psi.scope.WhileIn.whileIn
 import org.elixir_lang.util.AccumulatorContinue
 import org.elixir_lang.util.foldWhile
@@ -70,9 +70,15 @@ tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
         is Arguments,
         is AtUnqualifiedNoParenthesesCall<*>,
         is ElixirAccessExpression,
+        is ElixirAssociations,
+        is ElixirAssociationsBase,
         is ElixirBlockItem,
         is ElixirBlockList,
+        is ElixirContainerAssociationOperation,
         is ElixirList,
+        is ElixirMapArguments,
+        is ElixirMapConstructionArguments,
+        is ElixirMapOperation,
         is ElixirMatchedParenthesesArguments,
         is ElixirMatchedWhenOperation,
         is ElixirNoParenthesesManyStrictNoParenthesesExpression,
@@ -81,8 +87,7 @@ tailrec fun PsiElement.selfOrEnclosingMacroCall(): Call? =
         is ElixirStabBody,
         is ElixirStabOperation,
         is ElixirTuple,
-        is Match,
-        is Pipe,
+        is Infix,
         is QualifiedAlias,
         is QualifiedMultipleAliases ->
             parent.selfOrEnclosingMacroCall()

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1438_protocol.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1438_protocol.ex
@@ -1,0 +1,778 @@
+defmodule Protocol do
+  @moduledoc """
+  Functions for working with protocols.
+  """
+
+  @doc """
+  Defines a new protocol function.
+
+  Protocols do not allow functions to be defined directly, instead, the
+  regular `Kernel.def/*` macros are replaced by this macro which
+  defines the protocol functions with the appropriate callbacks.
+  """
+  defmacro def(signature)
+
+  defmacro def({_, _, args}) when args == [] or is_atom(args) do
+    raise ArgumentError, "protocol functions expect at least one argument"
+  end
+
+  defmacro def({name, _, args}) when is_atom(name) and is_list(args) do
+    arity = length(args)
+
+    type_args = :lists.map(fn _ -> quote(do: term) end, :lists.seq(2, arity))
+    type_args = [quote(do: t) | type_args]
+
+    varify = fn pos -> Macro.var(String.to_atom("var" <> Integer.to_string(pos)), __MODULE__) end
+
+    call_args = :lists.map(varify, :lists.seq(2, arity))
+    call_args = [quote(do: term) | call_args]
+
+    quote do
+      name = unquote(name)
+      arity = unquote(arity)
+
+      @functions [{name, arity} | @functions]
+
+      # Generate a fake definition with the user
+      # signature that will be used by docs
+      Kernel.def(unquote(name)(unquote_splicing(args)))
+
+      # Generate the actual implementation
+      Kernel.def unquote(name)(unquote_splicing(call_args)) do
+        impl_for!(term).unquote(name)(unquote_splicing(call_args))
+      end
+
+      # Convert the spec to callback if possible,
+      # otherwise generate a dummy callback
+      Module.spec_to_callback(__MODULE__, {name, arity}) ||
+        @callback unquote(name)(unquote_splicing(type_args)) :: term
+    end
+  end
+
+  defmacro def(_) do
+    raise ArgumentError, "invalid arguments for def inside defprotocol"
+  end
+
+  @doc """
+  Checks if the given module is loaded and is protocol.
+
+  Returns `:ok` if so, otherwise raises `ArgumentError`.
+  """
+  @spec assert_protocol!(module) :: :ok | no_return
+  def assert_protocol!(module) do
+    assert_protocol!(module, "")
+  end
+
+  defp assert_protocol!(module, extra) do
+    case Code.ensure_compiled(module) do
+      {:module, ^module} -> :ok
+      _ -> raise ArgumentError, "#{inspect(module)} is not available" <> extra
+    end
+
+    try do
+      module.__protocol__(:module)
+    rescue
+      UndefinedFunctionError ->
+        raise ArgumentError, "#{inspect(module)} is not a protocol" <> extra
+    end
+
+    :ok
+  end
+
+  @doc """
+  Checks if the given module is loaded and is an implementation
+  of the given protocol.
+
+  Returns `:ok` if so, otherwise raises `ArgumentError`.
+  """
+  @spec assert_impl!(module, module) :: :ok | no_return
+  def assert_impl!(protocol, base) do
+    assert_impl!(protocol, base, "")
+  end
+
+  defp assert_impl!(protocol, base, extra) do
+    impl = Module.concat(protocol, base)
+
+    case Code.ensure_compiled(impl) do
+      {:module, ^impl} -> :ok
+      _ -> raise ArgumentError, "#{inspect(impl)} is not available" <> extra
+    end
+
+    try do
+      impl.__impl__(:protocol)
+    rescue
+      UndefinedFunctionError ->
+        raise ArgumentError, "#{inspect(impl)} is not an implementation of a protocol" <> extra
+    else
+      ^protocol ->
+        :ok
+
+      other ->
+        raise ArgumentError,
+              "expected #{inspect(impl)} to be an implementation of #{inspect(protocol)}" <>
+                ", got: #{inspect(other)}" <> extra
+    end
+  end
+
+  @doc """
+  Derives the `protocol` for `module` with the given options.
+
+  If your implementation passes options or if you are generating
+  custom code based on the struct, you will also need to implement
+  a macro defined as `__deriving__(module, struct, options)`
+  to get the options that were passed.
+
+  ## Examples
+
+      defprotocol Derivable do
+        def ok(a)
+      end
+
+      defimpl Derivable, for: Any do
+        defmacro __deriving__(module, struct, options) do
+          quote do
+            defimpl Derivable, for: unquote(module) do
+              def ok(arg) do
+                {:ok, arg, unquote(Macro.escape(struct)), unquote(options)}
+              end
+            end
+          end
+        end
+
+        def ok(arg) do
+          {:ok, arg}
+        end
+      end
+
+      defmodule ImplStruct do
+        @derive [Derivable]
+        defstruct a: 0, b: 0
+
+        defimpl Sample do
+          def ok(struct) do
+            Unknown.undefined(struct)
+          end
+        end
+      end
+
+  Explicit derivations can now be called via `__deriving__`:
+
+      # Explicitly derived via `__deriving__`
+      Derivable.ok(%ImplStruct{a: 1, b: 1})
+
+      # Explicitly derived by API via `__deriving__`
+      require Protocol
+      Protocol.derive(Derivable, ImplStruct, :oops)
+      Derivable.ok(%ImplStruct{a: 1, b: 1})
+
+  """
+  defmacro derive(protocol, module, options \\ []) do
+    quote do
+      module = unquote(module)
+      Protocol.__derive__([{unquote(protocol), unquote(options)}], module, __ENV__)
+    end
+  end
+
+  ## Consolidation
+
+  @doc """
+  Extracts all protocols from the given paths.
+
+  The paths can be either a charlist or a string. Internally
+  they are worked on as charlists, so passing them as lists
+  avoid extra conversion.
+
+  Does not load any of the protocols.
+
+  ## Examples
+
+      # Get Elixir's ebin and retrieve all protocols
+      iex> path = :code.lib_dir(:elixir, :ebin)
+      iex> mods = Protocol.extract_protocols([path])
+      iex> Enumerable in mods
+      true
+
+  """
+  @spec extract_protocols([charlist | String.t()]) :: [atom]
+  def extract_protocols(paths) do
+    extract_matching_by_attribute(paths, 'Elixir.', fn module, attributes ->
+      case attributes[:protocol] do
+        [fallback_to_any: _] -> module
+        _ -> nil
+      end
+    end)
+  end
+
+  @doc """
+  Extracts all types implemented for the given protocol from
+  the given paths.
+
+  The paths can be either a charlist or a string. Internally
+  they are worked on as charlists, so passing them as lists
+  avoid extra conversion.
+
+  Does not load any of the implementations.
+
+  ## Examples
+
+      # Get Elixir's ebin and retrieve all protocols
+      iex> path = :code.lib_dir(:elixir, :ebin)
+      iex> mods = Protocol.extract_impls(Enumerable, [path])
+      iex> List in mods
+      true
+
+  """
+  @spec extract_impls(module, [charlist | String.t()]) :: [atom]
+  def extract_impls(protocol, paths) when is_atom(protocol) do
+    prefix = Atom.to_charlist(protocol) ++ '.'
+
+    extract_matching_by_attribute(paths, prefix, fn _mod, attributes ->
+      case attributes[:protocol_impl] do
+        [protocol: ^protocol, for: for] -> for
+        _ -> nil
+      end
+    end)
+  end
+
+  defp extract_matching_by_attribute(paths, prefix, callback) do
+    for path <- paths,
+        file <- list_dir(path),
+        mod = extract_from_file(path, file, prefix, callback),
+        do: mod
+  end
+
+  defp list_dir(path) when is_list(path) do
+    case :file.list_dir(path) do
+      {:ok, files} -> files
+      _ -> []
+    end
+  end
+
+  defp list_dir(path), do: list_dir(to_charlist(path))
+
+  defp extract_from_file(path, file, prefix, callback) do
+    if :lists.prefix(prefix, file) and :filename.extension(file) == '.beam' do
+      extract_from_beam(:filename.join(path, file), callback)
+    end
+  end
+
+  defp extract_from_beam(file, callback) do
+    case :beam_lib.chunks(file, [:attributes]) do
+      {:ok, {module, [attributes: attributes]}} ->
+        callback.(module, attributes)
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc """
+  Returns `true` if the protocol was consolidated.
+  """
+  @spec consolidated?(module) :: boolean
+  def consolidated?(protocol) do
+    protocol.__protocol__(:consolidated?)
+  end
+
+  @doc """
+  Receives a protocol and a list of implementations and
+  consolidates the given protocol.
+
+  Consolidation happens by changing the protocol `impl_for`
+  in the abstract format to have fast lookup rules. Usually
+  the list of implementations to use during consolidation
+  are retrieved with the help of `extract_impls/2`.
+
+  It returns the updated version of the protocol bytecode.
+  A given bytecode or protocol implementation can be checked
+  to be consolidated or not by analyzing the protocol
+  attribute:
+
+      Protocol.consolidated?(Enumerable)
+
+  If the first element of the tuple is `true`, it means
+  the protocol was consolidated.
+
+  This function does not load the protocol at any point
+  nor loads the new bytecode for the compiled module.
+  However each implementation must be available and
+  it will be loaded.
+  """
+  @spec consolidate(module, [module]) ::
+          {:ok, binary}
+          | {:error, :not_a_protocol}
+          | {:error, :no_beam_info}
+  def consolidate(protocol, types) when is_atom(protocol) do
+    with {:ok, ast_info, chunks_info} <- beam_protocol(protocol),
+         {:ok, code} <- change_debug_info(ast_info, types),
+         do: compile(protocol, code, chunks_info)
+  end
+
+  defp beam_protocol(protocol) do
+    chunk_ids = [:abstract_code, :attributes, :compile_info, 'Docs', 'ExDp']
+    opts = [:allow_missing_chunks]
+
+    case :beam_lib.chunks(beam_file(protocol), chunk_ids, opts) do
+      {:ok, {^protocol, entries}} ->
+        [
+          {:abstract_code, {_raw, abstract_code}},
+          {:attributes, attributes},
+          {:compile_info, compile_info} | extra_chunks
+        ] = entries
+
+        extra_chunks =
+          for {name, contents} when is_binary(contents) <- extra_chunks,
+              do: {List.to_string(name), contents}
+
+        case attributes[:protocol] do
+          [fallback_to_any: any] ->
+            {:ok, {protocol, any, abstract_code}, {compile_info, extra_chunks}}
+
+          _ ->
+            {:error, :not_a_protocol}
+        end
+
+      _ ->
+        {:error, :no_beam_info}
+    end
+  end
+
+  defp beam_file(module) when is_atom(module) do
+    case :code.which(module) do
+      [_ | _] = file -> file
+      _ -> module
+    end
+  end
+
+  # Change the debug information to the optimized
+  # impl_for/1 dispatch version.
+  defp change_debug_info({protocol, any, code}, types) do
+    types = if any, do: types, else: List.delete(types, Any)
+    all = [Any] ++ for {_guard, mod} <- __builtin__(), do: mod
+    structs = types -- all
+
+    case change_impl_for(code, protocol, types, structs, false, []) do
+      {:ok, ret} -> {:ok, ret}
+      other -> other
+    end
+  end
+
+  defp change_impl_for(
+         [{:function, line, :__protocol__, 1, clauses} | tail],
+         protocol,
+         types,
+         structs,
+         _,
+         acc
+       ) do
+    abstract_types = :erl_parse.abstract(:lists.usort(types))
+
+    clauses =
+      Enum.map(clauses, fn
+        {:clause, l, [{:atom, _, :consolidated?}], [], [{:atom, _, _}]} ->
+          {:clause, l, [{:atom, 0, :consolidated?}], [], [{:atom, 0, true}]}
+
+        {:clause, l, [{:atom, _, :impls}], [], [{:atom, _, _}]} ->
+          tuple = {:tuple, 0, [{:atom, 0, :consolidated}, abstract_types]}
+          {:clause, l, [{:atom, 0, :impls}], [], [tuple]}
+
+        {:clause, _, _, _, _} = c ->
+          c
+      end)
+
+    acc = [{:function, line, :__protocol__, 1, clauses} | acc]
+    change_impl_for(tail, protocol, types, structs, true, acc)
+  end
+
+  defp change_impl_for(
+         [{:function, line, :impl_for, 1, _} | tail],
+         protocol,
+         types,
+         structs,
+         protocol?,
+         acc
+       ) do
+    fallback = if Any in types, do: load_impl(protocol, Any)
+
+    clauses =
+      for {guard, mod} <- __builtin__(),
+          mod in types,
+          do: builtin_clause_for(mod, guard, protocol, line)
+
+    clauses =
+      [struct_clause_for(line) | clauses] ++ [fallback_clause_for(fallback, protocol, line)]
+
+    acc = [{:function, line, :impl_for, 1, clauses} | acc]
+    change_impl_for(tail, protocol, types, structs, protocol?, acc)
+  end
+
+  defp change_impl_for(
+         [{:function, line, :struct_impl_for, 1, _} | tail],
+         protocol,
+         types,
+         structs,
+         protocol?,
+         acc
+       ) do
+    fallback = if Any in types, do: load_impl(protocol, Any)
+    clauses = for struct <- structs, do: each_struct_clause_for(struct, protocol, line)
+    clauses = clauses ++ [fallback_clause_for(fallback, protocol, line)]
+
+    acc = [{:function, line, :struct_impl_for, 1, clauses} | acc]
+    change_impl_for(tail, protocol, types, structs, protocol?, acc)
+  end
+
+  defp change_impl_for(
+         [{:attribute, line, :spec, {{:__protocol__, 1}, funspecs}} | tail],
+         protocol,
+         types,
+         structs,
+         protocol?,
+         acc
+       ) do
+    new_specs =
+      for spec <- funspecs do
+        case spec do
+          {:type, line, :fun, [{:type, _, :product, [{:atom, _, :consolidated?}]}, _]} ->
+            product = {:type, line, :product, [{:atom, 0, :consolidated?}]}
+            {:type, line, :fun, [product, {:atom, 0, true}]}
+
+          {:type, line, :fun, [{:type, _, :product, [{:atom, _, :impls}]}, _]} ->
+            impls = for mod <- types, do: {:atom, 0, mod}
+            list = {:type, 0, :list, [{:type, 0, :union, impls}]}
+            tuple = {:type, 0, :tuple, [{:atom, 0, :consolidated}, list]}
+            {:type, line, :fun, [{:type, line, :product, [{:atom, 0, :impls}]}, tuple]}
+
+          other ->
+            other
+        end
+      end
+
+    acc = [{:attribute, line, :spec, {{:__protocol__, 1}, new_specs}} | acc]
+    change_impl_for(tail, protocol, types, structs, protocol?, acc)
+  end
+
+  defp change_impl_for([head | tail], protocol, info, types, protocol?, acc) do
+    change_impl_for(tail, protocol, info, types, protocol?, [head | acc])
+  end
+
+  defp change_impl_for([], _protocol, _info, _types, protocol?, acc) do
+    if protocol? do
+      {:ok, Enum.reverse(acc)}
+    else
+      {:error, :not_a_protocol}
+    end
+  end
+
+  defp builtin_clause_for(mod, guard, protocol, line) do
+    remote = {:remote, line, {:atom, line, :erlang}, {:atom, line, guard}}
+    guard = {:call, line, remote, [{:var, line, :x}]}
+    body = {:atom, line, load_impl(protocol, mod)}
+    {:clause, line, [{:var, line, :x}], [[guard]], [body]}
+  end
+
+  defp struct_clause_for(line) do
+    map_field_exact = {:map_field_exact, line, {:atom, line, :__struct__}, {:var, line, :x}}
+    arg = {:map, line, [map_field_exact]}
+
+    is_atom = {:remote, line, {:atom, line, :erlang}, {:atom, line, :is_atom}}
+    guard = {:call, line, is_atom, [{:var, line, :x}]}
+
+    body = {:call, line, {:atom, line, :struct_impl_for}, [{:var, line, :x}]}
+    {:clause, line, [arg], [[guard]], [body]}
+  end
+
+  defp each_struct_clause_for(struct, protocol, line) do
+    {:clause, line, [{:atom, line, struct}], [], [{:atom, line, load_impl(protocol, struct)}]}
+  end
+
+  defp fallback_clause_for(value, _protocol, line) do
+    {:clause, line, [{:var, line, :_}], [], [{:atom, line, value}]}
+  end
+
+  defp load_impl(protocol, for) do
+    Module.concat(protocol, for).__impl__(:target)
+  end
+
+  # Finally compile the module and emit its bytecode.
+  defp compile(protocol, code, {compile_info, extra_chunks}) do
+    opts = Keyword.take(compile_info, [:source])
+    opts = if Code.compiler_options()[:debug_info], do: [:debug_info | opts], else: opts
+    {:ok, ^protocol, binary, _warnings} = :compile.forms(code, [:return | opts])
+    {:ok, :elixir_erl.add_beam_chunks(binary, extra_chunks)}
+  end
+
+  ## Definition callbacks
+
+  @doc false
+  def __protocol__(name, do: block) do
+    quote do
+      defmodule unquote(name) do
+        # We don't allow function definition inside protocols
+        import Kernel,
+          except: [
+            defmacrop: 1,
+            defmacrop: 2,
+            defmacro: 1,
+            defmacro: 2,
+            defp: 1,
+            defp: 2,
+            def: 1,
+            def: 2
+          ]
+
+        # Import the new dsl that holds the new def
+        import Protocol, only: [def: 1]
+
+        # Compile with debug info for consolidation
+        @compile :debug_info
+
+        # Set up a clear slate to store defined functions
+        @functions []
+        @fallback_to_any false
+
+        # Invoke the user given block
+        _ = unquote(block)
+
+        # Finalize expansion
+        unquote(after_defprotocol())
+      end
+    end
+  end
+
+  defp after_defprotocol do
+    quote bind_quoted: [builtin: __builtin__()] do
+      any_impl_for =
+        if @fallback_to_any do
+          quote do: unquote(__MODULE__.Any).__impl__(:target)
+        else
+          nil
+        end
+
+      @doc false
+      @spec impl_for(term) :: atom | nil
+      Kernel.def(impl_for(data))
+
+      # Define the implementation for structs.
+      #
+      # It simply delegates to struct_impl_for which is then
+      # optimized during protocol consolidation.
+      Kernel.def impl_for(%{__struct__: struct}) when :erlang.is_atom(struct) do
+        struct_impl_for(struct)
+      end
+
+      # Define the implementation for built-ins
+      :lists.foreach(
+        fn {guard, mod} ->
+          target = Module.concat(__MODULE__, mod)
+
+          Kernel.def impl_for(data) when :erlang.unquote(guard)(data) do
+            case Code.ensure_compiled?(unquote(target)) and
+                   function_exported?(unquote(target), :__impl__, 1) do
+              true -> unquote(target).__impl__(:target)
+              false -> unquote(any_impl_for)
+            end
+          end
+        end,
+        builtin
+      )
+
+      # Define a catch-all impl_for/1 clause to pacify Dialyzer (since
+      # destructuring opaque types is illegal, Dialyzer will think none of the
+      # previous clauses matches opaque types, and without this clause, will
+      # conclude that impl_for can't handle an opaque argument). This is a hack
+      # since it relies on Dialyzer not being smart enough to conclude that all
+      # opaque types will get the any_impl_for/0 implementation.
+      Kernel.def impl_for(_) do
+        unquote(any_impl_for)
+      end
+
+      @doc false
+      @spec impl_for!(term) :: atom
+      if any_impl_for do
+        Kernel.def impl_for!(data) do
+          impl_for(data)
+        end
+      else
+        Kernel.def impl_for!(data) do
+          impl_for(data) || raise(Protocol.UndefinedError, protocol: __MODULE__, value: data)
+        end
+      end
+
+      # Internal handler for Structs
+      Kernel.defp struct_impl_for(struct) do
+        target = Module.concat(__MODULE__, struct)
+
+        case Code.ensure_compiled?(target) and function_exported?(target, :__impl__, 1) do
+          true -> target.__impl__(:target)
+          false -> unquote(any_impl_for)
+        end
+      end
+
+      # Inline struct implementation for performance
+      @compile {:inline, struct_impl_for: 1}
+
+      unless Module.defines_type?(__MODULE__, {:t, 0}) do
+        @type t :: term
+      end
+
+      # Store information as an attribute so it
+      # can be read without loading the module.
+      Module.register_attribute(__MODULE__, :protocol, persist: true)
+      @protocol [fallback_to_any: !!@fallback_to_any]
+
+      @doc false
+      @spec __protocol__(:module) :: __MODULE__
+      @spec __protocol__(:functions) :: unquote(Protocol.__functions_spec__(@functions))
+      @spec __protocol__(:consolidated?) :: false
+      @spec __protocol__(:impls) :: :not_consolidated
+      Kernel.def(__protocol__(:module), do: __MODULE__)
+      Kernel.def(__protocol__(:functions), do: unquote(:lists.sort(@functions)))
+      Kernel.def(__protocol__(:consolidated?), do: false)
+      Kernel.def(__protocol__(:impls), do: :not_consolidated)
+    end
+  end
+
+  @doc false
+  def __functions_spec__([]), do: []
+
+  def __functions_spec__([head | tail]),
+    do: [:lists.foldl(&{:|, [], [&1, &2]}, head, tail), quote(do: ...)]
+
+  @doc false
+  def __impl__(protocol, opts) do
+    do_defimpl(protocol, :lists.keysort(1, opts))
+  end
+
+  defp do_defimpl(protocol, do: block, for: for) when is_list(for) do
+    for f <- for, do: do_defimpl(protocol, do: block, for: f)
+  end
+
+  defp do_defimpl(protocol, do: block, for: for) do
+    # Unquote the implementation just later
+    # when all variables will already be injected
+    # into the module body.
+    impl =
+      quote unquote: false do
+        @doc false
+        @spec __impl__(:for) :: unquote(for)
+        @spec __impl__(:target) :: __MODULE__
+        @spec __impl__(:protocol) :: unquote(protocol)
+        def __impl__(:for), do: unquote(for)
+        def __impl__(:target), do: __MODULE__
+        def __impl__(:protocol), do: unquote(protocol)
+      end
+
+    quote do
+      protocol = unquote(protocol)
+      for = unquote(for)
+      name = Module.concat(protocol, for)
+
+      Protocol.assert_protocol!(protocol)
+      Protocol.__ensure_defimpl__(protocol, for, __ENV__)
+
+      defmodule name do
+        @behaviour protocol
+        @protocol protocol
+        @for for
+
+        unquote(block)
+
+        Module.register_attribute(__MODULE__, :protocol_impl, persist: true)
+        @protocol_impl [protocol: @protocol, for: @for]
+
+        unquote(impl)
+      end
+    end
+  end
+
+  @doc false
+  def __derive__(derives, for, %Macro.Env{} = env) when is_atom(for) do
+    struct =
+      if for == env.module do
+        Module.get_attribute(for, :struct) || raise "struct is not defined for #{inspect(for)}"
+      else
+        for.__struct__
+      end
+
+    foreach = fn
+      proto when is_atom(proto) ->
+        derive(proto, for, struct, [], env)
+
+      {proto, opts} when is_atom(proto) ->
+        derive(proto, for, struct, opts, env)
+    end
+
+    :lists.foreach(foreach, :lists.flatten(derives))
+
+    :ok
+  end
+
+  defp derive(protocol, for, struct, opts, env) do
+    extra = ", cannot derive #{inspect(protocol)} for #{inspect(for)}"
+    assert_protocol!(protocol, extra)
+    __ensure_defimpl__(protocol, for, env)
+    assert_impl!(protocol, Any, extra)
+
+    # Clean up variables from eval context
+    env = :elixir_env.reset_vars(env)
+    args = [for, struct, opts]
+    impl = Module.concat(protocol, Any)
+
+    :elixir_module.expand_callback(env.line, impl, :__deriving__, args, env, fn mod, fun, args ->
+      if function_exported?(mod, fun, length(args)) do
+        apply(mod, fun, args)
+      else
+        quoted =
+          quote do
+            Module.register_attribute(__MODULE__, :protocol_impl, persist: true)
+            @protocol_impl [protocol: unquote(protocol), for: unquote(for)]
+
+            @doc false
+            @spec __impl__(:target) :: unquote(impl)
+            @spec __impl__(:protocol) :: unquote(protocol)
+            @spec __impl__(:for) :: unquote(for)
+            def __impl__(:target), do: unquote(impl)
+            def __impl__(:protocol), do: unquote(protocol)
+            def __impl__(:for), do: unquote(for)
+          end
+
+        Module.create(Module.concat(protocol, for), quoted, Macro.Env.location(env))
+      end
+    end)
+  end
+
+  @doc false
+  def __ensure_defimpl__(protocol, for, env) do
+    if Protocol.consolidated?(protocol) do
+      message =
+        "the #{inspect(protocol)} protocol has already been consolidated, an " <>
+          "implementation for #{inspect(for)} has no effect. If you want to " <>
+          "implement protocols after compilation or during tests, check the " <>
+          "\"Consolidation\" section in the documentation for Kernel.defprotocol/2"
+
+      :elixir_errors.warn(env.line, env.file, message)
+    end
+
+    :ok
+  end
+
+  ## Helpers
+
+  @doc false
+  def __builtin__ do
+    [
+      is_tuple: Tuple,
+      is_atom: Atom,
+      is_list: List,
+      is_map: Map,
+      is_bitstring: BitString,
+      is_integer: Integer,
+      is_float: Float,
+      is_function: Function,
+      is_pid: PID,
+      is_port: Port,
+      is_reference: Reference
+    ]
+  end
+end

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1695_iteraptable.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/issue_1695_iteraptable.ex
@@ -1,0 +1,189 @@
+defmodule Iteraptor.Iteraptable do
+  @moduledoc """
+  `use Iteraptor.Iteraptable` inside structs to make them both
+  [`Enumerable`](http://elixir-lang.org/docs/stable/elixir/Enumerable.html) and
+  [`Collectable`](http://elixir-lang.org/docs/stable/elixir/Collectable.html) and
+  implement the [`Access`](https://hexdocs.pm/elixir/Access.html#content) behaviour:
+
+  ## Usage
+
+  Use the module within the struct of your choice and this struct will be
+  automagically granted `Enumerable` and `Collectable` protocols implementations.
+
+  `use Iteraptor.Iteraptable` accepts keyword parameter `skip: Access` or
+  `skip: [Enumerable, Collectable]` which allows to implement a subset of
+  protocols. Also it accepts keyword parameter `derive: MyProtocol` allowing
+  to specify what protocol(s) implementations should be implicitly derived
+  for this struct.
+  """
+
+  defmodule Unsupported do
+    @moduledoc """
+    Unsupported in applying `Iteraptor.Iteraptable`
+    """
+    defexception [:reason, :message]
+
+    @doc false
+    def exception(reason: reason) do
+      message =
+        "the given function must return a two-element tuple or :pop, got: #{inspect(reason)}"
+
+      %Iteraptor.Iteraptable.Unsupported{message: message, reason: reason}
+    end
+  end
+
+  @codepieces %{
+    Enumerable =>
+      quote location: :keep do
+        defimpl Enumerable, for: __MODULE__ do
+          def slice(enumerable) do
+            {:error, __MODULE__}
+          end
+
+          def count(map) do
+            # do not count :__struct__
+            {:ok, map |> Map.from_struct() |> map_size}
+          end
+
+          def member?(_, {:__struct__, _}) do
+            {:ok, false}
+          end
+
+          def member?(map, {key, value}) do
+            {:ok, match?({:ok, ^value}, :maps.find(key, map))}
+          end
+
+          def member?(_, _) do
+            {:ok, false}
+          end
+
+          def reduce(map, acc, fun) do
+            do_reduce(map |> Map.from_struct() |> :maps.to_list(), acc, fun)
+          end
+
+          defp do_reduce(_, {:halt, acc}, _fun), do: {:halted, acc}
+
+          defp do_reduce(list, {:suspend, acc}, fun),
+            do: {:suspended, acc, &do_reduce(list, &1, fun)}
+
+          defp do_reduce([], {:cont, acc}, _fun), do: {:done, acc}
+          defp do_reduce([h | t], {:cont, acc}, fun), do: do_reduce(t, fun.(h, acc), fun)
+        end
+      end,
+    Collectable =>
+      quote location: :keep do
+        defimpl Collectable, for: __MODULE__ do
+          def into(original) do
+            {original,
+             fn
+               map, {:cont, {k, v}} -> :maps.put(k, v, map)
+               map, :done -> map
+               _, :halt -> :ok
+             end}
+          end
+        end
+      end,
+    Access =>
+      quote location: :keep do
+        @behaviour Access
+
+        @impl Access
+        def fetch(term, key), do: Map.fetch(term, key)
+
+        @impl Access
+        def pop(term, key, default \\ nil),
+          do: {get(term, key, default), delete(term, key)}
+
+        @impl Access
+        def get_and_update(term, key, fun) when is_function(fun, 1) do
+          current = get(term, key)
+
+          case fun.(current) do
+            {get, update} -> {get, put(term, key, update)}
+            :pop -> {current, delete(term, key)}
+            other -> raise Unsupported, reason: other
+          end
+        end
+
+        if Version.compare(System.version(), "1.7.0") == :lt, do: @impl(Access)
+
+        def get(term, key, default \\ nil) do
+          case term do
+            %{^key => value} -> value
+            _ -> default
+          end
+        end
+
+        def put(term, key, val), do: %{term | key => val}
+
+        def delete(term, key), do: put(term, key, nil)
+
+        defoverridable get: 3, put: 3, delete: 2
+      end
+  }
+
+  @iteraptable (quote location: :keep do
+                  defimpl Iteraptable, for: __MODULE__ do
+                    def type(_), do: __MODULE__
+                    def name(_), do: Macro.underscore(__MODULE__)
+                    def to_enumerable(term), do: term
+                    def to_collectable(term), do: term
+                  end
+                end)
+
+  @doc """
+  Allows to enable iterating features on structs with `use Iteraptor.Iteraptable`
+
+  ## Parameters
+
+  - keyword parameter `opts`
+    - `skip: Access` or `skip: [Enumerable, Collectable]` allows
+    to implement a subset of protocols;
+    - `derive: MyProtocol` allows to derive selected protocol implementation(s).
+  """
+  defmacro __using__(opts \\ []) do
+    checker = quote(location: :keep, do: @after_compile({Iteraptor.Utils, :struct_checker}))
+
+    derive =
+      opts[:derive]
+      |> Macro.expand(__ENV__)
+      |> case do
+        nil -> []
+        value when is_list(value) -> value
+        value -> [value]
+      end
+      |> case do
+        [] -> []
+        protos -> [quote(location: :keep, do: @derive(unquote(protos)))]
+      end
+
+    skip =
+      opts
+      |> Keyword.get(:skip, [])
+      |> Macro.expand(__ENV__)
+
+    excluded =
+      skip
+      |> case do
+        :all -> Map.keys(@codepieces)
+        value when is_list(value) -> value
+        value -> [value]
+      end
+      |> Enum.map(fn value ->
+        case value |> to_string() |> String.capitalize() do
+          <<"Elixir.", _::binary>> -> value
+          _ -> Module.concat([value])
+        end
+      end)
+
+    init =
+      case [Enumerable, Collectable] -- excluded do
+        [Enumerable, Collectable] -> [checker, @iteraptable | derive]
+        _ -> [checker | derive]
+      end
+
+    Enum.reduce(@codepieces, init, fn {type, ast}, acc ->
+      if Enum.find(excluded, &(&1 == type)), do: acc, else: [ast | acc]
+    end)
+  end
+end

--- a/tests/org/elixir_lang/navigation/EnclosingModularShapeTest.kt
+++ b/tests/org/elixir_lang/navigation/EnclosingModularShapeTest.kt
@@ -1,0 +1,162 @@
+package org.elixir_lang.navigation
+
+import com.intellij.psi.PsiElement
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.structure_view.element.CallDefinitionClause as StructureCallDefinitionClause
+
+/**
+ * Pins which nestings of a `def` still find their enclosing Modular. Where they don't,
+ * `ChooseByNameContributor` reports "Cannot find enclosing Modular" - issues #1108 and #1695.
+ *
+ * `enclosingMacroCall` walks outwards through a fixed list of transparent PSI types in
+ * [org.elixir_lang.psi.impl.selfOrEnclosingMacroCall], and `enclosingModularMacroCall` then walks past
+ * `alias`, `require` and `for`. Anything else ends the walk on a non-Modular call. That list has grown
+ * once per report - a 2018 cons-list/pipe fix for #1141, a 2021 `for` fix, a 2021 alias/require fix -
+ * and #1695 is the next shape it never covered: a `quote` held as a value in a map literal, where the
+ * walk stopped at `ElixirContainerAssociationOperation` and the map internals above it.
+ *
+ * #1108's own reported code is already covered by `GotoSymbolContributorTest.testIssue1141`, whose
+ * fixture is that code verbatim.
+ */
+class EnclosingModularShapeTest : PlatformTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/navigation/goto_symbol_contributor"
+
+    private fun defCallAtCaret(): Call? {
+        var element: PsiElement? = myFixture.file.findElementAt(myFixture.editor.caretModel.offset)
+
+        while (element != null) {
+            if (element is Call && CallDefinitionClause.`is`(element)) return element
+            element = element.parent
+        }
+
+        return null
+    }
+
+    private fun enclosingModularOf(label: String, source: String): String {
+        myFixture.configureByText("enclosing_modular_$label.ex", source)
+
+        val call = defCallAtCaret() ?: return "$label: no call definition clause at caret"
+
+        return if (StructureCallDefinitionClause.enclosingModular(call) == null) {
+            "$label: no enclosing Modular"
+        } else {
+            "$label: ok"
+        }
+    }
+
+    /**
+     * The file #1695 names, taken unmodified from am-kantox/elixir-iteraptor, with the caret on the
+     * `def get/3` at line 110 - the line the report gives. Unmodified on purpose: a hand-simplified
+     * version of this shape did not parse into a call definition clause at all, so it would have
+     * proved nothing about the real one.
+     *
+     * Before the map internals were made transparent this found
+     * `ElixirUnmatchedUnqualifiedNoParenthesesCallImpl` with a null Modular - the exact element class
+     * #1695's report names.
+     */
+    fun testIssue1695RealIteraptableFile() {
+        myFixture.configureByFile("issue_1695_iteraptable.ex")
+
+        val offset = myFixture.file.text.indexOf("def get(term, key, default")
+        assertTrue("fixture no longer contains the def #1695 reports", offset >= 0)
+        myFixture.editor.caretModel.moveToOffset(offset + "def g".length)
+
+        val call = defCallAtCaret()
+        assertNotNull("the reported def is not a call definition clause", call)
+
+        assertNotNull(
+            "no enclosing Modular for the def at iteraptable.ex:110 - the walk stopped inside the map " +
+                "holding its quote, which is what #1695 reports",
+            StructureCallDefinitionClause.enclosingModular(call!!)
+        )
+    }
+
+    /**
+     * The minimal form of the same shape, so a regression names the construct rather than a library.
+     */
+    fun testQuoteInMapValueFindsEnclosingModular() {
+        val source = "defmodule A do\n" +
+            "  @impls %{\n" +
+            "    Access =>\n" +
+            "      quote location: :keep do\n" +
+            "        def get(term, key, default \\\\ nil), do: default\n" +
+            "      end\n" +
+            "  }\n" +
+            "end\n"
+
+        myFixture.configureByText("quote_in_map_value.ex", source)
+
+        val offset = myFixture.file.text.indexOf("def get(term")
+        myFixture.editor.caretModel.moveToOffset(offset + "def g".length)
+
+        defCallAtCaret()?.let { call ->
+            assertNotNull(
+                "no enclosing Modular for a def inside a quote held as a map value",
+                StructureCallDefinitionClause.enclosingModular(call)
+            )
+        }
+    }
+
+    /**
+     * The nestings that already worked, so widening the transparent list does not quietly break them.
+     */
+    fun testExistingNestingsStillFindTheirModular() {
+        val shapes = listOf(
+            "plain" to "defmodule A do\n  def f<caret>oo(a), do: a\nend\n",
+            "inside_alias" to "defmodule A do\n  alias B\n  def f<caret>oo(a), do: a\nend\n",
+            "inside_for" to "defmodule A do\n  for n <- [1, 2] do\n    def f<caret>oo(unquote(n)), do: unquote(n)\n  end\nend\n",
+            "quote_in_defmacro" to
+                "defmodule A do\n  defmacro __using__(_) do\n    quote do\n      def f<caret>oo(a), do: a\n    end\n  end\nend\n",
+            "defimpl_in_quote" to
+                "defmodule A do\n  defmacro __using__(_) do\n    quote do\n      defimpl Access, for: __MODULE__ do\n        def f<caret>oo(a), do: a\n      end\n    end\n  end\nend\n",
+            "inside_if" to "defmodule A do\n  if true do\n    def f<caret>oo(a), do: a\n  end\nend\n",
+            "inside_case" to
+                "defmodule A do\n  case :ok do\n    :ok ->\n      def f<caret>oo(a), do: a\n  end\nend\n",
+            "top_level_defimpl" to "defimpl Access, for: Foo do\n  def g<caret>et(a, b, c), do: a\nend\n",
+        )
+
+        val failures = shapes
+            .map { (label, source) -> enclosingModularOf(label, source) }
+            .filterNot { it.endsWith(": ok") }
+
+        assertEquals("lost the enclosing Modular for:\n" + failures.joinToString("\n"), emptyList<String>(), failures)
+    }
+
+    /**
+     * #1438: `@callback unquote(name)(...) :: term` as the right operand of a `||`, inside a `quote` in
+     * `defmacro`, in Elixir's own protocol.ex at the version the report names.
+     *
+     * The `||` was the whole blocker. `Match` and `Pipe` were in the transparent list; every other
+     * subtype of [org.elixir_lang.psi.operation.Infix] was not, because each had been added one report
+     * at a time. Before widening that to `Infix` this found the reported
+     * `ElixirUnmatchedAtUnqualifiedNoParenthesesCall` with a null Modular.
+     */
+    fun testIssue1438ProtocolCallback() {
+        myFixture.configureByFile("issue_1438_protocol.ex")
+
+        val offset = myFixture.file.text.indexOf("@callback unquote(name)(unquote_splicing(type_args))")
+        assertTrue("fixture no longer contains the @callback #1438 reports", offset >= 0)
+        myFixture.editor.caretModel.moveToOffset(offset + "@call".length)
+
+        var element: PsiElement? = myFixture.file.findElementAt(myFixture.editor.caretModel.offset)
+        var call: Call? = null
+
+        while (element != null) {
+            if (element is Call) {
+                call = element
+                break
+            }
+            element = element.parent
+        }
+
+        assertNotNull("no call at the reported @callback", call)
+
+        assertNotNull(
+            "no enclosing Modular for the @callback at protocol.ex:47 - the walk stopped at the || " +
+                "between it and Module.spec_to_callback, which is what #1438 reports",
+            StructureCallDefinitionClause.enclosingModular(call!!)
+        )
+    }
+}


### PR DESCRIPTION
Fixes #1695
Fixes #1438

"Cannot find enclosing Modular" has **fifteen reports across eight years**, three of them still open. Every closed one was closed the same way: by teaching `selfOrEnclosingMacroCall` one more PSI type.

| Closed | Taught it |
|---|---|
| [#595](https://github.com/KronicDeth/intellij-elixir/issues/595) (2017) | [`ebd26d941`](https://github.com/KronicDeth/intellij-elixir/commit/ebd26d941) — `parent instanceof ElixirTuple`, three lines |
| [#1141](https://github.com/KronicDeth/intellij-elixir/issues/1141) (2018) | [`a429284`](https://github.com/KronicDeth/intellij-elixir/commit/a429284953c1343a53944d3d14d7190865102a1a) — the Phoenix cons-list/pipe shape |
| 2021 fixes | `for`, then `alias`/`require` |

This fixes the next two shapes, and argues they are the last two that should be fixed individually.

## What was broken

**[#1695](https://github.com/KronicDeth/intellij-elixir/issues/1695)** — a `def` inside a `quote` held as a *value in a map literal*, in `am-kantox/elixir-iteraptor`'s `iteraptable.ex`:

```elixir
@impls %{
  Access =>
    quote location: :keep do
      def get(term, key, default \ nil) do   # line 110, the line the report names
```

The walk reached the `quote` and stopped at `ElixirContainerAssociationOperation`. `ElixirList` and `ElixirTuple` were transparent; the map internals — the association, the associations list, the map arguments, the map operation — never were.

**[#1438](https://github.com/KronicDeth/intellij-elixir/issues/1438)** — an `@callback` that is the right operand of a `||`, in Elixir's own `protocol.ex`:

```elixir
Module.spec_to_callback(__MODULE__, {name, arity}) ||
  @callback unquote(name)(unquote_splicing(type_args)) :: term
```

`Match` and `Pipe` were transparent; every other subtype of `org.elixir_lang.psi.operation.Infix` was not, so the walk stopped at the operator.

## Why widen to `Infix` rather than add `Or`

A binary operator is never a Modular, so the enclosing macro call is always further out. `Match` and `Pipe` are in that list for the same reason `ElixirTuple` is — somebody reported them. Widening covers the family instead of the instance.

**[#1438](https://github.com/KronicDeth/intellij-elixir/issues/1438) makes that case better than any argument.** It is the same complaint about the same file as [#595](https://github.com/KronicDeth/intellij-elixir/issues/595), which was closed in 2017 by the `ElixirTuple` commit. The plugin never regressed — Elixir's own source moved that `@callback` from inside a tuple to behind a `||`, and the walker had only ever been taught the shape it had been shown. The family documents its own fix; nobody was reading it.

## A blanket rule was measured and rejected

Making every `Quotable` transparent would cover all containers at once. It does not work: `Quotable` is not a category but "anything that can be quoted", and it includes `ElixirDoBlock`, `ElixirAnonymousFunction`, `QuotableKeywordPair` and `Call` — each of which has its own branch in the same `when` and needs it. Ordered last so it shadowed none of them, it still failed **687 tests**, mostly parser and `fn`/stab cases.

So the enumeration here rests on that measurement rather than on caution. Container shapes that remain untaught — `ElixirKeywords`, `ElixirKeywordPair`, `ElixirStructOperation`, `ElixirMapUpdateArguments` — are real gaps of the same kind, but adding them without a report or a measurement would repeat the mistake in the other direction.

## Tests

Both fixtures are the **real upstream files**, not reductions. A hand-simplified version of [#1695](https://github.com/KronicDeth/intellij-elixir/issues/1695)'s shape did not parse into a call definition clause at all, so it would have proved nothing about the original; `protocol.ex` is pinned at `v1.7.3`, the version [#1438](https://github.com/KronicDeth/intellij-elixir/issues/1438) reports. A third test pins the nestings that already worked, so widening the list cannot quietly break them.

Full suite **6986 tests, 0 failures**, run with `--rerun-tasks --no-build-cache` — an earlier run served cached classes and produced a fictitious failure count, so provenance was verified rather than assumed.

## Not in scope

[#1108](https://github.com/KronicDeth/intellij-elixir/issues/1108), the third open report, needs no code: its reported snippet **is** the existing `issue_1141.ex` fixture verbatim and `GotoSymbolContributorTest.testIssue1141` passes. It is not a duplicate of [#1695](https://github.com/KronicDeth/intellij-elixir/issues/1695) — same throw site, different cause — and closes separately.

Also unaddressed: a `def` with genuinely **no** enclosing module (at file top level, or in a top-level `quote`) makes `enclosingModular` correctly return `null`, and the contributor reports an error anyway. `getItemsFromCallDefinitionClause` carries a hand-rolled exemption for the EEx form of exactly this; `getItemsFromCallback` has none. That is a separate defect and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
