### PR TITLE
fix(resolution): key the __MODULE__ reference cache by its use call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,21 @@
 
 ### Bug Fixes
 
+- [#3977](https://github.com/KronicDeth/intellij-elixir/pull/3977) [@sh41](https://github.com/sh41)
+  - **Resolving `__MODULE__` inside a module that `use`s another no longer reports a non-idempotent
+    computation.** The reference was cached under one key per `__MODULE__` call, and the platform's
+    parameterized cache never consults the parameter when it looks a value up, so the reference built
+    for one `use` call was handed back to callers that passed a different one - and the two
+    computations disagreed on their dependencies. Completion and Go to Declaration were the usual
+    triggers. Fixes [#2205](https://github.com/KronicDeth/intellij-elixir/issues/2205),
+    [#3320](https://github.com/KronicDeth/intellij-elixir/issues/3320),
+    [#3467](https://github.com/KronicDeth/intellij-elixir/issues/3467),
+    [#3477](https://github.com/KronicDeth/intellij-elixir/issues/3477),
+    [#3495](https://github.com/KronicDeth/intellij-elixir/issues/3495),
+    [#3517](https://github.com/KronicDeth/intellij-elixir/issues/3517),
+    [#3592](https://github.com/KronicDeth/intellij-elixir/issues/3592) and
+    [#3593](https://github.com/KronicDeth/intellij-elixir/issues/3593).
+
 - [#3976](https://github.com/KronicDeth/intellij-elixir/pull/3976) [@sh41](https://github.com/sh41)
   - **An `fn` whose body has no `->` no longer reports "Don't know how to check if variable".** The
     walk that decides whether a name is a variable enumerates the ancestor types it understands and

--- a/src/org/elixir_lang/psi/__MODULE__.kt
+++ b/src/org/elixir_lang/psi/__MODULE__.kt
@@ -2,33 +2,42 @@ package org.elixir_lang.psi
 
 import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiReference
+import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
-import com.intellij.psi.util.ParameterizedCachedValue
-import com.intellij.psi.util.ParameterizedCachedValueProvider
+import com.intellij.psi.util.PsiModificationTracker
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.psi.__module__.Reference
 import org.elixir_lang.psi.call.Call
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 
 object __MODULE__ {
-    val KEY: Key<ParameterizedCachedValue<PsiReference, Call?>> = Key.create("__MODULE__REFERENCE")
+    private val KEY: Key<CachedValue<ConcurrentHashMap<Call, PsiReference>>> = Key.create("__MODULE__REFERENCE")
 
+    /**
+     * The reference for `__MODULE__Call`, resolved through the scope `useCall` injects when one is given.
+     *
+     * The reference is cached per `useCall`, not per `__MODULE__Call` alone.  A `ParameterizedCachedValue`
+     * holds one value per (data holder, key) and never consults the parameter when looking a value up, so
+     * a single slot handed the reference built for one `use` call back to callers that asked for a
+     * different one - and let the platform compare two computations whose dependency arrays named
+     * different elements, which it reports as a non-idempotent computation.
+     *
+     * The map must stay a [ConcurrentMap]: `IdempotenceChecker` exempts one from the value comparison
+     * it applies to every other cached collection, because a cache filled lazily after it is stored
+     * would otherwise be reported as non-idempotent itself.
+     */
+    @RequiresReadLock
     fun reference(__MODULE__Call: Call, useCall: Call? = null): PsiReference =
         CachedValuesManager
-                .getManager(__MODULE__Call.project)
-                .getParameterizedCachedValue(__MODULE__Call, KEY, Provider(__MODULE__Call), false, useCall)
-
-    private class Provider(private val __MODULE__Call: Call) : ParameterizedCachedValueProvider<PsiReference, Call?> {
-        override fun compute(useCall: Call?): CachedValueProvider.Result<PsiReference>? {
-            val dependencies: Array<Call> = if (useCall != null) {
-                arrayOf(__MODULE__Call, useCall)
-            } else {
-                arrayOf(__MODULE__Call)
+            .getCachedValue(__MODULE__Call, KEY) {
+                CachedValueProvider.Result.create(
+                    ConcurrentHashMap<Call, PsiReference>(),
+                    PsiModificationTracker.MODIFICATION_COUNT
+                )
             }
-
-            return CachedValueProvider.Result.create(
-                    Reference(call = __MODULE__Call, useCall = useCall),
-                    dependencies
-            )
-        }
-    }
+            // `__MODULE__Call` stands in for a null `useCall`, which a `ConcurrentHashMap` cannot key on.
+            // It cannot collide with a real one: a `use` call is never a `__MODULE__` call.
+            .computeIfAbsent(useCall ?: __MODULE__Call) { Reference(call = __MODULE__Call, useCall = useCall) }
 }

--- a/tests/org/elixir_lang/psi/__MODULE__Test.kt
+++ b/tests/org/elixir_lang/psi/__MODULE__Test.kt
@@ -1,0 +1,135 @@
+package org.elixir_lang.psi
+
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.__module__.Reference
+
+/**
+ * Tests for [org.elixir_lang.psi.__MODULE__.reference], whose `useCall` parameter selects which
+ * `use` call's injected scope `__MODULE__` resolves through.
+ */
+@Suppress("ClassName") // named for the `__MODULE__` special form, matching `org.elixir_lang.psi.__MODULE__`
+class __MODULE__Test : PlatformTestCase() {
+
+    private fun configureModuleUsingWeb() {
+        myFixture.configureByText(
+            "page_controller.ex",
+            """
+            defmodule MyApp.PageController do
+              use MyApp.Web
+
+              def index(conn, _params) do
+                __MODULE__.render(conn)
+              end
+            end
+            """.trimIndent()
+        )
+    }
+
+    private fun callWithText(text: String, root: PsiElement = myFixture.file): Call =
+        PsiTreeUtil.findChildrenOfType(root, Call::class.java).single { it.text == text }
+
+    /**
+     * `platform.random.idempotence.check.rate` makes the platform re-run the provider on every cache
+     * hit instead of once in a while, which is the recipe `IdempotenceChecker`'s own javadoc gives for
+     * turning this from a race into something a test can assert on.
+     */
+    private fun assertResolvingTwiceIsIdempotent(secondUseCall: Call?, firstUseCall: Call) {
+        Registry.get("platform.random.idempotence.check.rate").setValue(1, testRootDisposable)
+
+        val __MODULE__Call = callWithText("__MODULE__")
+        val (_, loggedErrors) = captureLoggedErrors {
+            __MODULE__.reference(__MODULE__Call, firstUseCall)
+            __MODULE__.reference(__MODULE__Call, secondUseCall)
+        }
+
+        assertEmpty(
+            "resolving __MODULE__ twice must not report a non-idempotent computation",
+            loggedErrors.filter { error ->
+                listOfNotNull(error.message, error.title).any { it.contains("Non-idempotent computation") }
+            }
+        )
+    }
+
+    /**
+     * `reference` caches under `KEY` on the `__MODULE__` call itself, and a `ParameterizedCachedValue`
+     * holds one value per (data holder, key) - the parameter reaches the provider but never the
+     * lookup.  So a reference computed for one `useCall` is handed back to every later caller that
+     * asks for a different one, while the file is unchanged.
+     */
+    fun testReferenceIsNotSharedAcrossUseCalls() {
+        configureModuleUsingWeb()
+
+        val __MODULE__Call = callWithText("__MODULE__")
+        val useCall = callWithText("use MyApp.Web")
+
+        val forUseCall = __MODULE__.reference(__MODULE__Call, useCall) as Reference
+        assertSame(useCall, forUseCall.useCall)
+
+        val forNoUseCall = __MODULE__.reference(__MODULE__Call) as Reference
+        assertNull(
+            "__MODULE__.reference() must not hand back the reference built for `use MyApp.Web` to a " +
+                "caller that passed no useCall",
+            forNoUseCall.useCall
+        )
+    }
+
+    /**
+     * The same slot in the other direction: the no-`useCall` reference is the one
+     * `Call.computeCallableReference` asks for, so it is usually cached first and then returned to
+     * `Call.maybeModularNameToModulars`, which loses the `use` scope it passed in.
+     */
+    fun testReferenceForNoUseCallIsNotReusedForAUseCall() {
+        configureModuleUsingWeb()
+
+        val __MODULE__Call = callWithText("__MODULE__")
+        val useCall = callWithText("use MyApp.Web")
+
+        assertNull((__MODULE__.reference(__MODULE__Call) as Reference).useCall)
+
+        assertSame(
+            "__MODULE__.reference(useCall = <use MyApp.Web>) must not hand back the reference built " +
+                "with no useCall",
+            useCall,
+            (__MODULE__.reference(__MODULE__Call, useCall) as Reference).useCall
+        )
+    }
+
+    /**
+     * The shared slot's user-visible face: the provider hands the platform `arrayOf(call, useCall)` or
+     * `arrayOf(call)` depending on the parameter, so two computations of the one slot disagree on how
+     * many dependencies it has and `IdempotenceChecker` reports the value as non-idempotent.
+     */
+    fun testResolvingWithAndWithoutAUseCallIsIdempotent() {
+        configureModuleUsingWeb()
+
+        assertResolvingTwiceIsIdempotent(
+            firstUseCall = callWithText("use MyApp.Web"),
+            secondUseCall = null
+        )
+    }
+
+    /**
+     * The shape the reports on the tracker carry, where both dependency arrays name both calls and
+     * only `PSI_MOD_COUNT_OPTIMIZATION` differs.  `PsiCachedValue.normalizeDependencies` prepends that
+     * sentinel only when every dependency is "very physical", so the same two-element array is
+     * observed as three elements for a `use` call in the edited file and as two for the same call in
+     * the non-physical copy code completion resolves against - which is the case
+     * `PsiCachedValue.isVeryPhysical`'s own comment calls out.
+     */
+    fun testResolvingAgainstANonPhysicalCopyIsIdempotent() {
+        configureModuleUsingWeb()
+
+        val copy = myFixture.file.copy() as PsiFile
+        assertFalse("a PSI file copy must be non-physical for this to be the reported case", copy.isPhysical)
+
+        assertResolvingTwiceIsIdempotent(
+            firstUseCall = callWithText("use MyApp.Web"),
+            secondUseCall = callWithText("use MyApp.Web", copy)
+        )
+    }
+}


### PR DESCRIPTION
`__MODULE__.reference` cached its `PsiReference` with `getParameterizedCachedValue`, which holds one
value per (data holder, key) and never consults the parameter when it looks a value up. Both call
sites share the `__MODULE__` call as the data holder but pass different `use` calls, so whichever
computed first won and the other received a reference built for a `use` call it had not asked for.

The platform then compared two computations of that one entry whose dependency arrays named different
elements. `PsiCachedValue` prepends a `PSI_MOD_COUNT_OPTIMIZATION` sentinel only when every dependency
is still very physical, and code completion resolves against a non-physical copy of the file, so one
array carried it and the other did not — reported as a non-idempotent computation with a `3 != 2` or
`2 != 3` dependency count. Which side computed first decides which ordering the report shows, which is
why both appear across the issues.

## The fix

Cache per `use` call, in a `ConcurrentHashMap` held by a plain `CachedValue`, so those computations
land in separate entries.

- The dependency array is now a lone `PsiModificationTracker.MODIFICATION_COUNT`, which
  `normalizeDependencies` returns untouched, so its length cannot vary either.
- Reference identity per (call, `use` call) is preserved, so `ResolveCache` — keyed by reference
  instance — still hits.
- The map has to stay a `ConcurrentMap`: `IdempotenceChecker` exempts one from the value comparison it
  applies to every other cached collection, because a cache filled lazily after it is stored would
  otherwise be reported as non-idempotent itself.

## Tests

`__MODULE__Test` covers both faces of the defect, all four red before the change and green after:

- two asserting `reference()` does not hand back a `Reference` built for a different `use` call, in
  both directions;
- two asserting the platform does not report a non-idempotent computation, using the check rate
  `IdempotenceChecker`'s own javadoc recommends. The second of those takes the `use` call from
  `myFixture.file.copy()` and reproduces the dependency arrays the reports carry character for
  character, single-threaded.

Full suite: 7054 passing.
