### PR TITLE
fix(psi): stop reporting file scope for a parameter in an fn without ->

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@
 
 ### Bug Fixes
 
+- [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)
+  - **A parameter of an `fn` that has no `->` yet no longer reports "Use scope for parameter not found
+    before reaching file scope".** The scope search stopped at a definition clause, a delegation, a call
+    with a do block or keyword, or a `->` clause, but not at the anonymous function around them - so
+    `fn p end`, which is what `fn p -> ... end` looks like part-way through being typed, searched past
+    the `fn` to the file and was reported. Fixes
+    [#2491](https://github.com/KronicDeth/intellij-elixir/issues/2491).
+
 - [#3979](https://github.com/KronicDeth/intellij-elixir/pull/3979) [@sh41](https://github.com/sh41)
   - **A variable whose scope search reaches the top of the file no longer reports "Don't know how to
     find variable use scope".** The search enumerates the ancestor types it understands and raises an

--- a/src/org/elixir_lang/psi/impl/declarations/UseScopeImpl.kt
+++ b/src/org/elixir_lang/psi/impl/declarations/UseScopeImpl.kt
@@ -105,6 +105,12 @@ object UseScopeImpl {
                     }
                 } else if (ancestor is ElixirStabOperation) {
                     break
+                } else if (ancestor is ElixirAnonymousFunction) {
+                    /* `Parameter.putParameterized` stops at an anonymous function and calls what it found a
+                       parameter, so this walk has to recognise one too. A well-formed `fn` hides the omission
+                       behind the `ElixirStabOperation` of its `->` clause, but code being typed reaches the `fn`
+                       without one. */
+                    break
                 } else if (ancestor is PsiFile) {
                     Logger.error(
                         UnqualifiedNoArgumentsCall::class.java,

--- a/testData/org/elixir_lang/psi/impl/declarations/issue_2491/anonymous_function_with_stab.ex
+++ b/testData/org/elixir_lang/psi/impl/declarations/issue_2491/anonymous_function_with_stab.ex
@@ -1,0 +1,1 @@
+fn <caret>p -> end

--- a/testData/org/elixir_lang/psi/impl/declarations/issue_2491/anonymous_function_without_stab.ex
+++ b/testData/org/elixir_lang/psi/impl/declarations/issue_2491/anonymous_function_without_stab.ex
@@ -1,0 +1,1 @@
+fn <caret>p end

--- a/tests/org/elixir_lang/psi/impl/declarations/Issue2491Test.kt
+++ b/tests/org/elixir_lang/psi/impl/declarations/Issue2491Test.kt
@@ -1,0 +1,55 @@
+package org.elixir_lang.psi.impl.declarations
+
+import com.intellij.psi.search.LocalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirAnonymousFunction
+import org.elixir_lang.psi.ElixirStabOperation
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall
+
+class Issue2491Test : PlatformTestCase() {
+    /**
+     * `fn p end` is what `fn p -> ... end` looks like part-way through being typed. Without the `->`, the
+     * parameter's ancestors hold no [ElixirStabOperation], so the use scope walk used to run past the
+     * anonymous function to the file and report reaching file scope as unexpected.
+     */
+    fun testAnonymousFunctionWithoutStab() {
+        val parameter = configureAndFindParameter("anonymous_function_without_stab.ex")
+        val anonymousFunction =
+                PsiTreeUtil.getParentOfType(parameter, ElixirAnonymousFunction::class.java)!!
+
+        val (useScope, errors) = captureLoggedErrors(suppress = false) { parameter.useScope }
+
+        assertEmpty(errors)
+        assertEquals(LocalSearchScope(anonymousFunction), useScope)
+    }
+
+    /**
+     * The `->` that the case above is missing. Its [ElixirStabOperation] was always recognised, and still
+     * takes precedence over the anonymous function around it.
+     */
+    fun testAnonymousFunctionWithStab() {
+        val parameter = configureAndFindParameter("anonymous_function_with_stab.ex")
+        val stabOperation = PsiTreeUtil.getParentOfType(parameter, ElixirStabOperation::class.java)!!
+
+        val (useScope, errors) = captureLoggedErrors(suppress = false) { parameter.useScope }
+
+        assertEmpty(errors)
+        assertEquals(LocalSearchScope(stabOperation), useScope)
+    }
+
+    private fun configureAndFindParameter(path: String): UnqualifiedNoArgumentsCall<*> {
+        myFixture.configureByFiles(path)
+
+        val parameter = PsiTreeUtil.getParentOfType(
+                myFixture.file.findElementAt(myFixture.caretOffset),
+                UnqualifiedNoArgumentsCall::class.java
+        )
+
+        assertNotNull(parameter)
+
+        return parameter!!
+    }
+
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/psi/impl/declarations/issue_2491"
+}


### PR DESCRIPTION
Fixes #2491

`UseScopeImpl`'s walk up from a parameter recognises a call definition clause, a delegation, a call with a do block or keyword, and a stab operation — but not the anonymous function they sit inside. `Parameter.putParameterized`, which decided the call was a parameter in the first place, does stop there and calls it one, so the two walks disagree.

A well-formed `fn` hides the disagreement, because the stab operation of its `->` clause always sits between the parameter and the `fn`. An `fn` whose stab has no arrow leaves none, so the walk ran past the `fn` to the file and reported reaching file scope as unexpected. That is a syntax error, but also a state the code passes through while being typed — `fn p end` is what `fn p -> ... end` looks like before the arrow is typed, and every report of this carries a single truncated token as its excerpt.

This is the same node, for the same reason, as the `Callable.isVariable` case added in #3976; the two differ only in direction. `isVariable` asks whether a node can declare, so a stab-less `fn` means keep searching above. `UseScopeImpl` asks what the search scope is, and the anonymous function is a real scope boundary, so it stops there.

#3976 and #3979 are both already on `main` and neither reaches this path — #3979 changes `variableUseScope`, which the parameter branch never calls, and the failing case below still failed with both present.

### Tests

`Issue2491Test` covers `fn p end` and, as a control, `fn p -> end`. Both use `captureLoggedErrors(suppress = false)`, so a logged error fails the test outright. With the new case removed the first fails and the control still passes, so it discriminates the fix rather than the fixture.

#2517, #1945 and #2568 were closed as duplicates of #2491.
