### PR TITLE
Start the quoter daemon on every run, and bind it to loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,10 @@
     so from the second run onwards the task was skipped while its marker still reported
     `quoter.available=true` and every test that quotes failed on a PID timeout. The task is now always
     out of date and never cached.
+  - **The quoter's Erlang distribution and `epmd` now bind loopback rather than every interface.** Both
+    listeners bound the wildcard address despite the nodes being local, which is what made Windows
+    Firewall prompt for the release's `erl.exe` and the IDE's `java.exe`, once per worktree. An `epmd`
+    that is already running is used as it is; only a fresh start asks for loopback.
 
 - [#3960](https://github.com/KronicDeth/intellij-elixir/pull/3960) [@sh41](https://github.com/sh41)
   - **`epmd` is now started from the Erlang SDK rather than the quoter's own bundled ERTS.** A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,13 @@
 
 ### Build / CI
 
+- [#3969](https://github.com/KronicDeth/intellij-elixir/pull/3969) [@sh41](https://github.com/sh41)
+  - **The quoter daemon is now started on every test run, not just the first in a checkout.** Its files
+    made `startQuoter` look up to date, but the daemon it starts is stopped again when the build ends,
+    so from the second run onwards the task was skipped while its marker still reported
+    `quoter.available=true` and every test that quotes failed on a PID timeout. The task is now always
+    out of date and never cached.
+
 - [#3960](https://github.com/KronicDeth/intellij-elixir/pull/3960) [@sh41](https://github.com/sh41)
   - **`epmd` is now started from the Erlang SDK rather than the quoter's own bundled ERTS.** A
     distributed node starts `epmd` from the ERTS of whatever release is starting, detached, so the one

--- a/buildSrc/src/main/kotlin/quoter/Epmd.kt
+++ b/buildSrc/src/main/kotlin/quoter/Epmd.kt
@@ -31,14 +31,19 @@ object Epmd {
     }
 
     /**
-     * `epmd -daemon` is a no-op when the port is already bound, so this runs on every build regardless
-     * of who started the one already there. The `-names` probe is what the result reports: suppressing
-     * the release's own start on a false positive would leave it unable to bring up distribution.
+     * An epmd that is already running is used as it is, whatever it is bound to; only a fresh start asks
+     * for loopback. Probed rather than started unconditionally, because on Windows a narrower bind
+     * succeeds alongside an existing wildcard one and would leave two daemons on 4369.
      */
     fun ensureRunning(epmd: File, logger: Logger): Boolean = try {
-        run(epmd, "-daemon")
-        run(epmd, "-names").also { up ->
-            logger.info(if (up) "epmd is up, from ${epmd.absolutePath}" else "epmd did not answer")
+        if (run(epmd, "-names")) {
+            logger.info("epmd is already up")
+            true
+        } else {
+            run(epmd, "-daemon", bindLoopback = true)
+            run(epmd, "-names").also { up ->
+                logger.info(if (up) "epmd is up, from ${epmd.absolutePath}" else "epmd did not answer")
+            }
         }
     } catch (exception: Exception) {
         logger.info("Could not start epmd from ${epmd.absolutePath}: ${exception.message}")
@@ -51,11 +56,17 @@ object Epmd {
      * the full 30-minute job timeout. Discarding both streams, and bounding the wait, is what makes this
      * safe to call on every build.
      */
-    private fun run(epmd: File, argument: String): Boolean {
-        val process = ProcessBuilder(epmd.absolutePath, argument)
+    private fun run(epmd: File, argument: String, bindLoopback: Boolean = false): Boolean {
+        val builder = ProcessBuilder(epmd.absolutePath, argument)
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .redirectError(ProcessBuilder.Redirect.DISCARD)
-            .start()
+
+        // Only when starting, never when probing - see [ensureRunning].
+        if (bindLoopback) {
+            builder.environment()["ERL_EPMD_ADDRESS"] = LOOPBACK_ADDRESS
+        }
+
+        val process = builder.start()
 
         if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
             process.destroyForcibly()

--- a/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
@@ -85,6 +85,9 @@ fun createQuoterPlatform(platform: Platform, startEpmd: Boolean = true): QuoterP
  */
 const val DEFAULT_QUOTER_NODE_NAME = "intellij_elixir@127.0.0.1"
 
+/** The only interface the quoter's distribution and epmd ever need; see [Epmd] and [getReleaseEnvironment]. */
+const val LOOPBACK_ADDRESS = "127.0.0.1"
+
 /**
  * Returns the standard environment variables for Quoter daemon.
  * Used by all platform implementations.
@@ -110,11 +113,22 @@ fun getReleaseEnvironment(
         put("RELEASE_NAME", releaseName)
         releaseTmp?.let { put("RELEASE_TMP", it.absolutePath) }
 
-        if (!startEpmd) {
-            // Appended rather than set: erlexec reads one ERL_AFLAGS, so overwriting an inherited value
-            // would silently drop flags the developer or CI set.
-            val inherited = System.getenv("ERL_AFLAGS")?.trim().orEmpty()
-            put("ERL_AFLAGS", listOf(inherited, "-start_epmd false").filter { it.isNotEmpty() }.joinToString(" "))
+        // Appended rather than set: erlexec reads one ERL_AFLAGS, so overwriting an inherited value
+        // would silently drop flags the developer or CI set.
+        val inherited = System.getenv("ERL_AFLAGS")?.trim().orEmpty()
+        val flags = buildList {
+            add(inherited)
+
+            // The node is named @127.0.0.1 but its listener binds every interface anyway, which is what
+            // makes Windows Firewall prompt for the release's erl.exe - once per worktree, since a rule
+            // is keyed on the program path.
+            add("-kernel inet_dist_use_interface {127,0,0,1}")
+
+            if (!startEpmd) {
+                add("-start_epmd false")
+            }
         }
+
+        put("ERL_AFLAGS", flags.filter { it.isNotEmpty() }.joinToString(" "))
     }
 }

--- a/buildSrc/src/main/kotlin/quoter/tasks/StartQuoterTask.kt
+++ b/buildSrc/src/main/kotlin/quoter/tasks/StartQuoterTask.kt
@@ -19,6 +19,16 @@ import org.gradle.api.tasks.TaskAction
  */
 abstract class StartQuoterTask : DefaultTask() {
 
+    init {
+        // [QuoterService.close] stops the daemon at the end of the build that started it, so no build
+        // leaves one running and this task has no correct up-to-date state. Skipped, [startedFile] goes
+        // on reporting a daemon that died with the run that wrote it.
+        outputs.upToDateWhen { false }
+
+        // A cache hit would skip the start just as thoroughly. Caching is not enabled here today.
+        outputs.cacheIf { false }
+    }
+
     @get:ServiceReference("quoter")
     abstract val quoterService: Property<QuoterService>
 

--- a/src/org/elixir_lang/IntellijElixir.java
+++ b/src/org/elixir_lang/IntellijElixir.java
@@ -25,7 +25,7 @@ public class IntellijElixir {
 
     public static OtpNode getLocalNode() throws IOException {
         if (localNode == null) {
-            localNode = new OtpNode(LOCAL_NODE, "intellij_elixir");
+            localNode = new OtpNode(LOCAL_NODE, "intellij_elixir", LoopbackTransportFactory.INSTANCE);
         }
 
         return localNode;

--- a/src/org/elixir_lang/Loopback.kt
+++ b/src/org/elixir_lang/Loopback.kt
@@ -1,0 +1,48 @@
+package org.elixir_lang
+
+import com.ericsson.otp.erlang.OtpServerTransport
+import com.ericsson.otp.erlang.OtpSocketTransport
+import com.ericsson.otp.erlang.OtpSocketTransportFactory
+import com.ericsson.otp.erlang.OtpTransport
+import com.ericsson.otp.erlang.OtpTransportFactory
+import java.net.InetAddress
+import java.net.ServerSocket
+
+/**
+ * Binds a JInterface node's distribution listener to loopback rather than to every interface.
+ *
+ * The quoter daemon this talks to is always on this machine, but JInterface binds its listener to
+ * [ServerSocket]'s all-interfaces default - the IPv6 wildcard, and a listener distinct from the one the
+ * quoter's `erl.exe` opens, which is why Windows Firewall prompts for `java.exe` too. Only the listener
+ * is narrowed; outbound connections go through JInterface's own transport.
+ */
+object LoopbackTransportFactory : OtpTransportFactory {
+    private val delegate = OtpSocketTransportFactory()
+
+    // Nullable deliberately: `OtpEpmd.r4_publish` registers the node by calling this with an explicit
+    // `(String) null` for "localhost". Tightening the platform type compiles, then throws on every node.
+    override fun createTransport(address: String?, port: Int): OtpTransport =
+        delegate.createTransport(address, port)
+
+    override fun createTransport(address: InetAddress?, port: Int): OtpTransport =
+        delegate.createTransport(address, port)
+
+    override fun createServerTransport(port: Int): OtpServerTransport = LoopbackServerTransport(port)
+}
+
+/**
+ * [com.ericsson.otp.erlang.OtpServerSocketTransport] with the bind address pinned, and otherwise
+ * identical to it - including the `TCP_NODELAY` its `accept` sets.
+ */
+private class LoopbackServerTransport(port: Int) : OtpServerTransport {
+    // Backlog 0 asks for ServerSocket's own default, as the (port) constructor would; only the address
+    // differs.
+    private val serverSocket = ServerSocket(port, 0, InetAddress.getLoopbackAddress())
+
+    override fun getLocalPort(): Int = serverSocket.localPort
+
+    override fun accept(): OtpTransport =
+        serverSocket.accept().also { it.tcpNoDelay = true }.let(::OtpSocketTransport)
+
+    override fun close() = serverSocket.close()
+}


### PR DESCRIPTION
The first `./gradlew.bat test` in a worktree passed; every later one failed with
`Could not determine PID for Elixir.IntellijElixir.Quoter ... within 1000` for every quoter-dependent
test — 1974 failures in one case — while `epmd -names` showed zero registered nodes.

## Why

`startQuoter` declares the availability marker as an input and the start marker as an output, but its
real product is a live OS daemon, and `QuoterService.close()` stops that daemon at the end of the same
build that started it. So no build ever leaves one running, and **`startQuoter` has no correct
up-to-date state at all**. Read from `--info` rather than inferred:

```
> Task :startQuoter UP-TO-DATE
Skipping task ':startQuoter' as it is up-to-date.
```

The failure is silent because the skip happens before `quoterService.get()`: the build service is never
instantiated, `close()` is a no-op, and nothing is ever in a position to notice the daemon is gone. The
marker goes on reporting `quoter.available=true` for a daemon that died with the run that wrote it.

This is a side effect of #3949, not of #3960. Before f0f10dc9 the task declared an `@InputFile` and no
outputs, so Gradle could never call it up-to-date; f0f10dc9 added `@OutputFile startedFile` — for good
reason, since the test task reads that marker to decide whether quoter tests can run — and that is what
made the task up-to-date-checkable. #3960 changes only where `epmd` is started and touches no input or
output declaration.

The marker stays. Only the up-to-dateness claim goes, plus `cacheIf { false }`, since an out-of-date
task can still be satisfied by a cache hit and `org.gradle.caching=true` here.

## Loopback

Second commit, separate concern: the daemon's and the test JVM's distribution listeners bound the
wildcard address despite both nodes being named `@127.0.0.1`, which is what makes Windows Firewall
prompt for the release's `erl.exe` and the IDE's `java.exe` — once per worktree, since a rule is keyed
on the program path.

Note this corrects a comment added in #3960 rather than being an unrelated tidy-up: `-daemon` does
**not** reliably no-op on Windows. A narrower bind succeeds alongside an existing wildcard one, so
passing `ERL_EPMD_ADDRESS` unconditionally starts a second daemon on 4369 and splits the registry —
observed as two pids. An `epmd` that is already running is now used as it is, whatever it is bound to.

## Verified

| | narrowed | default |
|---|---|---|
| quoter release | `127.0.0.1:29563` | `0.0.0.0:22137` |
| `OtpNode` | `127.0.0.1:27697` | `:::27693` |

`startQuoter` now executes on the second run; `epmd is already up` with no third daemon started; full
`:compileKotlin` rebuild clean.

One trap worth recording for anyone touching `OtpTransportFactory`: overriding `createTransport` in
Kotlin with a non-null `String` compiles cleanly and then throws `NullPointerException` on every node
created, because `OtpEpmd.r4_publish` registers a node by calling it with an explicit `(String) null`
meaning localhost. The parameters have to stay nullable. Caught by running it, not by compiling it.

## Not done here

The full suite has not been run against this branch — the quoter half is verified at task level and the
`OtpNode` change by direct probe, but not by the parser tests that use that node in anger.

The debugger's own JInterface listener has the same wildcard bind and is deliberately untouched; it goes
as a note on #3936.
