### PR TITLE
fix: remove-space quick fix looks past noParenthesesOneArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@
 
 ### Bug Fixes
 
+- [#3964](https://github.com/KronicDeth/intellij-elixir/pull/3964) [@sh41](https://github.com/sh41)
+  - **"Remove space between function name and parentheses" now removes the space instead of
+    throwing.** The space stopped being a child of the element the quick fix searched when the
+    grammar gained `noParenthesesOneArgument` in 2015. Fixes
+    [#3107](https://github.com/KronicDeth/intellij-elixir/issues/3107).
+
 - [#3963](https://github.com/KronicDeth/intellij-elixir/pull/3963) [@sh41](https://github.com/sh41)
   - **A `@spec` whose head has no function name no longer crashes the structure view.** Heads like
     `@spec foo.() :: term` and `@spec bar not in baz :: term` parse to a call with no name, so the

--- a/src/org/elixir_lang/local_quick_fix/RemoveSpaceInFrontOfNoParenthesesStrict.java
+++ b/src/org/elixir_lang/local_quick_fix/RemoveSpaceInFrontOfNoParenthesesStrict.java
@@ -1,12 +1,14 @@
 package org.elixir_lang.local_quick_fix;
 
 import com.intellij.codeInspection.LocalQuickFixOnPsiElement;
+import com.intellij.lang.ASTNode;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.TokenType;
 import com.intellij.psi.text.BlockSupport;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Created by kadie.enheduanna.inanna on 12/7/14.
@@ -21,7 +23,36 @@ public class RemoveSpaceInFrontOfNoParenthesesStrict extends LocalQuickFixOnPsiE
     }
 
     /*
-     * Methods
+     * Static Methods
+     */
+
+    /**
+     * The space to remove is not always a child of {@code node}: when the grammar gained
+     * {@code noParenthesesOneArgument}, that wrapper came to span only the parentheses, leaving the space on its
+     * previous sibling instead. The children are still searched first because a call that reaches
+     * {@code noParenthesesStrict} without the wrapper keeps the space inside.
+     */
+    @Nullable
+    private static ASTNode whiteSpaceBefore(@NotNull ASTNode node) {
+        ASTNode child = node.findChildByType(TokenType.WHITE_SPACE);
+
+        if (child != null) {
+            return child;
+        }
+
+        for (ASTNode ancestor = node; ancestor != null; ancestor = ancestor.getTreeParent()) {
+            ASTNode previous = ancestor.getTreePrev();
+
+            if (previous != null) {
+                return previous.getElementType() == TokenType.WHITE_SPACE ? previous : null;
+            }
+        }
+
+        return null;
+    }
+
+    /*
+     * Instance Methods
      */
 
     /**
@@ -44,8 +75,11 @@ public class RemoveSpaceInFrontOfNoParenthesesStrict extends LocalQuickFixOnPsiE
     @Override
     public void invoke(@NotNull Project project, @NotNull PsiFile file, @NotNull PsiElement startElement, @NotNull PsiElement endElement) {
         assert startElement == endElement;
-        com.intellij.lang.ASTNode parentNode = startElement.getNode();
-        com.intellij.lang.ASTNode whiteSpace = parentNode.findChildByType(TokenType.WHITE_SPACE);
+        ASTNode whiteSpace = whiteSpaceBefore(startElement.getNode());
+
+        if (whiteSpace == null) {
+            return;
+        }
 
         BlockSupport blockSupport = BlockSupport.getInstance(project);
         final int startOffset = whiteSpace.getStartOffset();

--- a/tests/org/elixir_lang/inspection/NoParentheseStrictTestCase.java
+++ b/tests/org/elixir_lang/inspection/NoParentheseStrictTestCase.java
@@ -1,6 +1,9 @@
 package org.elixir_lang.inspection;
 
+import com.intellij.codeInsight.intention.IntentionAction;
 import org.elixir_lang.PlatformTestCase;
+
+import java.util.List;
 
 /**
  * Created by kadie.enheduanna.inanna on 12/6/14.
@@ -34,6 +37,32 @@ public class NoParentheseStrictTestCase extends PlatformTestCase {
         myFixture.configureByFile("QualifierDotQuoteParentheses.ex");
         myFixture.enableInspections(NoParenthesesStrict.class);
         myFixture.checkHighlighting();
+    }
+
+    public void testFunctionSpaceEmptyParenthesesQuickFix() {
+        assertQuickFixRewrites("function ()", "function()");
+    }
+
+    public void testFunctionSpacePositionalsInParenthesesQuickFix() {
+        assertQuickFixRewrites("function (one, two)", "function(one, two)");
+    }
+
+    public void testQualifierDotQuoteParenthesesQuickFix() {
+        assertQuickFixRewrites("One.\"two\" ()", "One.\"two\"()");
+    }
+
+    private void assertQuickFixRewrites(String before, String after) {
+        myFixture.configureByText("remove_space.ex", before);
+        myFixture.enableInspections(NoParenthesesStrict.class);
+
+        List<IntentionAction> quickFixes = myFixture.getAllQuickFixes();
+
+        assertEquals(1, quickFixes.size());
+        assertEquals("Remove space between function name and parentheses", quickFixes.get(0).getText());
+
+        myFixture.launchAction(quickFixes.get(0));
+
+        myFixture.checkResult(after);
     }
 
     @Override


### PR DESCRIPTION
The quick fix "Remove space between function name and parentheses" threw on every invocation.

`NoParenthesesStrict` hands the fix the parent of the `ElixirNoParenthesesStrict` it matched, and the fix searched that parent's direct children for the space. `9cf4cc096` ("Matched and unmatched pratt parsers", 2015-06-27) introduced `noParenthesesOneArgument`, which spans only the parentheses, so the space has belonged to the grandparent ever since and the lookup returned null. At `d1417a294` (2015-03-27) the parent was the call itself and the fix worked.

Nothing caught it because no test in this repository launched a quick fix.

`whiteSpaceBefore` searches the children first, so the rarer shape where the space really is a direct child keeps working, then falls back to the token immediately before the element; it returns null rather than throwing when there is no space to remove.

Three regression tests apply the fix to `function ()`, `function (one, two)` and `One."two" ()`. With only the source reverted they fail with the reported NPE and the five existing tests still pass.

Fixes #3107. #1669 and #1970 are the same crash and will be closed as duplicates by hand, because auto-close cannot produce `DUPLICATE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
