### PR TITLE
fix(rename): don't rename a binding that shadows the renamed variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,13 @@
 
 ### Bug Fixes
 
+- [#3965](https://github.com/KronicDeth/intellij-elixir/pull/3965) [@sh41](https://github.com/sh41)
+  - **Renaming a variable no longer rewrites an inner binding that shadows it.** The shared usage
+    search matched by name and scope alone, so an `fn` parameter, `case` clause pattern or `for`
+    generator reusing an outer name was renamed with it. Fixes
+    [#1479](https://github.com/KronicDeth/intellij-elixir/issues/1479).
+  - **Renaming from a rebinding inside an `fn` or `case` body now covers the whole variable.**
+
 - [#3964](https://github.com/KronicDeth/intellij-elixir/pull/3964) [@sh41](https://github.com/sh41)
   - **"Remove space between function name and parentheses" now removes the space instead of
     throwing.** The space stopped being a child of the element the quick fix searched when the

--- a/src/org/elixir_lang/model/psi/ElixirUsageQueries.kt
+++ b/src/org/elixir_lang/model/psi/ElixirUsageQueries.kt
@@ -48,6 +48,7 @@ import org.elixir_lang.model.psi.protocol.ProtocolFunction
 import org.elixir_lang.model.psi.type.TypeReference
 import org.elixir_lang.model.psi.type.TypeSymbol
 import org.elixir_lang.model.psi.type.TypeVariableSymbol
+import org.elixir_lang.model.psi.variable.VariableReference
 import org.elixir_lang.model.psi.variable.VariableSymbol
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
@@ -994,6 +995,7 @@ internal object ElixirUsageQueries {
         @RequiresReadLock
         override fun mapOccurrence(occurrence: LeafOccurrence): Collection<PsiUsage> {
             val symbol = symbolPointer.dereference() ?: return emptyList()
+            val symbolChainRoot = symbol.chainRootSymbol() ?: return emptyList()
             val (_, leaf, _) = occurrence
             for (candidate in generateSequence(leaf) { it.parent }.takeWhile { it !is PsiFile }) {
                 ProgressManager.checkCanceled()
@@ -1005,11 +1007,15 @@ internal object ElixirUsageQueries {
                 ) {
                     continue
                 }
+                // A search scope is a text range, so it cannot tell a binding that SHADOWS this
+                // variable (an `fn` parameter, a `case` clause pattern, a `for` generator) from
+                // the outer one it hides - the inner binding sits inside the outer's scope.
+                // Resolution can, so the occurrence is kept only when it is this same variable.
+                if (!isOccurrenceOf(candidate, symbolChainRoot)) return emptyList()
                 // NOTE: the right-hand read of a rebinding (`x` in `x = x + 1`) semantically reads
-                // the PREVIOUS binding, but a rebinding chain is one user-facing variable (the
-                // symbol's search scope starts at the chain root - see
-                // VariableSymbol.maximalSearchScope), so it is a usage regardless of which
-                // binding anchors the symbol.
+                // the PREVIOUS binding, but a rebinding chain is one user-facing variable, so it
+                // is a usage regardless of which binding anchors the symbol. That is why the
+                // comparison above is by chain root rather than by symbol.
                 return listOf(
                     ElixirPsiUsage.create(
                         nameElement,
@@ -1020,6 +1026,24 @@ internal object ElixirUsageQueries {
                 )
             }
             return emptyList()
+        }
+
+        /**
+         * True when [candidate] is an occurrence of the variable rooted at [symbolChainRoot].
+         *
+         * A binding is compared by its own chain root; a read is resolved first, because a read
+         * belongs to whichever binding resolution reaches from where it stands. A read that
+         * resolution cannot place at all falls back to the search scope, so that a gap in
+         * resolution over-reports a usage rather than dropping one - Rename shares this search,
+         * and a dropped usage leaves a dangling reference behind.
+         */
+        @RequiresReadLock
+        private fun isOccurrenceOf(candidate: PsiElement, symbolChainRoot: VariableSymbol): Boolean {
+            if (VariableSymbol.isDeclaration(candidate)) {
+                return VariableSymbol.fromDeclaration(candidate)?.chainRootSymbol() == symbolChainRoot
+            }
+            val resolved = VariableReference.resolveSymbols(candidate)
+            return resolved.isEmpty() || resolved.any { it.chainRootSymbol() == symbolChainRoot }
         }
     }
 

--- a/src/org/elixir_lang/model/psi/variable/VariableSymbol.kt
+++ b/src/org/elixir_lang/model/psi/variable/VariableSymbol.kt
@@ -24,6 +24,7 @@ import org.elixir_lang.psi.ElixirStabNoParenthesesSignature
 import org.elixir_lang.psi.ElixirStabOperation
 import org.elixir_lang.psi.ElixirStabParenthesesSignature
 import org.elixir_lang.psi.ElixirVariable
+import org.elixir_lang.psi.QuotableKeywordPair
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.operation.InMatch
 import org.elixir_lang.psi.operation.Match
@@ -170,6 +171,9 @@ class VariableSymbol(
             }
 
     companion object {
+        /** Keyword keys whose value is a body rather than an argument. */
+        private val BLOCK_KEYWORDS = setOf("do", "else", "after", "catch", "rescue")
+
         /**
          * True when a rebinding chain from [declaration] cannot continue out through [ancestor].
          *
@@ -249,7 +253,8 @@ class VariableSymbol(
                 Kind.PARAMETER, Kind.IGNORED ->
                     ((org.elixir_lang.reference.Callable.isParameter(element) ||
                         org.elixir_lang.reference.Callable.isParameterWithDefault(element)) &&
-                        !isInsideAnonymousFunctionBody(element)) ||
+                        !isInsideAnonymousFunctionBody(element) &&
+                        !isInsideKeywordBody(element)) ||
                         isVariableDeclaration(element)
                 Kind.VARIABLE -> isVariableDeclaration(element)
                 null -> false
@@ -309,6 +314,26 @@ class VariableSymbol(
             }
             return false
         }
+
+        /**
+         * True when [element] sits in the VALUE of a `do:`-style keyword pair (`for x <- xs, do: x`).
+         *
+         * The same over-marking [isInsideAnonymousFunctionBody] discounts: the legacy parameter
+         * classifier walks out of the keyword value into the enclosing call and marks a plain read
+         * there as a parameter. The `do`-block spelling of the same code is unaffected, because a
+         * stab body intervenes. The walk stops at a binding boundary so that a nested construct's
+         * own binding - the inner generator of `for x <- xs, do: for(y <- ys, do: y)` - is still
+         * read as the declaration it is.
+         */
+        @RequiresReadLock
+        private fun isInsideKeywordBody(element: PsiElement): Boolean =
+            generateSequence(element) { it.parent }
+                .takeWhile { !isBindingBoundary(it, element) }
+                .filterIsInstance<QuotableKeywordPair>()
+                .any { pair ->
+                    pair.keywordKey.text.removeSuffix(":") in BLOCK_KEYWORDS &&
+                        PsiTreeUtil.isAncestor(pair.keywordValue, element, false)
+                }
 
         private fun isInsideStabSignature(element: PsiElement): Boolean =
             nearestStabContainer(element).let {

--- a/src/org/elixir_lang/model/psi/variable/VariableSymbol.kt
+++ b/src/org/elixir_lang/model/psi/variable/VariableSymbol.kt
@@ -93,6 +93,18 @@ class VariableSymbol(
         }
 
     /**
+     * This variable's identity for search and rename: its chain root, as a symbol.
+     *
+     * Two occurrences are the same variable exactly when their chain roots are equal, which is
+     * what lets a usage search tell an inner binding from the outer one it shadows.
+     */
+    @RequiresReadLock
+    fun chainRootSymbol(): VariableSymbol? =
+        (declarationCall() as? UnqualifiedNoArgumentsCall<*>)
+            ?.let { chainRootDeclaration(it) }
+            ?.let { fromElement(it) }
+
+    /**
      * The earliest same-named declaration in this declaration's rebinding chain - possibly itself.
      *
      * A rebinding (`x = x + 1` after `x = input`) SHADOWS the earlier binding, but the chain

--- a/src/org/elixir_lang/model/psi/variable/VariableSymbol.kt
+++ b/src/org/elixir_lang/model/psi/variable/VariableSymbol.kt
@@ -21,9 +21,11 @@ import org.elixir_lang.model.psi.ElixirSymbolWithUsages
 import org.elixir_lang.psi.ElixirAnonymousFunction
 import org.elixir_lang.psi.ElixirStabBody
 import org.elixir_lang.psi.ElixirStabNoParenthesesSignature
+import org.elixir_lang.psi.ElixirStabOperation
 import org.elixir_lang.psi.ElixirStabParenthesesSignature
 import org.elixir_lang.psi.ElixirVariable
 import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.psi.operation.InMatch
 import org.elixir_lang.psi.operation.Match
 import org.elixir_lang.psi.UnaryOperation
 import org.elixir_lang.psi.UnqualifiedNoArgumentsCall
@@ -97,10 +99,9 @@ class VariableSymbol(
      * A use scope anchored at a later rebinding is `SELF_AND_FOLLOWING_SIBLINGS` and would miss
      * the earlier bindings and the reads that resolve to them. The chain root is the earliest of:
      * this declaration, any same-named declaration in a PRECEDING statement of an enclosing stab
-     * body, or a same-named parameter of the enclosing definition clause head. The walk stops at
-     * the definition-clause and anonymous-function boundaries: a same-named variable in another
-     * function (or in the enclosing scope of an `fn` that rebinds locally) is a different
-     * variable.
+     * body, or a same-named parameter of the enclosing definition clause head. Both walks stop at
+     * the definition clause and at [isBindingBoundary]: a same-named variable on the far side of
+     * one of those is a different variable.
      */
     @RequiresReadLock
     private fun chainRootDeclaration(declaration: UnqualifiedNoArgumentsCall<*>): UnqualifiedNoArgumentsCall<*> {
@@ -108,9 +109,7 @@ class VariableSymbol(
 
         val ancestorsInClause = generateSequence(declaration as PsiElement) { it.parent }
             .takeWhile {
-                it !is PsiFile &&
-                    it !is ElixirAnonymousFunction &&
-                    !(it is Call && CallDefinitionClause.`is`(it))
+                !isBindingBoundary(it, declaration) && !(it is Call && CallDefinitionClause.`is`(it))
             }
 
         // Same-named declarations in preceding statements of every enclosing stab body.
@@ -127,7 +126,10 @@ class VariableSymbol(
             }
 
         // A same-named parameter of the enclosing definition clause is the outermost chain root.
+        // The walk stops at a binding boundary as well, or an `fn` parameter would chain to a
+        // same-named parameter of the `def` it happens to sit in.
         generateSequence(declaration as PsiElement) { it.parent }
+            .takeWhile { !isBindingBoundary(it, declaration) }
             .filterIsInstance<Call>()
             .firstOrNull { CallDefinitionClause.`is`(it) }
             ?.let { clause -> CallDefinitionClause.head(clause) }
@@ -168,6 +170,29 @@ class VariableSymbol(
             }
 
     companion object {
+        /**
+         * True when a rebinding chain from [declaration] cannot continue out through [ancestor].
+         *
+         * A stab signature (an `fn` parameter list, a `case`/`with`/`receive` clause head) and the
+         * left side of a `<-` generator bind the name afresh, so a same-named declaration outside
+         * is a different variable rather than an earlier link in the same chain. Only the PATTERN
+         * binds: a declaration in the clause BODY still rebinds whatever the name meant outside,
+         * so the chain continues through it - stopping there would report the body's write as a
+         * different variable from the read on its own right-hand side.
+         */
+        @RequiresReadLock
+        private fun isBindingBoundary(ancestor: PsiElement, declaration: PsiElement): Boolean =
+            when (ancestor) {
+                is PsiFile -> true
+                is ElixirStabOperation -> ancestor.leftOperand().bindsAsPattern(declaration)
+                is InMatch -> ancestor.leftOperand().bindsAsPattern(declaration)
+                else -> false
+            }
+
+        @RequiresReadLock
+        private fun PsiElement?.bindsAsPattern(declaration: PsiElement): Boolean =
+            this != null && PsiTreeUtil.isAncestor(this, declaration, false)
+
         @RequiresReadLock
         fun fromDeclaration(call: Call): VariableSymbol? {
             if (!isDeclaration(call)) return null

--- a/testData/org/elixir_lang/model/psi/rename/matrix/variable_case_clause_rebinding.ex
+++ b/testData/org/elixir_lang/model/psi/rename/matrix/variable_case_clause_rebinding.ex
@@ -1,0 +1,14 @@
+defmodule VariableCaseClauseRebinding do
+  def run(other) do
+    renamee = 0
+
+    case other do
+      :inc ->
+        renamee = renamee + 1
+        renamee
+
+      _ ->
+        renamee
+    end
+  end
+end

--- a/testData/org/elixir_lang/model/psi/rename/matrix/variable_case_clause_rebinding_after.ex
+++ b/testData/org/elixir_lang/model/psi/rename/matrix/variable_case_clause_rebinding_after.ex
@@ -1,0 +1,14 @@
+defmodule VariableCaseClauseRebinding do
+  def run(other) do
+    fresh = 0
+
+    case other do
+      :inc ->
+        fresh = fresh + 1
+        fresh
+
+      _ ->
+        fresh
+    end
+  end
+end

--- a/testData/org/elixir_lang/model/psi/rename/matrix/variable_fn_body_rebinding.ex
+++ b/testData/org/elixir_lang/model/psi/rename/matrix/variable_fn_body_rebinding.ex
@@ -1,0 +1,12 @@
+defmodule VariableFnBodyRebinding do
+  def run(list) do
+    renamee = 0
+
+    Enum.each(list, fn _item ->
+      renamee = renamee + 1
+      renamee
+    end)
+
+    renamee
+  end
+end

--- a/testData/org/elixir_lang/model/psi/rename/matrix/variable_fn_body_rebinding_after.ex
+++ b/testData/org/elixir_lang/model/psi/rename/matrix/variable_fn_body_rebinding_after.ex
@@ -1,0 +1,12 @@
+defmodule VariableFnBodyRebinding do
+  def run(list) do
+    fresh = 0
+
+    Enum.each(list, fn _item ->
+      fresh = fresh + 1
+      fresh
+    end)
+
+    fresh
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_comprehension_keyword_do_generator.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_comprehension_keyword_do_generator.ex
@@ -1,0 +1,5 @@
+defmodule ComprehensionKeywordDo do
+  def run(list) do
+    for no<caret>de <- list, do: node + 1
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_nested_comprehension_keyword_do_generator.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_nested_comprehension_keyword_do_generator.ex
@@ -1,0 +1,5 @@
+defmodule NestedComprehension do
+  def run(rows) do
+    for row <- rows, do: for(ce<caret>ll <- row, do: cell + 1)
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_anonymous_function.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_anonymous_function.ex
@@ -1,0 +1,7 @@
+defmodule Shadowing do
+  def run(list) do
+    no<caret>de = 1
+    Enum.map(list, fn node -> node + 1 end)
+    node
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_case_clause.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_case_clause.ex
@@ -1,0 +1,11 @@
+defmodule Shadowing do
+  def run(list) do
+    no<caret>de = 1
+
+    case list do
+      node -> node + 1
+    end
+
+    node
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_comprehension.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_comprehension.ex
@@ -1,0 +1,9 @@
+defmodule Shadowing do
+  def run(list) do
+    no<caret>de = 1
+
+    for node <- list, do: node + 1
+
+    node
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_comprehension_do_block.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowed_in_comprehension_do_block.ex
@@ -1,0 +1,11 @@
+defmodule Shadowing do
+  def run(list) do
+    no<caret>de = 1
+
+    for node <- list do
+      node + 1
+    end
+
+    node
+  end
+end

--- a/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowing_anonymous_function_parameter.ex
+++ b/testData/org/elixir_lang/model/psi/variable/usages_variable_shadowing_anonymous_function_parameter.ex
@@ -1,0 +1,7 @@
+defmodule Shadowing do
+  def run(list) do
+    node = 1
+    Enum.map(list, fn no<caret>de -> node + 1 end)
+    node
+  end
+end

--- a/tests/org/elixir_lang/model/psi/rename/RenameMatrixTest.kt
+++ b/tests/org/elixir_lang/model/psi/rename/RenameMatrixTest.kt
@@ -176,6 +176,17 @@ class RenameMatrixTest : PlatformTestCase() {
     fun testVariableComprehension() =
         doTestFromEveryOccurrence("variable_comprehension", "renamee", "fresh", expectedCarets = 2)
 
+    /**
+     * A rebinding inside an `fn` BODY is the same variable as the one it rebinds, unlike an `fn`
+     * PARAMETER of the same name, which shadows it.
+     */
+    fun testVariableAnonymousFunctionBodyRebinding() =
+        doTestFromEveryOccurrence("variable_fn_body_rebinding", "renamee", "fresh", expectedCarets = 5)
+
+    /** The same for a `case` clause body: only the clause PATTERN binds afresh. */
+    fun testVariableCaseClauseBodyRebinding() =
+        doTestFromEveryOccurrence("variable_case_clause_rebinding", "renamee", "fresh", expectedCarets = 5)
+
     /** `with {:ok, renamee} <- ...` binding and body use. */
     fun testVariableWith() = doTestFromEveryOccurrence("variable_with", "renamee", "fresh", expectedCarets = 2)
 

--- a/tests/org/elixir_lang/model/psi/variable/VariableFindUsagesTest.kt
+++ b/tests/org/elixir_lang/model/psi/variable/VariableFindUsagesTest.kt
@@ -61,6 +61,16 @@ class VariableFindUsagesTest : PlatformTestCase() {
         assertEquals(1, nonDeclarationUsageCount("usages_parameter_sibling_clause_same_name.ex"))
     }
 
+    fun testFindUsagesOnComprehensionKeywordDoGeneratorFindsBodyRead() {
+        assertEquals(1, nonDeclarationUsageCount("usages_comprehension_keyword_do_generator.ex"))
+    }
+
+    fun testFindUsagesOnNestedComprehensionKeywordDoGeneratorFindsBodyRead() {
+        // The inner generator sits in the OUTER comprehension's `do:` value, so it must still read
+        // as a binding of its own rather than as a body read of the outer one.
+        assertEquals(1, nonDeclarationUsageCount("usages_nested_comprehension_keyword_do_generator.ex"))
+    }
+
     fun testCtrlClickOnIgnoredParameterDeclarationChoosesShowUsages() {
         myFixture.configureByFiles("usages_ignored_parameter_declaration.ex")
         myFixture.assertShowUsagesChosenAtCaret()

--- a/tests/org/elixir_lang/model/psi/variable/VariableFindUsagesTest.kt
+++ b/tests/org/elixir_lang/model/psi/variable/VariableFindUsagesTest.kt
@@ -61,6 +61,30 @@ class VariableFindUsagesTest : PlatformTestCase() {
         assertEquals(1, nonDeclarationUsageCount("usages_parameter_sibling_clause_same_name.ex"))
     }
 
+    fun testFindUsagesOnVariableDeclarationIgnoresShadowingAnonymousFunctionBinding() {
+        // An `fn` parameter that reuses an outer name is an independent binding, so only the
+        // trailing read belongs to the outer variable - the `fn`'s own parameter and body read
+        // do not. Rename shares this search, so over-reporting here silently rewrites them.
+        assertEquals(1, nonDeclarationUsageCount("usages_variable_shadowed_in_anonymous_function.ex"))
+    }
+
+    fun testFindUsagesOnAnonymousFunctionParameterIgnoresShadowedOuterBinding() {
+        // The mirror direction: from the `fn` parameter, only its own body read is a usage.
+        assertEquals(1, nonDeclarationUsageCount("usages_variable_shadowing_anonymous_function_parameter.ex"))
+    }
+
+    fun testFindUsagesOnVariableDeclarationIgnoresShadowingCaseClauseBinding() {
+        assertEquals(1, nonDeclarationUsageCount("usages_variable_shadowed_in_case_clause.ex"))
+    }
+
+    fun testFindUsagesOnVariableDeclarationIgnoresShadowingComprehensionBinding() {
+        assertEquals(1, nonDeclarationUsageCount("usages_variable_shadowed_in_comprehension.ex"))
+    }
+
+    fun testFindUsagesOnVariableDeclarationIgnoresShadowingComprehensionDoBlockBinding() {
+        assertEquals(1, nonDeclarationUsageCount("usages_variable_shadowed_in_comprehension_do_block.ex"))
+    }
+
     fun testFindUsagesOnComprehensionKeywordDoGeneratorFindsBodyRead() {
         assertEquals(1, nonDeclarationUsageCount("usages_comprehension_keyword_do_generator.ex"))
     }


### PR DESCRIPTION
Renaming a variable could silently rewrite an unrelated binding that shadows it. The code still compiled and the user got no warning.

Find Usages, Highlight Usages at caret and Rename share one search, and it matched candidates by name and search scope alone. A search scope is a text range, and an inner binding sits inside the outer one's, so an `fn` parameter, a `case` clause pattern or a `for` generator reusing an outer name was reported — and renamed — as a usage of the outer variable. Resolution was never at fault: Go To Declaration and completion have always treated the inner binding correctly.

Three commits, each its own logical change:

| Commit | What |
|---|---|
| `stop a rebinding chain only at a clause pattern` | A stab signature and the left side of `<-` bind afresh; a clause body does not. Also fixes renaming from a rebinding inside an `fn` or `case` body, which previously stopped at the enclosing clause. |
| `don't classify a read in a \`do:\` body as a binding` | `for x <- xs, do: x` marked the body read a parameter, where the `do` block spelling did not. |
| `resolve variable occurrences before reporting them as usages` | The search resolves each occurrence, so a binding that shadows another is no longer reported as a usage of it. |

A read that resolution cannot place at all falls back to the search scope, so a gap in resolution over-reports a usage rather than dropping one — Rename shares this search, and a dropped usage leaves a dangling reference behind.

Fixes #1479.

## Tests

Eleven new fixtures, all `mix format` clean. Two `RenameMatrixTest` cases cover rebinding inside an `fn` and a `case` clause body; seven `VariableFindUsagesTest` cases cover shadowing in each construct and the keyword-`do:` comprehension forms.

Blast radius (`model.psi.*`, `psi.scope.*`, `refactoring.*`, `annotator.*`, `inspection.*`, `reference.*`), `--rerun-tasks`, 75 classes, 410 tests, 0 failures on **2025.3.6**, **2026.1.4** and **2026.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
