### PR TITLE
fix(mix): ignore the allow_pre dep option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,11 @@
 
 ### Bug Fixes
 
+- [#3957](https://github.com/KronicDeth/intellij-elixir/pull/3957) [@sh41](https://github.com/sh41)
+  - **A dep with `allow_pre:` no longer reports an unknown Mix dep option.** It is a Hex flag that
+    cannot change where a dep is checked out. Fixes
+    [#2487](https://github.com/KronicDeth/intellij-elixir/issues/2487).
+
 - [#3953](https://github.com/KronicDeth/intellij-elixir/pull/3953) [@sh41](https://github.com/sh41)
   - **"Cannot find enclosing Modular" no longer fires for a `def` inside a map-held `quote`, or for a
     `@callback` behind an infix operator.** The walk that finds a definition's enclosing module treated

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -68,8 +68,8 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 val key = keywordPair.keywordKey.text
 
                                 when (key) {
-                                    "app", "branch", "commit", "compile", "env", "git", "github", "hex", "manager",
-                                    "only", "optional", "organization", "override", "ref", "repo", "runtime",
+                                    "allow_pre", "app", "branch", "commit", "compile", "env", "git", "github", "hex",
+                                    "manager", "only", "optional", "organization", "override", "ref", "repo", "runtime",
                                     GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets",
                                     EDELIVER_DISTILLERY_WARN_MISSING, "sha", "depth", "subdir", "warn_if_outdated" -> acc
 

--- a/tests/org/elixir_lang/PlatformTestCase.kt
+++ b/tests/org/elixir_lang/PlatformTestCase.kt
@@ -57,4 +57,59 @@ abstract class PlatformTestCase : BasePlatformTestCase() {
         return Pair(result as T, capturedMessage)
     }
 
+    /**
+     * One error passed to [LoggedErrorProcessor.processError], with the `#` that `TestLoggerFactory`
+     * prefixes onto logger names already stripped from [category].
+     *
+     * [org.elixir_lang.errorreport.Logger] puts its own title in the [Throwable] and a PSI excerpt in
+     * the log message, so a test asserting on what *the plugin* reported wants [title], while one
+     * asserting on what a platform logger reported wants [message].
+     */
+    protected data class LoggedError(val category: String, val message: String, val title: String?)
+
+    /**
+     * Executes code that may log errors, capturing every one of them.
+     *
+     * Everything is captured and the caller filters, because the three things worth keying on differ
+     * per test - an exact category, a partial one, or the [LoggedError.title] of an error raised
+     * through [org.elixir_lang.errorreport.Logger]. Baking any one of those into the helper would
+     * leave the other two writing their own [LoggedErrorProcessor].
+     *
+     * @param suppress whether to swallow what is captured. [LoggedErrorProcessor]'s default action
+     *   set includes [LoggedErrorProcessor.Action.RETHROW], so a test that deliberately trips a
+     *   logged error fails on the error itself rather than on its own assertion unless this is true.
+     *   Pass `false` to keep the default, where any logged error should fail the test outright and
+     *   the captured list only sharpens the message.
+     * @param block The code to execute
+     * @return Pair of (result from block, errors in the order they were logged)
+     */
+    // `List` is qualified because `org.elixir_lang.List` is a PSI class in this package and shadows it.
+    protected fun <T> captureLoggedErrors(
+        suppress: Boolean = true,
+        block: () -> T
+    ): Pair<T, kotlin.collections.List<LoggedError>> {
+        val captured = mutableListOf<LoggedError>()
+        var result: T? = null
+
+        val processor = object : LoggedErrorProcessor() {
+            override fun processError(
+                category: String,
+                message: String,
+                details: Array<out String>,
+                t: Throwable?
+            ): Set<Action> {
+                captured.add(LoggedError(category.removePrefix("#"), message, t?.message))
+
+                return if (suppress) Action.NONE else Action.ALL
+            }
+        }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            result = block()
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return Pair(result as T, captured.toList())
+    }
+
 }

--- a/tests/org/elixir_lang/injection/markdown/DelegateToInjectorTest.kt
+++ b/tests/org/elixir_lang/injection/markdown/DelegateToInjectorTest.kt
@@ -2,7 +2,6 @@ package org.elixir_lang.injection.markdown
 
 import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.LoggedErrorProcessor
 import org.elixir_lang.ElixirLanguage
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
@@ -37,36 +36,21 @@ class DelegateToInjectorTest : PlatformTestCase() {
     fun testDelegateToKeyDoesNotCauseSevereError() {
         myFixture.configureByFile("delegate_to.ex")
 
-        var severeLogged = false
-        var severeMessage: String? = null
-
-        val processor = object : LoggedErrorProcessor() {
-            override fun processError(
-                category: String,
-                message: String,
-                details: Array<out String>,
-                t: Throwable?
-            ): Set<Action> {
-                val normalizedCategory = category.removePrefix("#")
-                if (normalizedCategory.contains("elixir_lang.injection.markdown.Injector")) {
-                    severeLogged = true
-                    severeMessage = message
-                }
-                // Return NONE to prevent the error from propagating and failing the test infrastructure
-                return Action.NONE
-            }
-        }
-
-        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+        val (_, loggedErrors) = captureLoggedErrors {
             // Trigger highlighting - this invokes all MultiHostInjectors including our Injector
             myFixture.doHighlighting()
         }
 
-        assertFalse(
-            "The markdown Injector logged a SEVERE error for an @doc keyword pair: $severeMessage. " +
+        val injectorErrors = loggedErrors.filter {
+            it.category.contains("elixir_lang.injection.markdown.Injector")
+        }
+
+        assertEmpty(
+            "The markdown Injector logged a SEVERE error for an @doc keyword pair: " +
+                "${injectorErrors.map { it.message }}. " +
                 "The injector must handle 'delegate_to' (and any other non-markdown metadata key) " +
                 "without logging errors.",
-            severeLogged
+            injectorErrors
         )
     }
 

--- a/tests/org/elixir_lang/mix/DepTest.kt
+++ b/tests/org/elixir_lang/mix/DepTest.kt
@@ -1,0 +1,110 @@
+package org.elixir_lang.mix
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirTuple
+
+/**
+ * Pins how [Dep.from] sorts a Mix dep's options.
+ *
+ * Every option lands in one of three arms: ignored because it cannot move the dep's directory,
+ * handled because it can, or reported through [org.elixir_lang.errorreport.Logger] because the
+ * plugin has never seen it. The reported arm is the only one a user ever notices, and none of the
+ * three was asserted anywhere before this class - an ignored option and an unknown one both return
+ * `deps/<name>`, so the logged error is the only difference between them.
+ *
+ * The option names here are [Dep.from]'s own list, so dropping one from either without the other
+ * fails.
+ */
+class DepTest : PlatformTestCase() {
+    /**
+     * Options Mix accepts that genuinely cannot change where the dep is checked out.
+     *
+     * `sha`, `commit` and `organization` are absent from `Mix.Tasks.Deps`' documented set. The two
+     * named constants are misspellings that widely installed packages ship, referenced by name rather
+     * than spelled out so a future reader does not "correct" them.
+     *
+     * `sparse` and `subdir` are on [Dep.from]'s ignored list but are deliberately absent here,
+     * because they do not belong on it: `Mix.SCM.Git` joins each onto the dep's destination, so Mix
+     * checks the dep out at `deps/<name>/<option>`. Adding either here would assert that the current
+     * answer is correct. Tracked on #3928; when it is fixed they join the handled options below.
+     */
+    private val pathNeutralOptions = listOf(
+        "allow_pre", "app", "branch", "commit", "compile", "depth", "env", "git", "github", "hex",
+        "manager", "only", "optional", "organization", "override", "ref", "repo", "runtime",
+        GUARDIAN_RUNTIME_TYPO, "sha", "submodules", "system_env", "tag", "targets",
+        EDELIVER_DISTILLERY_WARN_MISSING, "warn_if_outdated"
+    )
+
+    fun testPathNeutralOptionsAreNotReported() {
+        val depTuples = pathNeutralOptions.joinToString(",\n") { "{:dep_$it, \"~> 1.0\", $it: true}" }
+
+        val (deps, errorTitles) = depsFrom(depTuples)
+
+        assertEmpty("No path-neutral option may be reported as unknown", errorTitles)
+        assertEquals("Expected every dep tuple to parse", pathNeutralOptions.size, deps.size)
+
+        pathNeutralOptions.forEachIndexed { index, option ->
+            assertEquals("`$option` must not change the dep path", "deps/dep_$option", deps[index]?.path)
+            assertEquals("`$option` must not change the dep type", Dep.Type.LIBRARY, deps[index]?.type)
+        }
+    }
+
+    fun testUnknownOptionIsReported() {
+        val (deps, errorTitles) = depsFrom("{:my_dep, \"~> 1.0\", not_a_mix_dep_option: true}")
+
+        assertEquals(
+            listOf(
+                "Don't know if Mix.Dep option `not_a_mix_dep_option` is important for determining " +
+                        "location of dependency"
+            ),
+            errorTitles
+        )
+        assertEquals("An unknown option must still leave the accumulated dep", "deps/my_dep", deps.single()?.path)
+    }
+
+    fun testPathOptionReplacesDepsPath() {
+        val (deps, errorTitles) = depsFrom("{:my_dep, path: \"../my_dep\"}")
+
+        assertEmpty("`path` is handled, so it must not be reported", errorTitles)
+        assertEquals("../my_dep", deps.single()?.path)
+    }
+
+    fun testInUmbrellaOptionUsesUmbrellaApplicationPath() {
+        val (deps, errorTitles) = depsFrom("{:my_dep, in_umbrella: true}")
+
+        assertEmpty("`in_umbrella` is handled, so it must not be reported", errorTitles)
+        assertEquals("apps/my_dep", deps.single()?.path)
+        assertEquals(Dep.Type.MODULE, deps.single()?.type)
+    }
+
+    /**
+     * Parses [depTuples] as the `deps` of a `mix.exs` and runs [Dep.from] over each tuple, returning
+     * the deps in source order alongside the title of every error [Dep] logged.
+     */
+    private fun depsFrom(depTuples: String): Pair<List<Dep?>, List<String>> {
+        val (deps, loggedErrors) = captureLoggedErrors {
+            val psiFile = myFixture.configureByText(
+                "mix.exs",
+                """
+                defmodule Sample.MixProject do
+                  def project do
+                    [
+                      deps: [
+                        $depTuples
+                      ]
+                    ]
+                  end
+                end
+                """.trimIndent()
+            )
+
+            PsiTreeUtil.findChildrenOfType(psiFile, ElixirTuple::class.java).map { Dep.from(it) }
+        }
+
+        return Pair(
+            deps,
+            loggedErrors.filter { it.category == Dep::class.java.name }.map { it.title ?: it.message }
+        )
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/UnquoteCallbackNamedVariableTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UnquoteCallbackNamedVariableTest.kt
@@ -1,6 +1,5 @@
 package org.elixir_lang.reference.callable
 
-import com.intellij.testFramework.LoggedErrorProcessor
 import org.elixir_lang.PlatformTestCase
 import java.io.File
 
@@ -19,20 +18,9 @@ import java.io.File
 class UnquoteCallbackNamedVariableTest : PlatformTestCase() {
 
     private fun testNoErrorLogged(fixtureDir: String, fixtureFile: String, displayName: String) {
-        var errorLogged = false
-        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
-            override fun processError(
-                category: String,
-                message: String,
-                details: Array<out String>,
-                t: Throwable?
-            ): Set<Action> {
-                if (t?.message?.contains("Don't know how to walk unquoted variable parent") == true) {
-                    errorLogged = true
-                }
-                return Action.ALL
-            }
-        }) {
+        // suppress = false keeps the default RETHROW, so any logged error fails the test outright;
+        // the captured list only sharpens the message for the one this is actually about.
+        val (_, loggedErrors) = captureLoggedErrors(suppress = false) {
             val testFile = File("testData/org/elixir_lang/reference/callable/$fixtureDir", fixtureFile)
             val content = testFile.readText()
             val psiFile = myFixture.configureByText(fixtureFile, content)
@@ -53,9 +41,11 @@ class UnquoteCallbackNamedVariableTest : PlatformTestCase() {
             })
         }
 
-        assertFalse(
+        assertEmpty(
             "Logger.error should not be called for unquoted variable parent in $displayName",
-            errorLogged
+            loggedErrors.filter {
+                it.title?.contains("Don't know how to walk unquoted variable parent") == true
+            }
         )
     }
 


### PR DESCRIPTION
`allow_pre` is a Hex flag documented on `Version.match?/3`, not a Mix dep option — `grep -rn allow_pre lib/mix/lib/` in elixir-lang/elixir returns nothing, so it cannot reach the dep's destination and belongs on `Dep.from`'s path-neutral list. Both reports came from `deps/opentelemetry_ecto/mix.exs`, which the reporter could not edit.

Checked against Elixir source rather than assumed, since every previous fix in this family added a name on the belief that it was path-neutral. Exactly four options move a dep: `path` and `in_umbrella`, both handled, and `sparse` and `subdir`, which are on the ignored list and should not be. Not fixed here — recorded on #3928.

Two commits: the shared test helper first, then the fix.

- **`test: share one helper for asserting on a logged error`** — `DelegateToInjectorTest` and `UnquoteCallbackNamedVariableTest` had each written their own `LoggedErrorProcessor`. `captureLoggedErrors` captures records and leaves matching to the caller, since the callers key on different fields.
- **`fix(mix): ignore the allow_pre dep option`** — the one-line change, plus `DepTest`. Nothing asserted any of `Dep.from`'s three arms, because a known option and an unknown one both return `deps/<name>` and only the logged error differs. `sparse` and `subdir` are left out rather than asserted, so nothing claims their current answer is correct.

Before: 5 tests, 1 failure, `allow_pre`. After: 22 pass across the four affected classes.

Fixes #2487
