### PR TITLE
fix(annotator): stop a qualified call in a @type parameter list erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@
     [#1796](https://github.com/KronicDeth/intellij-elixir/issues/1796) and
     [#3142](https://github.com/KronicDeth/intellij-elixir/issues/3142).
 
+- [#3974](https://github.com/KronicDeth/intellij-elixir/pull/3974) [@sh41](https://github.com/sh41)
+  - **A qualified call in a `@type` parameter list no longer raises an error report.** `@type
+    date(spec.date_type)` reached two annotator branches that between them knew every other shape a
+    parameter can take but not a dot-qualified one, so typing it reported "Cannot extract type type
+    parameter name set" and, on the same keystroke, "Cannot highlight types and type parameter
+    declarations". A qualified call names a type in another module rather than declaring a parameter,
+    so it is now left out of the parameter-name set and painted the way a type usage is. Fixes
+    [#1835](https://github.com/KronicDeth/intellij-elixir/issues/1835).
+
 - [#3973](https://github.com/KronicDeth/intellij-elixir/pull/3973) [@sh41](https://github.com/sh41)
   - **HTML inside a `~L` or `~E` sigil is now highlighted.** The injected fragment carried no file
     extension, so EEx's template-data language fell through to plain text and only the Elixir inside

--- a/src/org/elixir_lang/annotator/ModuleAttribute.kt
+++ b/src/org/elixir_lang/annotator/ModuleAttribute.kt
@@ -475,6 +475,17 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 )
             }
 
+            /* A qualified call declares no type parameter, so both halves are painted the way a type
+               usage is. */
+            is QualifiedNoArgumentsCall<*> -> {
+                highlightTypesAndTypeParameterUsages(
+                    psiElement,
+                    typeParameterNameSet,
+                    annotationHolder,
+                    typeTextAttributesKey
+                )
+            }
+
             else -> {
                 if (psiElement !is ElixirAtomKeyword) {
                     error("Cannot highlight types and type parameter declarations", psiElement)
@@ -1515,6 +1526,11 @@ internal class ModuleAttribute : Annotator, DumbAware {
             is ElixirUnmatchedUnqualifiedNoArgumentsCall -> {
                 setOf(psiElement.getText())
             }
+
+            /* A qualified call names a type in another module, so it declares no type parameter of its own.
+
+               See https://github.com/KronicDeth/intellij-elixir/issues/1835 */
+            is QualifiedNoArgumentsCall<*> -> emptySet()
 
             else -> {
                 error("Cannot extract type type parameter name set", psiElement)

--- a/testData/org/elixir_lang/annotator/module_attribute/issue_1835.ex
+++ b/testData/org/elixir_lang/annotator/module_attribute/issue_1835.ex
@@ -1,0 +1,1 @@
+@type date(spec.date_type) :: spec.date_type

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -82,6 +82,11 @@ public class ModuleAttributeTest extends PlatformTestCase {
         myFixture.checkHighlighting(false, false, true);
     }
 
+    public void testIssue1835() {
+        myFixture.configureByFile("issue_1835.ex");
+        myFixture.checkHighlighting(false, false, true);
+    }
+
     public void testIssue2198() {
         myFixture.configureByFile("issue_2198.ex");
         myFixture.checkHighlighting(false, false, false);


### PR DESCRIPTION
Fixes #1835.

`@type date(spec.date_type)` — a dot-qualified call in a type's parameter list — reaches two `when` dispatches in `ModuleAttribute` that between them name every other shape a type parameter can take. Neither names a qualified call, so the parameter-name extraction fell through to its `else` and reported "Cannot extract type type parameter name set", and the highlighting pass beside it fell through to its own `else` on the same keystroke with "Cannot highlight types and type parameter declarations". Only the first has ever been reported; the error balloon groups on the first throwable submitted.

A qualified call names a type in another module rather than declaring a parameter, so it contributes no name to the parameter set, and its qualifier and relative identifier are painted the way the usage side already paints them.

Not a regression: `git log -S` over the file's whole history, including its pre-Kotlin form, finds no commit that ever added such a clause.

### Testing

`testIssue1835`, following `testIssue694`, over a one-line fixture. `Logger.error` throws under the test harness, so the assertion is that annotating the fixture reports nothing.

Each clause was shown to be independently necessary by deleting it and re-running, rather than inferred from call order:

| Tree | `Executed N tests` |
|---|---|
| fixture only, no source change | 14 (1 failed) — *Cannot extract type type parameter name set*, element class `ElixirUnmatchedQualifiedNoArgumentsCallImpl`, the class the report names |
| name-set clause only | 14 (1 failed) — *Cannot highlight types and type parameter declarations* |
| highlighting clause only | 14 (1 failed) — *Cannot extract type type parameter name set* |
| both clauses | 14 |
| both clauses, whole suite | 7031 |

The other 13 tests in the class stayed green in every red run, including `testIssue694`, which exercises a neighbouring clause of the same `when`.
