### PR TITLE
fix: don't crash the structure view on a `@spec` head with no function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@
 
 ### Bug Fixes
 
+- [#3963](https://github.com/KronicDeth/intellij-elixir/pull/3963) [@sh41](https://github.com/sh41)
+  - **A `@spec` whose head has no function name no longer crashes the structure view.** Heads like
+    `@spec foo.() :: term` and `@spec bar not in baz :: term` parse to a call with no name, so the
+    malformed spec is now left out of the tree instead of throwing. Fixes
+    [#1564](https://github.com/KronicDeth/intellij-elixir/issues/1564).
+
 - [#3962](https://github.com/KronicDeth/intellij-elixir/pull/3962) [@sh41](https://github.com/sh41)
   - **Ctrl+Click and highlighting no longer throw on a function the decompiler could not recreate.**
     Refs [#3309](https://github.com/KronicDeth/intellij-elixir/issues/3309).

--- a/src/org/elixir_lang/reference/resolver/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/reference/resolver/CallDefinitionClause.kt
@@ -23,7 +23,7 @@ object CallDefinitionClause : ResolveCache.PolyVariantResolver<org.elixir_lang.r
         ApplicationManager.getApplication().assertReadAccessAllowed()
         return enclosingModularMacroCall(callDefinitionClause.moduleAttribute)?.macroChildCalls()?.let { siblings ->
             if (siblings.isNotEmpty()) {
-                val nameArity = typeNameArity(callDefinitionClause.element)
+                val nameArity = typeNameArity(callDefinitionClause.element) ?: return emptyArray()
                 val name = nameArity.name
                 val arity = nameArity.arity
 

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionSpecification.kt
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionSpecification.kt
@@ -95,9 +95,14 @@ class CallDefinitionSpecification(
         fun type(matchedWhenOperation: ElixirMatchedWhenOperation): Call? =
                 (matchedWhenOperation.leftOperand() as? Type)?.let { type(it) }
 
+        /**
+         * `null` when [type] has no function name, as for the `foo.()` and `bar not in baz` heads
+         * the parser produces from a malformed `@spec`: [Call.functionName] is `@Nullable` and
+         * every caller here already treats a missing name as "not a specification".
+         */
         @JvmStatic
-        fun typeNameArity(type: Call): org.elixir_lang.NameArity {
-            val name = type.functionName()!!
+        fun typeNameArity(type: Call): org.elixir_lang.NameArity? {
+            val name = type.functionName() ?: return null
             val arity = type.resolvedFinalArity()
 
             return org.elixir_lang.NameArity(name, arity)

--- a/tests/org/elixir_lang/structure_view/element/CallDefinitionSpecificationTest.kt
+++ b/tests/org/elixir_lang/structure_view/element/CallDefinitionSpecificationTest.kt
@@ -1,0 +1,77 @@
+package org.elixir_lang.structure_view.element
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.impl.ElixirPsiImplUtil.moduleAttributeName
+import org.elixir_lang.structure_view.Model
+
+/**
+ * A `@spec` head the parser resolves to no function name must not crash the structure view.
+ *
+ * `@spec foo.() :: term` and `@spec bar not in baz :: term` are the shapes an editor sees mid-edit;
+ * both parse to a [org.elixir_lang.psi.call.Call] whose `functionNameElement()` is a hard-coded
+ * `null`, which `typeNameArity` used to force-unwrap.
+ */
+class CallDefinitionSpecificationTest : PlatformTestCase() {
+    private fun specAttributes(): List<AtUnqualifiedNoParenthesesCall<*>> =
+        PsiTreeUtil
+            .findChildrenOfType(myFixture.file, AtUnqualifiedNoParenthesesCall::class.java)
+            .filter { moduleAttributeName(it) == "@spec" }
+
+    private fun walk(element: StructureViewTreeElement) {
+        for (child in element.children) {
+            if (child is StructureViewTreeElement) {
+                walk(child)
+            }
+        }
+    }
+
+    private fun walkStructureView() = walk(Model(myFixture.file as ElixirFile, null).root)
+
+    fun testHeadWithoutFunctionNameHasNoNameArity() {
+        myFixture.configureByText(
+            "spec_head_without_function_name.ex",
+            "defmodule A do\n" +
+                "  @spec foo.() :: term\n" +
+                "  @spec bar not in baz :: term\n" +
+                "  def foo, do: :ok\n" +
+                "end\n"
+        )
+
+        val nameArities = specAttributes().map { CallDefinitionSpecification.moduleAttributeNameArity(it) }
+
+        assertEquals(2, nameArities.size)
+        assertEquals(listOf(null, null), nameArities)
+    }
+
+    fun testHeadWithFunctionNameStillHasNameArity() {
+        myFixture.configureByText(
+            "spec_head_with_function_name.ex",
+            "defmodule A do\n" +
+                "  @spec ok(term) :: term\n" +
+                "  def ok(x), do: x\n" +
+                "end\n"
+        )
+
+        val nameArity = specAttributes().single().let { CallDefinitionSpecification.moduleAttributeNameArity(it) }
+
+        assertEquals(org.elixir_lang.NameArity("ok", 1), nameArity)
+    }
+
+    fun testStructureViewDoesNotThrowOnHeadWithoutFunctionName() {
+        myFixture.configureByText(
+            "structure_view_spec_head.ex",
+            "defmodule A do\n" +
+                "  @spec foo.() :: term\n" +
+                "  @spec bar not in baz :: term\n" +
+                "  @spec baz.() :: term when term: any\n" +
+                "  def foo, do: :ok\n" +
+                "end\n"
+        )
+
+        walkStructureView()
+    }
+}


### PR DESCRIPTION
`CallDefinitionSpecification.typeNameArity` force-unwrapped `Call.functionName()`, which the `Call`
interface declares `@Nullable`. `CallImpl.functionNameElement` returns a hard-coded `null` for
`DotCall` (`foo.()`), `NotIn` (`bar not in baz`) and `AtUnqualifiedNoParenthesesCall`, so a `@spec`
whose head parses to one of those shapes — what the editor sees while a spec is being typed — threw
out of the structure view's tree walk. That walk backs the Structure tool window, the Ctrl+F12 file
structure popup and the method-separator line markers.

`typeNameArity` now returns `null` for a head with no name. The wrapper `moduleAttributeNameArity`
was already declared nullable and every caller of it — `FunctionByNameArity`, the three sites in the
`CallDefinition` line-marker provider — already handled `null`, so the malformed spec is simply left
out of the tree rather than crashing it. The one caller of `typeNameArity` outside this file,
`reference.resolver.CallDefinitionClause`, returns no resolve results for such a head.

The unchecked `!!` dates from `44b5b16fd` (2018) and had never been touched; the file's only other
history entry is the `gen/` → `src/` relocation.

Test drives the real structure view model (`structure_view.Model(file, null).root`, recursed) over
the malformed heads and asserts the happy path still yields `NameArity("ok", 1)`. Reverting both
source hunks compiles and fails two of the three tests with `NullPointerException`.

Fixes #1564.
