### PR TITLE
fix(injection): give ~E and ~L fragments an HTML data language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,12 @@
 
 ### Bug Fixes
 
+- [#3973](https://github.com/KronicDeth/intellij-elixir/pull/3973) [@sh41](https://github.com/sh41)
+  - **HTML inside a `~L` or `~E` sigil is now highlighted.** The injected fragment carried no file
+    extension, so EEx's template-data language fell through to plain text and only the Elixir inside
+    `<%= %>` was coloured. Still behind the experimental sigil-injection setting. Fixes
+    [#1827](https://github.com/KronicDeth/intellij-elixir/issues/1827).
+
 - [#3971](https://github.com/KronicDeth/intellij-elixir/pull/3971) [@sh41](https://github.com/sh41)
   - **A module attribute declared in a `__using__` macro's `quote` block resolves again.** Since
     24.0.0 a symbol was only built for a declaration whose enclosing modular could be named, and a

--- a/src/org/elixir_lang/injection/ElixirSigilInjector.kt
+++ b/src/org/elixir_lang/injection/ElixirSigilInjector.kt
@@ -35,11 +35,12 @@ internal class ElixirSigilInjector : MultiHostInjector {
 
     private fun handleSigilLine(registrar: MultiHostRegistrar, sigilLine: SigilLine) {
         if (!sigilLine.isValidHost) return
-        val lang = languageForSigil(sigilLine.sigilName()) ?: return
+        val sigilName = sigilLine.sigilName()
+        val lang = languageForSigil(sigilName) ?: return
         val ranges = sigilLineInjectionRanges(sigilLine, lang)
         if (ranges.isEmpty()) return
 
-        registrar.startInjecting(lang)
+        registrar.startInjecting(lang, fileExtensionForSigil(sigilName))
         for (range in ranges) {
             registrar.addPlace(null, null, sigilLine, range)
         }
@@ -59,7 +60,8 @@ internal class ElixirSigilInjector : MultiHostInjector {
             return
         }
 
-        val lang = languageForSigil(sigilHeredoc.sigilName()) ?: return
+        val sigilName = sigilHeredoc.sigilName()
+        val lang = languageForSigil(sigilName) ?: return
         val heredocLineList = sigilHeredoc.heredocLineList
 
         if (LOG.isDebugEnabled) {
@@ -71,7 +73,7 @@ internal class ElixirSigilInjector : MultiHostInjector {
             return
         }
 
-        registrar.startInjecting(lang)
+        registrar.startInjecting(lang, fileExtensionForSigil(sigilName))
         for (range in ranges) {
             if (LOG.isDebugEnabled) {
                 LOG.debug("handleSigilHeredoc: injecting range $range")
@@ -103,6 +105,16 @@ internal class ElixirSigilInjector : MultiHostInjector {
             'r' -> RegExpLanguage.INSTANCE
             else -> null
         }
+    }
+
+    // EEx guesses an injected fragment's template-data language from a double extension, the way a
+    // real `.html.eex` file carries one; with no extension the guess falls through to plain text and
+    // the markup gets no HTML highlighting. Phoenix.HTML's ~E and LiveView's ~L are HTML by
+    // definition, so name the fragment to say so. HEEx defaults to HTML without help, and a regex is
+    // not a template.
+    private fun fileExtensionForSigil(sigilName: Char): String? = when (sigilName) {
+        'E', 'L' -> "html.eex"
+        else -> null
     }
 
     private fun interpolationRanges(body: PsiElement, bodyStartOffsetInHost: Int): List<TextRange> {

--- a/tests/org/elixir_lang/injection/HeexSigilInjectionTest.kt
+++ b/tests/org/elixir_lang/injection/HeexSigilInjectionTest.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.html.HTMLLanguage
 import com.intellij.lang.injection.InjectedLanguageManager
 import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.templateLanguages.TemplateLanguageFileViewProvider
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.xml.XmlTag
 import org.elixir_lang.ElixirLanguage
@@ -232,6 +233,86 @@ class HeexSigilInjectionTest : PlatformTestCase() {
             "Expected no injection while the experimental setting is off, got: $injected",
             injected.isNullOrEmpty()
         )
+    }
+
+    fun testLSigilInjectsNothingWhenSettingDisabled() {
+        ElixirExperimentalSettings.instance.state.enableHtmlInjection = false
+
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def render(assigns) do
+                    ~L'''
+                    <div><%= @x %></div>
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val sigilHeredoc = PsiTreeUtil.findChildOfType(myFixture.file, SigilHeredocLiteral::class.java)
+        checkNotNull(sigilHeredoc) { "Sigil host not found in test file" }
+
+        val injected = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(sigilHeredoc)
+        assertTrue(
+            "Expected no injection while the experimental setting is off, got: $injected",
+            injected.isNullOrEmpty()
+        )
+    }
+
+    fun testLSigilDataRootIsHtmlNotPlainText() {
+        val viewProvider = injectedEexViewProvider("L")
+
+        assertEquals(
+            "~L is LiveView's HTML template sigil, so its data root must be HTML, not plain text",
+            HTMLLanguage.INSTANCE,
+            viewProvider.templateDataLanguage
+        )
+
+        val divTag = PsiTreeUtil.findChildOfType(viewProvider.getPsi(HTMLLanguage.INSTANCE), XmlTag::class.java)
+        assertNotNull("Expected the <div> to parse as real HTML PSI, not text", divTag)
+        assertEquals("div", divTag!!.name)
+    }
+
+    fun testESigilDataRootIsHtmlNotPlainText() {
+        val viewProvider = injectedEexViewProvider("E")
+
+        assertEquals(
+            "Phoenix.HTML's ~E is an HTML template sigil, so its data root must be HTML, not plain text",
+            HTMLLanguage.INSTANCE,
+            viewProvider.templateDataLanguage
+        )
+
+        val divTag = PsiTreeUtil.findChildOfType(viewProvider.getPsi(HTMLLanguage.INSTANCE), XmlTag::class.java)
+        assertNotNull("Expected the <div> to parse as real HTML PSI, not text", divTag)
+        assertEquals("div", divTag!!.name)
+    }
+
+    private fun injectedEexViewProvider(sigilName: String): TemplateLanguageFileViewProvider {
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def render(assigns) do
+                    ~$sigilName'''
+                    <div><%= @x %></div>
+                    '''
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val sigilHeredoc = PsiTreeUtil.findChildOfType(myFixture.file, SigilHeredocLiteral::class.java)
+        checkNotNull(sigilHeredoc) { "Sigil host not found in test file" }
+
+        val injected = InjectedLanguageManager.getInstance(project).getInjectedPsiFiles(sigilHeredoc).orEmpty()
+        val eexRoot = injected
+            .map { it.first.containingFile }
+            .firstOrNull { it.language.isKindOf(EexLanguage.INSTANCE) }
+        checkNotNull(eexRoot) { "Expected an EEx injection, got: ${injected.map { it.first.containingFile.language }}" }
+
+        return eexRoot.viewProvider as TemplateLanguageFileViewProvider
     }
 
     private fun injectedHeexFile(text: String): PsiFile {


### PR DESCRIPTION
Fixes #1827

`~L` and `~E` both inject EEx, and #3696 gave the injected fragment a real PSI tree instead of flat
text. But the tree's *data* root came out as plain text, so the markup this issue is about still had
no HTML PSI and no highlighting at all — only the Elixir inside `<%= %>` was ever coloured.

**This is not redundant with the fix described on #1827 in August.** That comment said turning the
experimental setting on would make `~L` highlight. It would not have. Measured on this PR's own merge
base (ef69b81e4), with `enableHtmlInjection` on and the fix reverted, both new tests fail:

```
expected:<Language: HTML> but was:<Language: TEXT>
```

## Cause

`ElixirSigilInjector` called the one-argument `MultiHostRegistrar.startInjecting(language)`, so
`InjectionRegistrarImpl` had a null `fileExtension` and `PathUtil.makeFileName` returned the host
file's name unchanged — the fragment was called `test.ex`, not `test.ex.something`. EEx picks its
template-data language by looking for a double extension the way a real `.html.eex` file carries one
(`eex/file/Type.onlyTemplateDataFileType`). There was no second extension to find, so it fell through
to `EexLanguage.defaultTemplateLanguageFileType()`, which is `PLAIN_TEXT`.

This is the same failure #3696's commit message describes for HEEx pre-fix. HEEx was fixed by
hard-defaulting its data language to HTML, which is right for HEEx and wrong for EEx: a `.eex` *file*
can template anything (`.json.eex`, `.txt.eex`). It is the `~E` and `~L` *sigils* that are HTML by
definition — Phoenix.HTML and LiveView respectively — so the knowledge belongs at the injection site,
not in the view provider.

## Change

`startInjecting(language, "html.eex")` for `~E` and `~L`, so the fragment is named `<host>.html.eex`
and EEx's existing guess resolves HTML. `~H` and `~r` pass `null` and are unchanged.

## Tests

- `testLSigilDataRootIsHtmlNotPlainText` / `testESigilDataRootIsHtmlNotPlainText` — the data root's
  language is HTML, and the `<div>` parses as a real `XmlTag` rather than text. Both fail without the
  change, as above.
- `testLSigilInjectsNothingWhenSettingDisabled` — `~H` and `~E` had a setting-disabled test and `~L`
  did not. Injection stays gated on `enableHtmlInjection`; this fix does not change that.

## Still gated

`enableHtmlInjection` is read in `PsiLanguageInjectionHost.isValidHost`, upstream of everything here:
with the setting off a sigil is not a valid host, the injector returns early, and there is no
injection to give a data language to. Unchanged by this PR.
