### PR TITLE
feat(injection): inject EEx into ~E sigils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Enhancements
 
+- [#3954](https://github.com/KronicDeth/intellij-elixir/pull/3954) [@sh41](https://github.com/sh41)
+  - **`~E` sigils now get EEx highlighting and completion.** `~H` injected HEEx and `~L` injected EEx,
+    but Phoenix.HTML's own `~E` fell through to no injection at all, leaving the template as plain
+    string text. It is EEx, like `~L`, and shares the same experimental HTML-injection setting.
+    Refs [#1257](https://github.com/KronicDeth/intellij-elixir/issues/1257).
+
 - [#3925](https://github.com/KronicDeth/intellij-elixir/pull/3925) [@sh41](https://github.com/sh41)
   - **File and line are now linked inside an inspected stack trace.** A crash report often carries
     its trace as a term rather than a formatted trace, putting each frame's location in a keyword

--- a/src/org/elixir_lang/injection/ElixirSigilInjector.kt
+++ b/src/org/elixir_lang/injection/ElixirSigilInjector.kt
@@ -99,7 +99,7 @@ internal class ElixirSigilInjector : MultiHostInjector {
 
         return when (sigilName) {
             'H' -> HeexLanguage.INSTANCE
-            'L' -> EexLanguage.INSTANCE
+            'E', 'L' -> EexLanguage.INSTANCE
             'r' -> RegExpLanguage.INSTANCE
             else -> null
         }

--- a/tests/org/elixir_lang/injection/HeexSigilInjectionTest.kt
+++ b/tests/org/elixir_lang/injection/HeexSigilInjectionTest.kt
@@ -17,7 +17,7 @@ import org.elixir_lang.eex.Language as EexLanguage
 
 /**
  * `~H` sigils must inject the same three-root HEEx tree a `.heex` file gets - HTML data, Elixir
- * code, and the HEEx root that layers them - not plain HTML text. `~L` stays plain EEx.
+ * code, and the HEEx root that layers them - not plain HTML text. `~E` and `~L` stay plain EEx.
  */
 class HeexSigilInjectionTest : PlatformTestCase() {
     private var originalEnableHtmlInjection = false
@@ -123,6 +123,60 @@ class HeexSigilInjectionTest : PlatformTestCase() {
         assertNotNull(
             "Expected `@x` inside <%= %> to parse as Elixir PSI, not HTML text",
             atOperation
+        )
+    }
+
+    fun testESigilInjectsEexNotHeex() {
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def render(assigns) do
+                    ~E'''
+                    <div><%= @x %></div>
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val sigilHeredoc = PsiTreeUtil.findChildOfType(myFixture.file, SigilHeredocLiteral::class.java)
+        checkNotNull(sigilHeredoc) { "Sigil host not found in test file" }
+
+        val injected = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(sigilHeredoc).orEmpty()
+        assertTrue(
+            "Expected an EEx injection for ~E, got: ${injected.map { it.first.let { p -> p.containingFile.language } }}",
+            injected.any { it.first.containingFile.language.isKindOf(EexLanguage.INSTANCE) }
+        )
+        assertFalse(
+            "~E must not inject HEEx",
+            injected.any { it.first.containingFile.language.isKindOf(HeexLanguage.INSTANCE) }
+        )
+    }
+
+    fun testESigilInjectsNothingWhenSettingDisabled() {
+        ElixirExperimentalSettings.instance.state.enableHtmlInjection = false
+
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def render(assigns) do
+                    ~E'''
+                    <div><%= @x %></div>
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val sigilHeredoc = PsiTreeUtil.findChildOfType(myFixture.file, SigilHeredocLiteral::class.java)
+        checkNotNull(sigilHeredoc) { "Sigil host not found in test file" }
+
+        val injected = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(sigilHeredoc)
+        assertTrue(
+            "Expected no injection while the experimental setting is off, got: $injected",
+            injected.isNullOrEmpty()
         )
     }
 


### PR DESCRIPTION
`languageForSigil` mapped `~H` to HEEx and `~L` to EEx but let `~E` fall through to null, so Phoenix.HTML's own EEx sigil got no injection at all — no highlighting, no completion, no brace matching inside the template.

`~E` and `~L` are both plain EEx, so they share a branch. The experimental `enableHtmlInjection` gate is unchanged: it lives in `PsiLanguageInjectionHost.isValidHost` and already covers every sigil, so `~E` inherits it exactly as `~L` does.

Two cases added to `HeexSigilInjectionTest`, mirroring the existing `~L` and setting-disabled ones. Checked to pin rather than merely pass — without the fix `testESigilInjectsEexNotHeex` fails with `Expected an EEx injection for ~E, got: []`; with it, all seven pass.

Fixes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)