### PR TITLE
fix(capture): show docs and navigate to decompiled clauses from a capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,18 @@
     `<%= %>` was coloured. Still behind the experimental sigil-injection setting. Fixes
     [#1827](https://github.com/KronicDeth/intellij-elixir/issues/1827).
 
+- [#3972](https://github.com/KronicDeth/intellij-elixir/pull/3972) [@sh41](https://github.com/sh41)
+  - **Quick Documentation now works on a captured function.** `&Callee.multiply/2` showed nothing
+    where `Callee.multiply(2, 3)` showed its `@doc`, because a captured name carries no reference of
+    its own - it lives on the enclosing capture operator, the only element that also spans the
+    `/arity`.
+  - **Go To Definition on a capture of a decompiled function now navigates.** `&:queue.new/0` went
+    nowhere while `:queue.new()` opened the decompiled module, because the capture dropped every
+    result that was not already source PSI.
+  - Captures are now covered by the Go To Definition, Find Usages, arity and protocol-function
+    suites as well, which previously exercised only ordinary calls. Refs
+    [#1810](https://github.com/KronicDeth/intellij-elixir/issues/1810).
+
 - [#3971](https://github.com/KronicDeth/intellij-elixir/pull/3971) [@sh41](https://github.com/sh41)
   - **A module attribute declared in a `__using__` macro's `quote` block resolves again.** Since
     24.0.0 a symbol was only built for a declaration whose enclosing modular could be named, and a

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -25,7 +25,9 @@ import org.elixir_lang.psi.impl.call.macroChildCallSequence
 import org.elixir_lang.psi.impl.childExpressions
 import org.elixir_lang.psi.impl.identifierName
 import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.psi.operation.capture.NonNumeric
 import org.elixir_lang.psi.stub.type.call.Stub.isModular
+import org.elixir_lang.reference.CaptureNameArity
 import org.elixir_lang.reference.Resolver
 import org.elixir_lang.structure_view.element.Callback
 import org.intellij.markdown.html.HtmlGenerator
@@ -273,6 +275,18 @@ internal class ElixirDocumentationProvider : DocumentationProvider {
         return contextElement?.let(::getCustomDocumentationElement)
     }
 
+    /**
+     * The reference to resolve for documentation on [call]. Inside `&Mod.name/arity` the name carries no
+     * reference of its own - it lives on the enclosing capture operator, which is the only element that
+     * also spans the `/arity` - so a captured name is looked up through that instead.
+     */
+    private fun documentedReference(call: Call): PsiPolyVariantReference? =
+        PsiTreeUtil.getParentOfType(call, NonNumeric::class.java)
+            ?.reference
+            ?.let { it as? CaptureNameArity }
+            ?.takeIf { it.nameElement == call }
+            ?: call.getReference() as? PsiPolyVariantReference
+
     private tailrec fun getCustomDocumentationElement(contextElement: PsiElement): PsiElement? = when {
         contextElement is LeafPsiElement || contextElement is ElixirIdentifier || contextElement is ElixirRelativeIdentifier ->
             getCustomDocumentationElement(contextElement.parent)
@@ -289,9 +303,7 @@ internal class ElixirDocumentationProvider : DocumentationProvider {
         }
 
         contextElement is Call -> {
-            contextElement
-                .getReference()
-                ?.let { it as PsiPolyVariantReference }
+            documentedReference(contextElement)
                 ?.let { reference ->
                     val allResults = reference.multiResolve(false)
 

--- a/src/org/elixir_lang/model/psi/function/CaptureFunctionReferenceProvider.kt
+++ b/src/org/elixir_lang/model/psi/function/CaptureFunctionReferenceProvider.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.model.psi.protocol.ProtocolFunction
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.call.Call
@@ -60,7 +61,15 @@ class CaptureFunctionReference(
     override fun resolveReference(): Collection<Symbol> {
         val clauses = legacyReference.multiResolve(false)
             .filter { it.isValidResult }
-            .mapNotNull { it.element as? Call }
+            .mapNotNull { result ->
+                when (val element = result.element) {
+                    // A source clause is already a `Call`, while a decompiled beam function exposes the
+                    // equivalent clause as its navigation element, so capturing one navigates like calling it.
+                    is Call -> element
+                    is CallDefinitionImpl<*> -> element.navigationElement as? Call
+                    else -> null
+                }
+            }
             .filter { CallDefinitionClause.`is`(it) }
 
         val functionSymbols = clauses

--- a/testData/org/elixir_lang/documentation/local_function_quick_doc/capture_function.ex
+++ b/testData/org/elixir_lang/documentation/local_function_quick_doc/capture_function.ex
@@ -1,0 +1,13 @@
+defmodule Callee do
+  @moduledoc "Callee module."
+  @doc "Multiplies two numbers."
+  def multiply(a, b) do
+    a * b
+  end
+end
+
+defmodule Caller do
+  def run do
+    &Callee.mul<caret>tiply/2
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/beam_capture_goto.ex
+++ b/testData/org/elixir_lang/model/psi/function/beam_capture_goto.ex
@@ -1,0 +1,5 @@
+defmodule BeamCaptureGoto do
+  def run do
+    &:queue.ne<caret>w/0
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/capture_site_arity.ex
+++ b/testData/org/elixir_lang/model/psi/function/capture_site_arity.ex
@@ -1,0 +1,8 @@
+defmodule CaptureArity do
+  def foo(a), do: a
+  def foo(a, b), do: a + b
+
+  def call do
+    &fo<caret>o/1
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/goto_declaration_capture_referenced.ex
+++ b/testData/org/elixir_lang/model/psi/function/goto_declaration_capture_referenced.ex
@@ -1,0 +1,5 @@
+defmodule GotoDeclarationCapture.Referenced do
+  def changeset(struct, params) do
+    {struct, params}
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/goto_declaration_qualified_call.ex
+++ b/testData/org/elixir_lang/model/psi/function/goto_declaration_qualified_call.ex
@@ -1,0 +1,5 @@
+defmodule GotoDeclarationQualifiedCall do
+  def run(struct, params) do
+    GotoDeclarationCapture.Referenced.change<caret>set(struct, params)
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/goto_declaration_qualified_capture.ex
+++ b/testData/org/elixir_lang/model/psi/function/goto_declaration_qualified_capture.ex
@@ -1,0 +1,5 @@
+defmodule GotoDeclarationQualifiedCapture do
+  def run do
+    &GotoDeclarationCapture.Referenced.change<caret>set/2
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/protocol_capture.ex
+++ b/testData/org/elixir_lang/model/psi/function/protocol_capture.ex
@@ -1,0 +1,9 @@
+defprotocol CaptureConvertible do
+  def convert(data)
+end
+
+defmodule CaptureRunner do
+  def run do
+    &CaptureConvertible.con<caret>vert/1
+  end
+end

--- a/testData/org/elixir_lang/model/psi/function/usages_capture.ex
+++ b/testData/org/elixir_lang/model/psi/function/usages_capture.ex
@@ -1,0 +1,9 @@
+defmodule UsagesCapture do
+  def per<caret>form(data) do
+    data
+  end
+end
+
+defmodule UsagesCaptureCaller do
+  def run, do: &UsagesCapture.perform/1
+end

--- a/tests/org/elixir_lang/documentation/FunctionCallQuickDocumentationTest.kt
+++ b/tests/org/elixir_lang/documentation/FunctionCallQuickDocumentationTest.kt
@@ -48,6 +48,27 @@ class FunctionCallQuickDocumentationTest : QuickDocumentationTestCase() {
         )
     }
 
+    /** A capture names the function without calling it, so Ctrl+Q on it must still show its `@doc`. */
+    fun testQuickDocOnQualifiedCaptureShowsAtDoc() {
+        myFixture.configureByFiles("capture_function.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull("Quick Documentation should be shown for a documented captured function", documentation)
+        assertTrue(
+            "Expected the defining module in the documentation, got: $documentation",
+            documentation!!.contains("<b>Callee</b>")
+        )
+        assertTrue(
+            "Expected the function head in the documentation, got: $documentation",
+            documentation.contains("multiply")
+        )
+        assertTrue(
+            "Expected the @doc body in the documentation, got: $documentation",
+            documentation.contains("Multiplies two numbers")
+        )
+    }
+
     fun testQuickDocOnModuleAliasShowsModuleDoc() {
         myFixture.configureByFiles("module_alias.ex")
 

--- a/tests/org/elixir_lang/model/psi/function/BeamFunctionGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/function/BeamFunctionGotoDeclarationTest.kt
@@ -39,6 +39,21 @@ class BeamFunctionGotoDeclarationTest : BeamLibraryTestCase() {
         )
     }
 
+    /** Capturing a decompiled function must navigate into the `.beam` mirror the same way calling it does. */
+    fun testGoToDeclarationNavigatesFromCaptureToRemoteBeamFunction() {
+        myFixture.configureByFiles("beam_capture_goto.ex")
+        val target = myFixture.gotoDeclarationDestinationAtCaret()
+        assertNotNull("Go To Declaration should navigate into the decompiled :queue module", target)
+        assertTrue(
+            "Should land in the decompiled queue.beam, not the source file (was ${target!!.containingFile.name})",
+            target.containingFile.name.startsWith("queue")
+        )
+        assertTrue(
+            "Should land on the decompiled `def new` definition (was '${target.text}')",
+            target.text.contains("new")
+        )
+    }
+
     fun testFindUsagesFromRemoteBeamFunctionUsageFindsSourceUsages() {
         myFixture.configureByFiles("beam_qualified_call_find_usages.ex")
         assertEquals(

--- a/tests/org/elixir_lang/model/psi/function/FunctionCallSiteArityTest.kt
+++ b/tests/org/elixir_lang/model/psi/function/FunctionCallSiteArityTest.kt
@@ -7,6 +7,7 @@ import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.model.psi.protocol.ProtocolFunction
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.operation.capture.NonNumeric
 
 /**
  * Regression for [FunctionCallReference] resolution:
@@ -51,5 +52,44 @@ class FunctionCallSiteArityTest : PlatformTestCase() {
             "Convertible.convert([]) should resolve to the protocol function clause",
             resolved.any { it is ProtocolFunction && it.arity == 1 }
         )
+    }
+
+    /**
+     * A capture states its arity in the source instead of implying it from an argument list, so `&foo/1`
+     * must select the same single clause `foo(1)` does.
+     */
+    fun testCaptureResolvesOnlyToMatchingArity() {
+        myFixture.configureByFiles("capture_site_arity.ex")
+        val functionSymbols = resolvedCaptureSymbolsAtCaret().filterIsInstance<FunctionSymbol>()
+
+        assertTrue("&foo/1 should resolve to at least one function symbol", functionSymbols.isNotEmpty())
+        assertTrue(
+            "&foo/1 must resolve only to foo/1, never foo/2",
+            functionSymbols.all { it.arity == 1 }
+        )
+    }
+
+    fun testCapturedProtocolFunctionResolvesToProtocolFunction() {
+        myFixture.configureByFiles("protocol_capture.ex")
+        val resolved = resolvedCaptureSymbolsAtCaret()
+        assertTrue(
+            "&CaptureConvertible.convert/1 should resolve to the protocol function clause",
+            resolved.any { it is ProtocolFunction && it.arity == 1 }
+        )
+    }
+
+    /**
+     * A capture hosts its symbol reference on the enclosing `&` operator rather than on the inner call,
+     * because the bare name there classifies as a variable to the legacy scope walker.
+     */
+    private fun resolvedCaptureSymbolsAtCaret(): List<Symbol> {
+        val element = myFixture.file.findElementAt(myFixture.caretOffset)
+        assertNotNull("Element at caret should exist", element)
+        val capture = generateSequence(element!!) { it.parent }
+            .filterIsInstance<NonNumeric>()
+            .firstOrNull()
+        assertNotNull("Could not find the enclosing capture operator", capture)
+        return PsiSymbolReferenceService.getService().getReferences(capture!!)
+            .flatMap { it.resolveReference() }
     }
 }

--- a/tests/org/elixir_lang/model/psi/function/FunctionFindUsagesTest.kt
+++ b/tests/org/elixir_lang/model/psi/function/FunctionFindUsagesTest.kt
@@ -29,6 +29,14 @@ class FunctionFindUsagesTest : PlatformTestCase() {
         )
     }
 
+    /** A capture is a use of the function, so Find Usages on the `def` must list the capture site. */
+    fun testCaptureSiteIsFound() {
+        assertTrue(
+            "Expected the capture site `&UsagesCapture.perform/1` among the function's usages",
+            callSiteUsageCount("usages_capture.ex") >= 1
+        )
+    }
+
     fun testApplyCallSiteIsFound() {
         assertTrue(
             "Expected the `apply(ApplyTarget, :reverse, [...])` call site among the function's usages",

--- a/tests/org/elixir_lang/model/psi/function/FunctionGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/function/FunctionGotoDeclarationTest.kt
@@ -80,6 +80,21 @@ class FunctionGotoDeclarationTest : PlatformTestCase() {
         myFixture.assertGotoDeclarationLandsIn("perform", "a defmacro clause") { CallDefinitionClause.`is`(it) }
     }
 
+    /**
+     * A capture, `&Mod.fun/arity`, must navigate to the same `def` the equivalent qualified call does.
+     * The capture carries its arity in the source rather than in an argument list, so it reaches the
+     * resolver by a different route and needs its own case; the call below is the control.
+     */
+    fun testGoToDeclarationNavigatesFromQualifiedCapture() {
+        myFixture.configureByFiles("goto_declaration_qualified_capture.ex", "goto_declaration_capture_referenced.ex")
+        myFixture.assertGotoDeclarationLandsIn("changeset", "a def clause") { CallDefinitionClause.`is`(it) }
+    }
+
+    fun testGoToDeclarationNavigatesFromQualifiedCall() {
+        myFixture.configureByFiles("goto_declaration_qualified_call.ex", "goto_declaration_capture_referenced.ex")
+        myFixture.assertGotoDeclarationLandsIn("changeset", "a def clause") { CallDefinitionClause.`is`(it) }
+    }
+
     fun testCtrlClickOnErlangQualifiedCallDoesNothingYet() {
         myFixture.configureByFiles("goto_declaration_erlang_qualified_call.ex")
         myFixture.assertNoNavigationAtCaret()


### PR DESCRIPTION
A captured name carries no reference of its own — it lives on the enclosing `&` operator, the only element that spans both the name and the `/arity`. Two features never learned that, and each fails where the equivalent ordinary call succeeds.

**Quick Documentation is blank for a captured function.** `ElixirDocumentationProvider.getCustomDocumentationElement` asks the inner call for a reference that a captured name does not have, so `&Callee.multiply/2` shows nothing where `Callee.multiply(2, 3)` shows its `@doc`. A `documentedReference` helper now prefers the enclosing capture's `CaptureNameArity`, guarded by an identity check on its `nameElement` so an unrelated outer capture cannot be claimed.

**Capturing a decompiled function navigates nowhere.** `CaptureFunctionReference.resolveReference` mapped results with `it.element as? Call`, which silently drops a decompiled clause because that arrives as `CallDefinitionImpl`. Its call-site sibling `FunctionCallReference` already handles this by taking `navigationElement as? Call`; the capture bridge now mirrors it, so `&:queue.new/0` lands in the decompiled module just as `:queue.new()` does.

### Coverage

Captures had no Go To Definition fixture anywhere, and the only qualified-capture assertion in the suite was incidental, inside a test written for source-versus-decompiled preference. Added alongside the fixes: Go To Definition on a qualified capture and on a cross-file qualified call, Find Usages listing a capture site, `&foo/1` selecting only the arity-1 clause, and a captured protocol function resolving to `ProtocolFunction` — a named branch of `CaptureFunctionReferenceProvider` that had no test at all.

Each new test was written first and observed failing before its fix. Full suite green at 7032 tests.

Found while reviewing [#1810](https://github.com/KronicDeth/intellij-elixir/issues/1810), which reports Go To Definition failing on `&Module.function/2`. That specific behaviour already works and these are separate defects, so this pull request does not close it.