### PR TITLE
fix(resolution): resolve a module attribute declared in a __using__ quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@
 
 ### Bug Fixes
 
+- [#3971](https://github.com/KronicDeth/intellij-elixir/pull/3971) [@sh41](https://github.com/sh41)
+  - **A module attribute declared in a `__using__` macro's `quote` block resolves again.** Since
+    24.0.0 a symbol was only built for a declaration whose enclosing modular could be named, and a
+    declaration inside `quote` is enclosed by the `quote` call rather than by a module. The scope
+    walk found the declaration and the result was then discarded, so Go To Declaration, Find Usages
+    and completion silently stopped working for every attribute injected through `use`. Refs
+    [#1783](https://github.com/KronicDeth/intellij-elixir/issues/1783),
+    [#1292](https://github.com/KronicDeth/intellij-elixir/issues/1292).
+
 - [#3968](https://github.com/KronicDeth/intellij-elixir/pull/3968) [@sh41](https://github.com/sh41)
   - **"Align operands of pipe operator (|)" no longer staircases a multi-operand union.** `a | b | c`
     parses as nested pipe operations, and each level built its own alignment, so every level anchored

--- a/src/org/elixir_lang/model/psi/module_attribute/ModuleAttributeSymbol.kt
+++ b/src/org/elixir_lang/model/psi/module_attribute/ModuleAttributeSymbol.kt
@@ -106,9 +106,16 @@ class ModuleAttributeSymbol(
             val atIdentifier = call.atIdentifier
             if (ModuleAttribute.isNonReferencing(atIdentifier)) return null
             val name = atIdentifier.identifierName()
-            val enclosingModular = CallDefinitionClause.enclosingModularMacroCall(call) ?: return null
-            val moduleName = runCatching { org.elixir_lang.psi.Module.name(enclosingModular) }
-                .getOrElse { if (it is ProcessCanceledException) throw it else null }
+            // An attribute declared inside a `quote` block is enclosed by the `quote` call, which is
+            // not a modular and has no name, so walk outward until one that does name a module is
+            // found. Without this the declaration resolves but no symbol is ever built for it.
+            val moduleName = generateSequence(CallDefinitionClause.enclosingModularMacroCall(call)) {
+                CallDefinitionClause.enclosingModularMacroCall(it)
+            }
+                .firstNotNullOfOrNull { modular ->
+                    runCatching { org.elixir_lang.psi.Module.name(modular) }
+                        .getOrElse { if (it is ProcessCanceledException) throw it else null }
+                }
                 ?: return null
             return ModuleAttributeSymbol(call.containingFile, atIdentifier.identifierTextRange(), moduleName, name)
         }

--- a/testData/org/elixir_lang/model/psi/module_attribute/goto_declaration_use_injected.ex
+++ b/testData/org/elixir_lang/model/psi/module_attribute/goto_declaration_use_injected.ex
@@ -1,0 +1,17 @@
+defmodule UseInjectedAttributeMacro do
+  defmacro __using__(_) do
+    quote do
+      @from_macro "Module attribute from macro"
+    end
+  end
+end
+
+defmodule UseInjectedAttributeUser do
+  use UseInjectedAttributeMacro
+
+  def read_keyword, do: @from_macro
+
+  def read_block do
+    @from_<caret>macro
+  end
+end

--- a/tests/org/elixir_lang/model/psi/module_attribute/ModuleAttributeUseInjectedResolutionTest.kt
+++ b/tests/org/elixir_lang/model/psi/module_attribute/ModuleAttributeUseInjectedResolutionTest.kt
@@ -1,0 +1,24 @@
+package org.elixir_lang.model.psi.module_attribute
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.code_insight.assertGotoDeclarationLandsIn
+import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
+
+/**
+ * A module attribute declared inside a `__using__` macro's `quote` block belongs to every module
+ * that `use`s it, so a read of it navigates to that declaration. The declaration is enclosed by the
+ * `quote` call rather than by a module, which is the case a symbol has to be built for anyway.
+ */
+class ModuleAttributeUseInjectedResolutionTest : PlatformTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/module_attribute"
+
+    fun testGotoDeclarationOnUseInjectedAttributeLandsOnDeclaration() {
+        myFixture.configureByFiles("goto_declaration_use_injected.ex")
+        // The read and the declaration share the name `from_macro`, so the assertion is on the
+        // enclosing element: only the declaration is an AtUnqualifiedNoParenthesesCall, which
+        // distinguishes reaching it from navigating to the read itself.
+        myFixture.assertGotoDeclarationLandsIn("from_macro", "the @from_macro declaration") {
+            it is AtUnqualifiedNoParenthesesCall<*>
+        }
+    }
+}


### PR DESCRIPTION
A module attribute declared in a `__using__` macro's `quote` block stopped resolving in 24.0.0. Go To Declaration, Find Usages and completion all silently do nothing for it, with no warning of any kind.

Resolution itself was never at fault. The scope walk added in `335584d3f` still works: it descends the `use`, finds the declaration in the `quote` block, and marks the result valid. The Symbol API migration in `217f5c535` and `e608bbf35` put `ModuleAttributeSymbol.fromDeclaration` above that walk, and it requires the declaration to have an enclosing modular whose name it can read. A declaration inside a `quote` is enclosed by the `quote` call, not by a module, so no symbol was built and the resolved declaration was discarded.

The same migration also stopped module attributes producing an unresolved reference at all, so nothing reported the failure — the plugin quietly resolves nothing instead of saying it cannot. That pairing is why this went unnoticed for a release: the change that broke the behaviour also removed the alarm that watched it.

The fix walks outward past the `quote` to the first enclosing call that does name a module. It only runs where `fromDeclaration` previously returned `null` and no symbol was built at all, so every case that already resolved is untouched.

Refs #1783, #1292.

## Tests

`ModuleAttributeUseInjectedResolutionTest` covers the reported shape — an attribute declared in a `__using__` `quote` block, read from a `use`-ing module. The read and the declaration share a name, so the assertion is on the enclosing element: only the declaration is an `AtUnqualifiedNoParenthesesCall`, which distinguishes reaching it from navigating to the read itself. Verified red on the parent commit and green with the fix.

Nothing under `testData` covered `use`, `__using__` or `Module.put_attribute` for module attributes, and `335584d3f` shipped without a test, which is how the regression got through.

Blast radius (`model.psi.*`, `reference.*`, `code_insight.*`, `inspection.*`, `navigation.*`), 452 tests, 0 failures on **2025.3.6**.
