### PR TITLE
fix(beam): navigate to the element when its mirror was never set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@
 
 ### Bug Fixes
 
+- [#3962](https://github.com/KronicDeth/intellij-elixir/pull/3962) [@sh41](https://github.com/sh41)
+  - **Ctrl+Click and highlighting no longer throw on a function the decompiler could not recreate.**
+    Refs [#3309](https://github.com/KronicDeth/intellij-elixir/issues/3309).
+
 - [#3957](https://github.com/KronicDeth/intellij-elixir/pull/3957) [@sh41](https://github.com/sh41)
   - **A dep with `allow_pre:` no longer reports an unknown Mix dep option.** It is a Hex flag that
     cannot change where a dep is checked out. Fixes

--- a/src/org/elixir_lang/beam/psi/impl/CallDefinitionImpl.kt
+++ b/src/org/elixir_lang/beam/psi/impl/CallDefinitionImpl.kt
@@ -68,7 +68,9 @@ class CallDefinitionImpl<T : CallDefinitionStub<*>>(private val stub: T) : Modul
     override fun setName(@NonNls name: String): PsiElement =
         throw IncorrectOperationException("Cannot modify module name in Beam files")
 
-    override fun getNavigationElement(): PsiElement = mirror
+    // `ModuleImpl.setMirror` leaves the mirror unset for any definition the decompiled source lacks, and
+    // `getMirror()` is unannotated Java that Kotlin reads as non-null. `this` is `PsiElementBase`'s default.
+    override fun getNavigationElement(): PsiElement = mirror ?: this
 
     override fun getNode(): ASTNode? = null
 

--- a/src/org/elixir_lang/beam/psi/impl/ModuleImpl.kt
+++ b/src/org/elixir_lang/beam/psi/impl/ModuleImpl.kt
@@ -154,7 +154,9 @@ class ModuleImpl<T : ModuleStub<*>?>(private val stub: T) : ModuleElementImpl(),
     override fun setName(@NonNls name: String): PsiElement =
         throw IncorrectOperationException("Cannot modify module name in Beam files")
 
-    override fun getNavigationElement(): PsiElement = mirror
+    // The mirror is unset whenever the file's own `setMirror` threw, and `getMirror()` is unannotated Java
+    // that Kotlin reads as non-null. `this` is `PsiElementBase`'s default.
+    override fun getNavigationElement(): PsiElement = mirror ?: this
 
     override fun processDeclarations(
         processor: PsiScopeProcessor,

--- a/src/org/elixir_lang/beam/psi/impl/TypeDefinitionImpl.kt
+++ b/src/org/elixir_lang/beam/psi/impl/TypeDefinitionImpl.kt
@@ -64,7 +64,9 @@ class TypeDefinitionImpl<T : TypeDefinitionStub<*>>(private val stub: T) : Modul
     override fun setName(@NonNls name: String): PsiElement =
         throw IncorrectOperationException("Cannot modify module name in Beam files")
 
-    override fun getNavigationElement(): PsiElement = mirror
+    // `ModuleImpl.setMirror` leaves the mirror unset for any definition the decompiled source lacks, and
+    // `getMirror()` is unannotated Java that Kotlin reads as non-null. `this` is `PsiElementBase`'s default.
+    override fun getNavigationElement(): PsiElement = mirror ?: this
 
     override fun getNode(): ASTNode? = null
 

--- a/tests/org/elixir_lang/beam/psi/impl/MirrorlessNavigationElementTest.kt
+++ b/tests/org/elixir_lang/beam/psi/impl/MirrorlessNavigationElementTest.kt
@@ -1,0 +1,81 @@
+package org.elixir_lang.beam.psi.impl
+
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.psi.PsiCompiledFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import java.io.File
+
+/**
+ * `getNavigationElement()` must not throw for a decompiled element whose mirror was never set.
+ *
+ * `ModuleImpl.setMirror` logs-and-skips any definition the decompiled source lacks, so a mirror-less
+ * `CallDefinitionImpl` is ordinary: 139 of `gl.beam`'s 1068 are compiler-generated comprehension helpers.
+ */
+class MirrorlessNavigationElementTest : PlatformTestCase() {
+    fun testMirrorlessCallDefinitionNavigatesToItself() {
+        val (withoutMirror, _) = callDefinitionsOf(FIXTURE)
+
+        assertFalse(
+            "$FIXTURE no longer has a call definition without a mirror, so it cannot cover this. Delete the " +
+                "test if the decompiler now renders them, or swap in OTP-PUB-KEY.beam, which had 1112",
+            withoutMirror.isEmpty()
+        )
+
+        for (callDefinition in withoutMirror) {
+            assertSame(
+                "getNavigationElement() on the mirror-less ${callDefinition.exportedName()} should fall back to " +
+                    "the element itself",
+                callDefinition,
+                callDefinition.navigationElement
+            )
+        }
+    }
+
+    fun testMirroredCallDefinitionStillNavigatesToItsMirror() {
+        val (_, withMirror) = callDefinitionsOf(FIXTURE)
+
+        assertFalse("$FIXTURE decompiled to no mirrored call definitions at all", withMirror.isEmpty())
+
+        for (callDefinition in withMirror) {
+            assertSame(
+                "getNavigationElement() on the mirrored ${callDefinition.exportedName()} should still be its mirror",
+                callDefinition.mirror,
+                callDefinition.navigationElement
+            )
+        }
+    }
+
+    /** Decompiles [beamName] and splits its call definitions by whether `setMirror` reached them. */
+    private fun callDefinitionsOf(beamName: String): Pair<List<CallDefinitionImpl<*>>, List<CallDefinitionImpl<*>>> {
+        val directory = File(DECOMPILER_TEST_DATA).absoluteFile
+        VfsRootAccess.allowRootAccess(testRootDisposable, directory.path)
+
+        val beam = File(directory, beamName)
+        val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(beam)
+        assertNotNull("Could not find $beamName in VFS at ${beam.absolutePath}", virtualFile)
+
+        val compiledFile = PsiManager.getInstance(project).findFile(virtualFile!!)
+        assertTrue("$beamName is not a PsiCompiledFile", compiledFile is PsiCompiledFile)
+
+        // Builds the mirror, which is what populates the per-element mirrors this test partitions on.
+        (compiledFile as PsiCompiledFile).decompiledPsiFile
+
+        val modules = PsiTreeUtil.findChildrenOfType(compiledFile, ModuleImpl::class.java)
+            .ifEmpty { compiledFile.children.filterIsInstance<ModuleImpl<*>>() }
+        assertFalse("$beamName decompiled to no modules", modules.isEmpty())
+
+        val callDefinitions = modules.flatMap { (it as ModuleImpl<*>).callDefinitions().asIterable() }
+
+        return callDefinitions.partition { it.mirror == null }
+    }
+
+    companion object {
+        private const val DECOMPILER_TEST_DATA = "testData/org/elixir_lang/beam/decompiler"
+
+        /** 139 of its 1068 call definitions are `-name/arity-lbc$^0/2-0-` helpers the decompiler does not emit. */
+        private const val FIXTURE = "gl.beam"
+    }
+}


### PR DESCRIPTION
`ModuleImpl.setMirror` matches each compiled definition against the source the decompiler recreates and logs-and-skips what it cannot find, so a definition with no mirror is ordinary on a healthy `.beam` — 139 of `gl.beam`'s 1068, all compiler-generated comprehension helpers. `ModuleElementImpl.getMirror()` is unannotated Java, so Kotlin read the three `getNavigationElement()` overrides as non-null and threw on exactly those definitions:

```
java.lang.NullPointerException: getMirror(...) must not be null
	at org.elixir_lang.beam.psi.impl.CallDefinitionImpl.getNavigationElement(CallDefinitionImpl.kt)
```

Every other mirror accessor on `ModuleElementImpl` already null-checks, and `PsiElementBase.getNavigationElement()` — which this class inherits, and which `ClsElementImpl` never overrides — returns the element itself. The fallback restores that default. `getTextOffset()` is then `-1`, which `EditSourceUtil.getDescriptor` already treats as "open the file, don't place the caret".

Reported four times before (#2503, #2530, #2534, #2607) and closed each time on the grounds that the callers had been removed; the declaration was never guarded, so it returned when a caller did. The resolve-result de-duplication key added in `abc6e0e8e` reads `navigationElement` on every resolve result, which puts it on the annotator's path — it now fires while typing, with no gesture.

## Refs #3309, not Fixes

#3309's `Elixir.String` case was already fixed by #3850's lexer unicode-escape work — on `main` that beam decompiles clean, with a mirror on all 144 of its definitions. This covers the other way a mirror goes missing: a definition the decompiler never emits at all, like `gl.beam`'s comprehension helpers. Unrelated to unicode, and still reaching users on 24.0.1.

## Tests

`MirrorlessNavigationElementTest`, two cases on the existing `gl.beam` fixture — no new binary. Mirror-less definitions navigate to themselves; mirrored ones still navigate to their mirror. The first also asserts the fixture still has mirror-less definitions, so it fails loudly rather than passing vacuously if the decompiler later renders them.

Reverting only the `CallDefinitionImpl` guard fails the first case while the second still passes, so the second is a control rather than a duplicate.

No fixture yields a mirror-less `TypeDefinitionImpl` or `ModuleImpl`, so those two guards are uncovered — a missing type logs at `LOGGER.error`, which `TestLoggerFactory` rethrows, so any fixture reaching that site fails for a different reason first.

---

Raised as part of an AI-assisted review of the backlog. A human checked this one before it was opened, but it might still be wrong — if any of it is, please say so here.
