### PR TITLE
fix(build): start epmd from the Erlang SDK, not the quoter release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,14 @@
 
 ### Build / CI
 
+- [#3960](https://github.com/KronicDeth/intellij-elixir/pull/3960) [@sh41](https://github.com/sh41)
+  - **`epmd` is now started from the Erlang SDK rather than the quoter's own bundled ERTS.** A
+    distributed node starts `epmd` from the ERTS of whatever release is starting, detached, so the one
+    the quoter left behind ran from under `cache/` inside the checkout. On Windows a running executable
+    pins its own directory, which made deleting a checkout or a git worktree fail with "Device or
+    resource busy" long after the build finished. The build now starts `epmd` from the SDK first and
+    passes `-start_epmd false`, falling back to the previous behaviour when no SDK `epmd` is found.
+
 - [#3913](https://github.com/KronicDeth/intellij-elixir/pull/3913) [@sh41](https://github.com/sh41)
   - **Quoter tests now respect the quoting rules for the Elixir version under test.** Six quoted-form
     divergences are gated on the release that introduced each, so the same fixtures pass on every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,14 @@ The build system automatically detects your platform:
 - Verify no orphaned Erlang processes: `tasklist | findstr erl`
 - Kill orphaned processes: `taskkill /F /IM erl.exe`
 
+**Deleting a checkout or worktree fails with "Device or resource busy":**
+- A leftover `epmd` running from inside the tree pins the directory. The build starts `epmd` from the
+  Erlang SDK to avoid this, but one started earlier can still be holding it.
+- Find it with `Get-Process epmd | Select-Object Id,Path`; if the path is inside the checkout, stop it
+  with `Stop-Process -Id <id> -Force`.
+- Check `epmd -names` first: `epmd` is machine-wide, so stopping it deregisters every node and fails
+  any test run in progress in another checkout.
+
 **`erl` not found, or the build starts compiling Elixir from source:**
 - The resolver could not find the *expected* version. Check what it decided - it logs
   `Expected versions (from ...): Elixir ..., Erlang ...` followed by `Resolved SDKs: ...` with the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -890,14 +890,22 @@ val releaseQuoter = tasks.register<ReleaseQuoterTask>("releaseQuoter") {
     inputs.dir(quoterUnzippedPath.dir("deps")).withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
+// Written by resolveElixirErlangSdks below. Declared here because a build service's `parameters {}`
+// runs at registration rather than deferred like a task lambda, so a val declared further down is
+// still null at that point.
+val sdkPropertiesFile = layout.buildDirectory.file("elixir-erlang-sdks.properties")
+
 // Register the QuoterService - Gradle calls close() at build end regardless of failure.
-// The daemon is a self-contained mix release (bundled ERTS), so it needs no Elixir/Erlang SDK here.
+// The daemon is a self-contained mix release (bundled ERTS), so it needs no Elixir/Erlang SDK to run.
+// sdkProperties is only for epmd's sake: started from the SDK, the machine-wide daemon stays out of
+// cache/, where a leftover pins the checkout against deletion. See quoter.Epmd.
 // See: https://docs.gradle.org/current/userguide/build_services.html
 val quoterService = gradle.sharedServices.registerIfAbsent("quoter", QuoterService::class) {
     parameters {
         executable.set(quoterExe)
         tmpDir.set(quoterTmpPath)
         nodeName.set(quoterNodeName)
+        sdkProperties.set(sdkPropertiesFile)
     }
 }
 
@@ -1024,8 +1032,6 @@ tasks.named<Zip>("buildPlugin") {
     }
 }
 
-
-val sdkPropertiesFile = layout.buildDirectory.file("elixir-erlang-sdks.properties")
 
 val resolveElixirErlangSdks = tasks.register<ResolveElixirErlangSdksTask>("resolveElixirErlangSdks") {
     description = "Resolves Erlang and Elixir SDKs for testing"

--- a/buildSrc/src/main/kotlin/platform/posix/PosixQuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/platform/posix/PosixQuoterPlatform.kt
@@ -10,8 +10,10 @@ import java.io.File
 /**
  * POSIX implementation of QuoterPlatform.
  * Uses the 'daemon' command which detaches the process automatically.
+ *
+ * [startEpmd] false when an epmd is already answering - see [quoter.Epmd].
  */
-class PosixQuoterPlatform : QuoterPlatform {
+class PosixQuoterPlatform(private val startEpmd: Boolean = true) : QuoterPlatform {
 
     override fun startDaemon(
         execOps: ExecOperations,
@@ -25,7 +27,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         val startOutput = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(executable.absolutePath, "daemon")
-            environment(getReleaseEnvironment(releaseTmp, releaseName))
+            environment(getReleaseEnvironment(releaseTmp, releaseName, startEpmd))
             standardOutput = startOutput
             errorOutput = startOutput
             isIgnoreExitValue = true
@@ -53,7 +55,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         val errorStream = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(executable.absolutePath, "pid")
-            environment(getReleaseEnvironment(releaseTmp, releaseName))
+            environment(getReleaseEnvironment(releaseTmp, releaseName, startEpmd))
             standardOutput = pidOutput
             errorOutput = errorStream
             isIgnoreExitValue = true
@@ -82,7 +84,7 @@ class PosixQuoterPlatform : QuoterPlatform {
         val stopOutput = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(executable.absolutePath, "stop")
-            environment(getReleaseEnvironment(releaseTmp, releaseName))
+            environment(getReleaseEnvironment(releaseTmp, releaseName, startEpmd))
             standardOutput = stopOutput
             errorOutput = stopOutput
             isIgnoreExitValue = true

--- a/buildSrc/src/main/kotlin/platform/windows/WindowsQuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/platform/windows/WindowsQuoterPlatform.kt
@@ -17,8 +17,11 @@ import kotlin.concurrent.thread
  * so we use 'start' and manage the process lifecycle directly.
  *
  * This approach does NOT use Windows services (no admin required).
+ *
+ * [startEpmd] false when an epmd is already answering. It matters most here: erlexec launches epmd
+ * detached on Windows, and a running executable pins its own directory - see [quoter.Epmd].
  */
-class WindowsQuoterPlatform : QuoterPlatform {
+class WindowsQuoterPlatform(private val startEpmd: Boolean = true) : QuoterPlatform {
 
     /**
      * Converts the executable path to Windows format by appending .bat extension.
@@ -65,7 +68,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         val pb = ProcessBuilder(windowsExecutable.absolutePath, "start")
 
         // Set environment variables
-        pb.environment().putAll(getReleaseEnvironment(releaseTmp, releaseName))
+        pb.environment().putAll(getReleaseEnvironment(releaseTmp, releaseName, startEpmd))
 
         logger.debug("Environment: ${pb.environment().filterKeys { it.startsWith("RELEASE_") }}")
 
@@ -135,7 +138,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
         val errorStream = ByteArrayOutputStream()
         val result = execOps.exec {
             commandLine(windowsExecutable.absolutePath, "pid")
-            environment(getReleaseEnvironment(releaseTmp, releaseName))
+            environment(getReleaseEnvironment(releaseTmp, releaseName, startEpmd))
             standardOutput = pidOutput
             errorOutput = errorStream
             isIgnoreExitValue = true
@@ -181,7 +184,7 @@ class WindowsQuoterPlatform : QuoterPlatform {
             val stopError = ByteArrayOutputStream()
             val result = execOps.exec {
                 commandLine(windowsExecutable.absolutePath, "stop")
-                environment(getReleaseEnvironment(releaseTmp, releaseName))
+                environment(getReleaseEnvironment(releaseTmp, releaseName, startEpmd))
                 standardOutput = stopOutput
                 errorOutput = stopError
                 isIgnoreExitValue = true

--- a/buildSrc/src/main/kotlin/quoter/Epmd.kt
+++ b/buildSrc/src/main/kotlin/quoter/Epmd.kt
@@ -1,0 +1,67 @@
+package quoter
+
+import org.gradle.api.logging.Logger
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Keeps the machine-wide epmd out of the checkout.
+ *
+ * A distributed node starts epmd from the ERTS of whatever release is starting, detached, and the
+ * quoter's release lives under `cache/` - so on Windows the leftover pins that directory and deleting
+ * the checkout fails with "Device or resource busy". Only the first epmd survives (it is a singleton on
+ * port 4369), so starting one from the SDK first makes the release's own attempt lose the race.
+ */
+object Epmd {
+    private const val TIMEOUT_SECONDS = 10L
+
+    /**
+     * epmd ships in the ERTS directory, not in `<erlangHome>/bin` alongside `erl`, and the ERTS version
+     * is not the OTP version - so it is found rather than derived. Where a tree holds more than one
+     * ERTS any epmd will do; the sort is only for a stable choice, not a version comparison.
+     */
+    fun find(erlangHome: File): File? {
+        val names = listOf("epmd.exe", "epmd")
+        val ertsBins = (erlangHome.listFiles { file -> file.isDirectory && file.name.startsWith("erts-") } ?: emptyArray())
+            .sortedBy { it.name }
+            .map { File(it, "bin") }
+
+        return (ertsBins + File(erlangHome, "bin"))
+            .firstNotNullOfOrNull { bin -> names.map { File(bin, it) }.firstOrNull { it.isFile } }
+    }
+
+    /**
+     * `epmd -daemon` is a no-op when the port is already bound, so this runs on every build regardless
+     * of who started the one already there. The `-names` probe is what the result reports: suppressing
+     * the release's own start on a false positive would leave it unable to bring up distribution.
+     */
+    fun ensureRunning(epmd: File, logger: Logger): Boolean = try {
+        run(epmd, "-daemon")
+        run(epmd, "-names").also { up ->
+            logger.info(if (up) "epmd is up, from ${epmd.absolutePath}" else "epmd did not answer")
+        }
+    } catch (exception: Exception) {
+        logger.info("Could not start epmd from ${epmd.absolutePath}: ${exception.message}")
+        false
+    }
+
+    /**
+     * Deliberately not `ExecOperations`: `-daemon` leaves a detached child holding the stdout handle it
+     * inherited, so anything that reads the pipe to completion never returns - which hung a CI build for
+     * the full 30-minute job timeout. Discarding both streams, and bounding the wait, is what makes this
+     * safe to call on every build.
+     */
+    private fun run(epmd: File, argument: String): Boolean {
+        val process = ProcessBuilder(epmd.absolutePath, argument)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
+        if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            return false
+        }
+
+        return process.exitValue() == 0
+    }
+}

--- a/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
@@ -68,12 +68,14 @@ interface QuoterPlatform {
 /**
  * Creates the appropriate platform-specific QuoterPlatform implementation.
  * @param platform The target platform
+ * @param startEpmd false to let the release rely on an already-running epmd rather than starting one
+ *                  out of its own bundled ERTS - see [Epmd]. Defaults to the historical behaviour.
  * @return Platform-specific implementation
  */
-fun createQuoterPlatform(platform: Platform): QuoterPlatform {
+fun createQuoterPlatform(platform: Platform, startEpmd: Boolean = true): QuoterPlatform {
     return when (platform) {
-        Platform.WINDOWS -> WindowsQuoterPlatform()
-        Platform.POSIX -> PosixQuoterPlatform()
+        Platform.WINDOWS -> WindowsQuoterPlatform(startEpmd)
+        Platform.POSIX -> PosixQuoterPlatform(startEpmd)
     }
 }
 
@@ -91,12 +93,28 @@ const val DEFAULT_QUOTER_NODE_NAME = "intellij_elixir@127.0.0.1"
  * It has to differ per checkout: epmd allows one node per name, so a second checkout starting a quoter
  * under the same name gets "the name ... seems to be in use by another Erlang node" and exits 0, which
  * the build reports as the daemon dying immediately.
+ *
+ * [startEpmd] false adds `-start_epmd false`, so the release does not spawn an epmd from its own bundled
+ * ERTS inside the checkout - see [Epmd]. Pass it only once an epmd is known to be answering. It covers
+ * every release invocation, not just the daemon start, because `pid` and `stop` are RPC and so start a
+ * node too.
  */
-fun getReleaseEnvironment(releaseTmp: File?, releaseName: String = DEFAULT_QUOTER_NODE_NAME): Map<String, String> {
+fun getReleaseEnvironment(
+    releaseTmp: File?,
+    releaseName: String = DEFAULT_QUOTER_NODE_NAME,
+    startEpmd: Boolean = true
+): Map<String, String> {
     return buildMap {
         put("RELEASE_COOKIE", "intellij_elixir")
         put("RELEASE_DISTRIBUTION", "name")
         put("RELEASE_NAME", releaseName)
         releaseTmp?.let { put("RELEASE_TMP", it.absolutePath) }
+
+        if (!startEpmd) {
+            // Appended rather than set: erlexec reads one ERL_AFLAGS, so overwriting an inherited value
+            // would silently drop flags the developer or CI set.
+            val inherited = System.getenv("ERL_AFLAGS")?.trim().orEmpty()
+            put("ERL_AFLAGS", listOf(inherited, "-start_epmd false").filter { it.isNotEmpty() }.joinToString(" "))
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/quoter/QuoterService.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterService.kt
@@ -2,6 +2,7 @@ package quoter
 
 import platform.detectPlatform
 import platform.logPlatformDetection
+import sdk.readPropertiesFile
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logging
@@ -9,6 +10,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.process.ExecOperations
+import java.io.File
 import javax.inject.Inject
 
 /**
@@ -36,6 +38,13 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
          * so two worktrees can run tests at the same time - see [quoter.DEFAULT_QUOTER_NODE_NAME].
          */
         val nodeName: Property<String>
+
+        /**
+         * Read for `erlang.sdk.path`, so epmd starts from the SDK rather than the release's bundled
+         * ERTS - see [Epmd]. The daemon itself still needs no SDK; this is only about where the
+         * machine-wide epmd lives. Optional: unset, and the daemon starts as it always has.
+         */
+        val sdkProperties: RegularFileProperty
     }
 
     @get:Inject
@@ -43,7 +52,10 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
 
     private val logger = Logging.getLogger(QuoterService::class.java)
     private val platform = detectPlatform()
-    private val quoterPlatform = createQuoterPlatform(platform)
+
+    /** Lazy: the epmd probe has to run before the platform is configured, and [close] needs the same
+     * instance [startDaemon] used. */
+    private val quoterPlatform by lazy { createQuoterPlatform(platform, startEpmd = !ensureSdkEpmdRunning()) }
 
     @Volatile
     private var started = false
@@ -105,6 +117,30 @@ abstract class QuoterService : BuildService<QuoterService.Params>, AutoCloseable
         process = null
 
         throw RuntimeException("Quoter daemon failed to start after $maxAttempts attempts.")
+    }
+
+    /**
+     * Starts epmd from the Erlang SDK so the one owning port 4369 lives outside the checkout, and
+     * reports whether it answers. Anything missing or failing returns false, restoring the previous
+     * behaviour rather than failing the build.
+     */
+    private fun ensureSdkEpmdRunning(): Boolean = try {
+        val sdkProperties = parameters.sdkProperties.orNull?.asFile?.takeIf { it.isFile }
+        val erlangHome = sdkProperties?.let { readPropertiesFile(it)["erlang.sdk.path"] }?.let(::File)
+        val epmd = erlangHome?.let(Epmd::find)
+
+        when {
+            erlangHome == null -> false
+            epmd == null -> {
+                logger.info("No epmd under ${erlangHome.absolutePath}; the release will start its own")
+                false
+            }
+            else -> Epmd.ensureRunning(epmd, logger)
+        }
+    } catch (exception: Exception) {
+        // readPropertiesFile throws on a malformed file, and this path is only an optimisation.
+        logger.info("Could not resolve an SDK epmd: ${exception.message}")
+        false
     }
 
     override fun close() {


### PR DESCRIPTION
A distributed Erlang node starts `epmd` itself when none is running, from the ERTS of whatever release is starting:

```c
// erts/etc/common/erlexec.c
if (isdistributed && start_epmd)
    start_epmd_daemon(epmd_prog);
```

`start_epmd_daemon` builds the command from that release's own `bindir`, and on Windows launches it `DETACHED_PROCESS`, so nothing reaps it. The quoter is a self-contained release under `cache/` inside the checkout, so the `epmd` it left behind ran from inside the tree — and on Windows a running executable pins its own directory. Deleting a checkout or a git worktree then fails with `Device or resource busy` long after the build finished, which is how this was found.

`epmd` is a singleton on port 4369: every later one fails to bind and exits, so only the first survives. Which checkout got pinned was therefore a race between concurrent worktrees, and stayed pinned for the rest of the machine session.

## What changes

- `quoter/Epmd.kt` locates `epmd` in the Erlang SDK (under `erts-*/bin`, not `<erlangHome>/bin` beside `erl`), starts it with `-daemon`, and probes with `-names`.
- `QuoterService` runs that before the release starts, and only then passes `-start_epmd false` so the release cannot spawn one of its own. That flag covers `pid` and `stop` too, not just the daemon start — both are RPC, so both start a node.
- `getReleaseEnvironment` appends to any inherited `ERL_AFLAGS` rather than overwriting it.

Both steps degrade to the previous behaviour — no SDK properties, no `erlang.sdk.path`, no `epmd` in that tree, or a failed start all fall back to the release starting its own. This is an optimisation and must never fail a build that would otherwise have worked, so `-start_epmd false` is passed only once an `epmd` is confirmed answering; with none running it would leave the node unable to bring up distribution at all.

`QuoterService` gains an optional `sdkProperties` parameter for this. The daemon itself still needs no SDK — it is a self-contained release; this is only about where the machine-wide `epmd` lives.

## Verification

- `test --tests "org.elixir_lang.parser_definition.*"` — **1984 tests, 0 failures**. These quote through the daemon, so they exercise the whole path.
- After a full run, no `epmd` under the worktree, and port 4369 owned by the SDK binary.
- On a fresh port with no `epmd` running, the one that claims it is the SDK binary rather than the release's — the behaviour the change exists for.
- Falling back works: killing the SDK `epmd` mid-build makes the probe fail and the release starts its own, exactly as before.

## Notes for review

- `buildSrc` has no test source set, so `Epmd.find`'s `erts-*` globbing is not pinned by a test. It is a pure function taking a `File`, so it is testable as soon as that exists.
- `sdkPropertiesFile` moved above the `QuoterService` registration in `build.gradle.kts`: a build service's `parameters {}` is evaluated at registration rather than deferred like a task's configuration lambda, so the original position gave `Cannot set the value of a property using a null provider`.
- `ensureRunning` executes a path read from `elixir-erlang-sdks.properties`. That is the same trust boundary the build already crosses running `mix` from that SDK.
