### PR TITLE
fix(reference): stop reporting an error for an fn without ->

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,13 @@
 
 ### Bug Fixes
 
+- [#3976](https://github.com/KronicDeth/intellij-elixir/pull/3976) [@sh41](https://github.com/sh41)
+  - **An `fn` whose body has no `->` no longer reports "Don't know how to check if variable".** The
+    walk that decides whether a name is a variable enumerates the ancestor types it understands and
+    raises an error report for anything else, and an anonymous function missing its clause arrow
+    reaches it while the code is still being typed. Fixes
+    [#2376](https://github.com/KronicDeth/intellij-elixir/issues/2376).
+
 - [#3975](https://github.com/KronicDeth/intellij-elixir/pull/3975) [@sh41](https://github.com/sh41)
   - **A hexadecimal or octal number in a type no longer reports "Cannot highlight types".** The
     annotator listed the bases it knew rather than matching whole numbers, so `0x0001..0xFFFF` in a

--- a/src/org/elixir_lang/reference/Callable.kt
+++ b/src/org/elixir_lang/reference/Callable.kt
@@ -320,6 +320,9 @@ class Callable : PsiReferenceBase<Call>, PsiPolyVariantReference {
                     true
 
                 is ElixirAccessExpression,
+                    /* an anonymous function is only reached when its stab has no `->`, which is a syntax error,
+                       but it can also occur during typing, so try searching above it */
+                is ElixirAnonymousFunction,
                 is ElixirAssociations,
                 is ElixirAssociationsBase,
                 is ElixirBitString,

--- a/testData/org/elixir_lang/reference/callable/issue_2376/is_variable.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_2376/is_variable.ex
@@ -1,0 +1,4 @@
+fn exec<caret> do
+  :ok
+  end
+end

--- a/tests/org/elixir_lang/reference/callable/Issue2376Test.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue2376Test.kt
@@ -1,0 +1,19 @@
+package org.elixir_lang.reference.callable
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.reference.Callable.Companion.isVariable
+
+class Issue2376Test : PlatformTestCase() {
+    fun testIsVariable() {
+        myFixture.configureByFiles("is_variable.ex")
+        val callable = myFixture
+                .file
+                .findElementAt(myFixture.caretOffset)!!
+                .parent
+        assertInstanceOf(callable, Call::class.java)
+        assertFalse("exec is incorrectly marked as a variable", isVariable(callable))
+    }
+
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/reference/callable/issue_2376"
+}


### PR DESCRIPTION
`Callable.isVariable` walks an element's ancestors to decide whether a name is a variable. It
enumerates the PSI types it understands and raises an error report for anything else.

Per `Elixir.bnf`, `stab ::= stabOperations | stabBody` and `anonymousFunction ::= FN … stab … END`,
so `ElixirStab` is a direct child of `ElixirAnonymousFunction` and the walk reaches the anonymous
function whenever the body has no `->`. With a `->` present it terminates one level earlier at
`ElixirStabOperation`. `ElixirAnonymousFunction` was never in the type list, so a `fn` being typed
raised "Don't know how to check if variable" — as reported in #2376, from `fn exec do … end`.

It now recurses through the anonymous function, as the other nodes that only appear mid-typing
already do. The walk then terminates at `ElixirAccessExpression` → `ElixirFile`, both already
handled, so no second unhandled type is introduced.

`Issue2376Test` pins it on the reporter's snippet. Before the fix it fails with `Element Class Name:
org.elixir_lang.psi.impl.ElixirAnonymousFunctionImpl` — the same class the filed report names.

Fixes #2376
