### PR TITLE
fix(mix): scope dep library names relative to the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - [#3983](https://github.com/KronicDeth/intellij-elixir/pull/3983) [@sh41](https://github.com/sh41)
   - **Elixir's `Tools` menu actions are grouped under `Tools > Elixir`.**
+  - **New `Tools > Elixir > Sync Dependency Libraries` Action**. Rescans every content root's
+    `deps` and `_build`.
 
 - [#3954](https://github.com/KronicDeth/intellij-elixir/pull/3954) [@sh41](https://github.com/sh41)
   - **`~E` sigils now get EEx highlighting and completion.** `~H` injected HEEx and `~L` injected EEx,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
     writes**, however it was triggered.
   - **External Libraries shows a dependency's name and location again.**
   - **A dependency's optional and non-`:prod` dependencies no longer become empty libraries.**
+  - **A `sparse:` and/or `subdir:` git dependency is now located correctly.** Refs [#3928](https://github.com/KronicDeth/intellij-elixir/issues/3928).
   - **Bracketed dependency options such as `[path: "../dep"]` are read.**
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
   - **A `sparse:` and/or `subdir:` git dependency is now located correctly.** Refs [#3928](https://github.com/KronicDeth/intellij-elixir/issues/3928).
   - **A dependency's own dependencies are located correctly.** Refs [#3928](https://github.com/KronicDeth/intellij-elixir/issues/3928).
   - **Bracketed dependency options such as `[path: "../dep"]` are read.**
+  - **An umbrella app's dependencies resolve when each app is its own module.** Refs
+    [#3986](https://github.com/KronicDeth/intellij-elixir/issues/3986).
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)
   - **A parameter of an `fn` that has no `->` yet no longer reports "Use scope for parameter not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
   - **Dependency scanning waits for the IDE's Project Model to be fully loaded to avoid lost
     writes**, however it was triggered.
   - **External Libraries shows a dependency's name and location again.**
+  - **A dependency's optional and non-`:prod` dependencies no longer become empty libraries.**
   - **Bracketed dependency options such as `[path: "../dep"]` are read.**
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@
   - **Bracketed dependency options such as `[path: "../dep"]` are read.**
   - **An umbrella app's dependencies resolve when each app is its own module.** Refs
     [#3986](https://github.com/KronicDeth/intellij-elixir/issues/3986).
+  - **A dependency an umbrella app reaches through an `in_umbrella:` sibling now resolves.** Refs
+    [#3990](https://github.com/KronicDeth/intellij-elixir/issues/3990).
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)
   - **A parameter of an `fn` that has no `->` yet no longer reports "Use scope for parameter not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - **Elixir's `Tools` menu actions are grouped under `Tools > Elixir`.**
   - **New `Tools > Elixir > Sync Dependency Libraries` Action**. Rescans every content root's
     `deps` and `_build`.
+  - **Mix libraries are re-checked when a project opens**, picking up changes made while it was
+    closed.
 
 - [#3954](https://github.com/KronicDeth/intellij-elixir/pull/3954) [@sh41](https://github.com/sh41)
   - **`~E` sigils now get EEx highlighting and completion.** `~H` injected HEEx and `~L` injected EEx,
@@ -71,6 +73,8 @@
 - [#3983](https://github.com/KronicDeth/intellij-elixir/pull/3983) [@sh41](https://github.com/sh41)
   - **Dependency libraries are scoped relative to the project**, so `.idea/libraries` and `.iml` can
     be shared again. Refs [#3926](https://github.com/KronicDeth/intellij-elixir/issues/3926).
+  - **Dependency scanning waits for the IDE's Project Model to be fully loaded to avoid lost
+    writes**, however it was triggered.
   - **External Libraries shows a dependency's name and location again.**
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
   - **External Libraries shows a dependency's name and location again.**
   - **A dependency's optional and non-`:prod` dependencies no longer become empty libraries.**
   - **A `sparse:` and/or `subdir:` git dependency is now located correctly.** Refs [#3928](https://github.com/KronicDeth/intellij-elixir/issues/3928).
+  - **A dependency's own dependencies are located correctly.** Refs [#3928](https://github.com/KronicDeth/intellij-elixir/issues/3928).
   - **Bracketed dependency options such as `[path: "../dep"]` are read.**
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@
 - [#3991](https://github.com/KronicDeth/intellij-elixir/pull/3991) [@sh41](https://github.com/sh41)
   - **The `+++` and `---` operators are now parsed.** Fixes [#2755](https://github.com/KronicDeth/intellij-elixir/issues/2755).
 
+- [#3983](https://github.com/KronicDeth/intellij-elixir/pull/3983) [@sh41](https://github.com/sh41)
+  - **Dependency libraries are scoped relative to the project**, so `.idea/libraries` and `.iml` can
+    be shared again. Refs [#3926](https://github.com/KronicDeth/intellij-elixir/issues/3926).
+  - **External Libraries shows a dependency's name and location again.**
+
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)
   - **A parameter of an `fn` that has no `->` yet no longer reports "Use scope for parameter not found
     before reaching file scope".** The scope search stopped at a definition clause, a delegation, a call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
   - **Dependency scanning waits for the IDE's Project Model to be fully loaded to avoid lost
     writes**, however it was triggered.
   - **External Libraries shows a dependency's name and location again.**
+  - **Bracketed dependency options such as `[path: "../dep"]` are read.**
 
 - [#3982](https://github.com/KronicDeth/intellij-elixir/pull/3982) [@sh41](https://github.com/sh41)
   - **A parameter of an `fn` that has no `->` yet no longer reports "Use scope for parameter not found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Enhancements
 
+- [#3983](https://github.com/KronicDeth/intellij-elixir/pull/3983) [@sh41](https://github.com/sh41)
+  - **Elixir's `Tools` menu actions are grouped under `Tools > Elixir`.**
+
 - [#3954](https://github.com/KronicDeth/intellij-elixir/pull/3954) [@sh41](https://github.com/sh41)
   - **`~E` sigils now get EEx highlighting and completion.** `~H` injected HEEx and `~L` injected EEx,
     but Phoenix.HTML's own `~E` fell through to no injection at all, leaving the template as plain

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -525,8 +525,8 @@
             <separator/>
             <add-to-group group-id="HelpMenu" anchor="last"/>
         </group>
-        <group id="LangElixir.SdkActions">
-            <separator/>
+        <group id="LangElixir.SdkActions" popup="true" compact="true" text="Elixir"
+               icon="org.elixir_lang.Icons.LANGUAGE">
             <action id="Elixir.OpenElixirSdkSettings"
                     class="org.elixir_lang.action.OpenElixirSdkSettingsAction"
                     text="Configure Elixir SDKs"
@@ -556,7 +556,6 @@
                     text="Reconfigure Elixir Module Setup"
                     icon="AllIcons.Actions.Refresh"
                     description="Apply canonical folder marks and fix module SDK references for all Elixir modules"/>
-            <separator/>
             <add-to-group group-id="ToolsMenu" anchor="last"/>
         </group>
         <group id="Internal.Elixir" popup="true" internal="true" compact="true" text="Elixir">

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -34,6 +34,7 @@
 
         <postStartupActivity implementation="org.elixir_lang.sdk.SdkTableListenerStartupActivity"/>
         <postStartupActivity implementation="org.elixir_lang.mix.DepsCheckerStartupActivity"/>
+        <postStartupActivity implementation="org.elixir_lang.mix.sync.MixLibraryReconcileStartupActivity"/>
 
         <!--        <errorHandler implementation="org.elixir_lang.errorreport.Submitter"/>-->
         <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -550,6 +550,16 @@
                     text="Install Mix Deps (hex, rebar, deps.get, deps.compile)"
                     icon="org.elixir_lang.mix.configuration.Icons.TYPE"
                     description="Installs hex, rebar, fetches Mix deps, and compiles them"/>
+            <action id="Elixir.SyncDependencyLibraries"
+                    class="org.elixir_lang.action.SyncDependencyLibrariesAction"
+                    text="Sync Dependency Libraries"
+                    icon="AllIcons.Actions.Refresh"
+                    description="Rescans every content root's deps and _build to sync its Mix dep libraries">
+                <synonym text="Rebuild Mix Libraries"/>
+                <synonym text="Mix Libraries"/>
+                <synonym text="External Libraries"/>
+                <synonym text="Refresh Dependencies"/>
+            </action>
             <separator/>
             <action id="Elixir.ReconfigureModuleSetup"
                     class="org.elixir_lang.action.ReconfigureModuleSetupAction"

--- a/src/org/elixir_lang/PackageManager.kt
+++ b/src/org/elixir_lang/PackageManager.kt
@@ -10,6 +10,16 @@ import org.elixir_lang.package_manager.DepsStatusResult
 interface PackageManager {
     val fileName: String
     fun depGatherer(): DepGatherer
+
+    /**
+     * A gatherer for a package file that may belong to a dependency rather than to a project being
+     * built, which decides whether options like `only:` and `optional:` exclude a dep.
+     *
+     * Defaulted rather than replacing [depGatherer] so an out-of-repo implementor of the
+     * `org.elixir_lang.packageManager` extension point keeps compiling; a package manager with no
+     * such distinction needs no override.
+     */
+    fun depGatherer(@Suppress("UNUSED_PARAMETER") isDependency: Boolean): DepGatherer = depGatherer()
     fun depsStatus(project: Project, packageVirtualFile: VirtualFile, sdk: Sdk?): DepsStatusResult =
         DepsStatusResult.Unsupported
 }

--- a/src/org/elixir_lang/action/SyncDependencyLibrariesAction.kt
+++ b/src/org/elixir_lang/action/SyncDependencyLibrariesAction.kt
@@ -1,0 +1,29 @@
+package org.elixir_lang.action
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import org.elixir_lang.mix.sync.MixDepsSyncService
+import org.elixir_lang.mix.sync.SyncRequest
+import org.elixir_lang.notification.setup_sdk.Notifier
+
+/**
+ * Syncs every dependency library with what is currently on disk.
+ *
+ * The sync service is otherwise driven only by VFS events under `deps/` and `_build/`, plus a
+ * first-time project configuration, so a project whose libraries are wrong has no way back: `mix
+ * deps.get` on already-fetched deps changes nothing on disk and therefore produces no events, and
+ * reopening the project does not re-sync one that is already configured.
+ */
+class SyncDependencyLibrariesAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+
+        project.service<MixDepsSyncService>().enqueue(SyncRequest.All)
+
+        Notifier.dependencyLibrarySyncScheduled(project)
+    }
+
+    override fun isDumbAware(): Boolean = true
+}

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -63,7 +63,7 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                     val initial = Options(Dep(application = name, path = "deps/$name"))
 
                     val options = if (stripped.size > 1) {
-                        stripped.last().let { it as? ElixirKeywords }?.keywordPairList?.let { keywordPairList ->
+                        keywords(stripped.last())?.keywordPairList?.let { keywordPairList ->
                             keywordPairList.fold(initial) { acc, keywordPair ->
                                 val key = keywordPair.keywordKey.text
 
@@ -111,6 +111,21 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
 
         /** The dep this tuple describes. */
         private fun Options.resolve(): Dep = dep
+
+        /**
+         * The options of a dep tuple, whether or not they are wrapped in a list.
+         *
+         * `{:dep, "~> 1.0", optional: true}` and `{:dep, "~> 1.0", [optional: true]}` are the same
+         * declaration and both are written in the wild - `ecto` brackets neither, `db_connection`
+         * brackets its `optional:`. Only the bare form was read, so the bracketed one silently had
+         * every option ignored, `path:` and `in_umbrella:` included.
+         */
+        private fun keywords(optionsElement: PsiElement): ElixirKeywords? =
+            optionsElement as? ElixirKeywords
+                ?: (optionsElement as? ElixirList)
+                    ?.children
+                    ?.singleOrNull()
+                    ?.stripAccessExpression() as? ElixirKeywords
 
         private val logger by lazy { com.intellij.openapi.diagnostic.Logger.getInstance(Dep::class.java) }
 

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -55,7 +55,15 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
     }
 
     companion object {
-        fun from(depsListElement: ElixirTuple): Dep? {
+        fun from(depsListElement: ElixirTuple): Dep? = from(depsListElement, isDependency = false)
+
+        /**
+         * @param isDependency whether the `mix.exs` being read belongs to a dependency rather than to
+         *   a project the IDE is building. Mix checks a dependency's own deps against `:prod` rather
+         *   than the current `MIX_ENV`, and does not force a dependency's optional deps on the project
+         *   using it, so under this flag either option can drop the dep.
+         */
+        fun from(depsListElement: ElixirTuple, isDependency: Boolean): Dep? {
             val stripped = depsListElement.children.stripAccessExpressions()
 
             return if (stripped.isNotEmpty()) {
@@ -69,9 +77,12 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
 
                                 when (key) {
                                     "allow_pre", "app", "branch", "commit", "compile", "env", "git", "github", "hex",
-                                    "manager", "only", "optional", "organization", "override", "ref", "repo", "runtime",
+                                    "manager", "organization", "override", "ref", "repo", "runtime",
                                     GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets",
                                     EDELIVER_DISTILLERY_WARN_MISSING, "sha", "depth", "subdir", "warn_if_outdated" -> acc
+
+                                    "only" -> acc.copy(only = environments(keywordPair.keywordValue))
+                                    "optional" -> acc.copy(optional = isTrue(keywordPair.keywordValue))
 
                                     "in_umbrella" ->
                                         acc.copy(dep = acc.dep.copy(path = "apps/$name", type = Type.MODULE))
@@ -91,7 +102,9 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                         initial
                     }
 
-                    options.resolve()
+                    // Accumulate first and resolve once: an elvis on the resolved dep would read a
+                    // deliberate null as "this tuple had no options" and hand back the unfiltered dep.
+                    options.resolve(isDependency)
                 }
             } else {
                 null
@@ -107,10 +120,45 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
          * depending on which `mix.exs` the tuple came from. Deciding once, at the end, is the only
          * shape that accommodates any of that.
          */
-        private data class Options(val dep: Dep)
+        private data class Options(
+            val dep: Dep,
+            val only: List<String>? = null,
+            val optional: Boolean = false,
+        )
 
-        /** The dep this tuple describes. */
-        private fun Options.resolve(): Dep = dep
+        /** The dep this tuple describes, or `null` when Mix would not fetch it here. */
+        private fun Options.resolve(isDependency: Boolean): Dep? {
+            if (isDependency) {
+                // An `in_umbrella:` dep of a dependency is an app of *that* umbrella, never a module
+                // of this project, so it cannot be wired here either.
+                if (dep.type == Type.MODULE) return null
+                if (optional || (only != null && PROD_ENVIRONMENT !in only)) return null
+            }
+
+            return dep
+        }
+
+        /**
+         * The environments an `only:` names, or `null` when the value cannot be read.
+         *
+         * Unreadable means unrestricted. Dropping a dep that is physically present costs resolution
+         * and completion, while keeping one Mix never fetches costs an empty placeholder library -
+         * so every shape this cannot parse, including a quoted atom, keeps the dep.
+         */
+        private fun environments(keywordValue: Quotable): List<String>? =
+            when (keywordValue) {
+                is ElixirAtom -> keywordValue.name?.let { listOf(it) }
+                is ElixirList ->
+                    keywordValue.children.stripAccessExpressions().map { element ->
+                        (element as? ElixirAtom)?.name ?: return null
+                    }
+                else -> null
+            }
+
+        private fun isTrue(keywordValue: Quotable): Boolean =
+            keywordValue is ElixirAtomKeyword && keywordValue.text == "true"
+
+        private const val PROD_ENVIRONMENT = "prod"
 
         /**
          * The options of a dep tuple, whether or not they are wrapped in a list.

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -60,9 +60,9 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
 
             return if (stripped.isNotEmpty()) {
                 name(stripped[0])?.let { name ->
-                    val initial = Dep(application = name, path = "deps/$name")
+                    val initial = Options(Dep(application = name, path = "deps/$name"))
 
-                    if (stripped.size > 1) {
+                    val options = if (stripped.size > 1) {
                         stripped.last().let { it as? ElixirKeywords }?.keywordPairList?.let { keywordPairList ->
                             keywordPairList.fold(initial) { acc, keywordPair ->
                                 val key = keywordPair.keywordKey.text
@@ -73,8 +73,9 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                     GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets",
                                     EDELIVER_DISTILLERY_WARN_MISSING, "sha", "depth", "subdir", "warn_if_outdated" -> acc
 
-                                    "in_umbrella" -> acc.copy(path = "apps/$name", type = Type.MODULE)
-                                    "path" -> putPath(acc, keywordPair.keywordValue)
+                                    "in_umbrella" ->
+                                        acc.copy(dep = acc.dep.copy(path = "apps/$name", type = Type.MODULE))
+                                    "path" -> acc.copy(dep = putPath(acc.dep, keywordPair.keywordValue))
                                     else -> {
                                         Logger.error(
                                             logger,
@@ -89,11 +90,27 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                     } else {
                         initial
                     }
+
+                    options.resolve()
                 }
             } else {
                 null
             }
         }
+
+        /**
+         * The options of one dep tuple, accumulated across the whole fold before any is acted on.
+         *
+         * An option cannot always be applied where it is read. Two can combine into one path, Mix can
+         * apply a pair in a fixed order that need not match the order they are written, one can gate
+         * whether another applies at all and may appear after it, and one can mean different things
+         * depending on which `mix.exs` the tuple came from. Deciding once, at the end, is the only
+         * shape that accommodates any of that.
+         */
+        private data class Options(val dep: Dep)
+
+        /** The dep this tuple describes. */
+        private fun Options.resolve(): Dep = dep
 
         private val logger by lazy { com.intellij.openapi.diagnostic.Logger.getInstance(Dep::class.java) }
 

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -76,10 +76,16 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                                 val key = keywordPair.keywordKey.text
 
                                 when (key) {
-                                    "allow_pre", "app", "branch", "commit", "compile", "env", "git", "github", "hex",
+                                    "allow_pre", "app", "branch", "commit", "compile", "env", "hex",
                                     "manager", "organization", "override", "ref", "repo", "runtime",
-                                    GUARDIAN_RUNTIME_TYPO, "sparse", "submodules", "system_env", "tag", "targets",
-                                    EDELIVER_DISTILLERY_WARN_MISSING, "sha", "depth", "subdir", "warn_if_outdated" -> acc
+                                    GUARDIAN_RUNTIME_TYPO, "submodules", "system_env", "tag", "targets",
+                                    EDELIVER_DISTILLERY_WARN_MISSING, "sha", "depth", "warn_if_outdated" -> acc
+
+                                    // Only `Mix.SCM.Git` joins `sparse`/`subdir` onto the destination,
+                                    // and it declines a dep naming neither `git:` nor `github:`.
+                                    "git", "github" -> acc.copy(hasGitScm = true)
+                                    "sparse" -> acc.copy(sparse = stringBody(keywordPair.keywordValue))
+                                    "subdir" -> acc.copy(subdir = stringBody(keywordPair.keywordValue))
 
                                     "only" -> acc.copy(only = environments(keywordPair.keywordValue))
                                     "optional" -> acc.copy(optional = isTrue(keywordPair.keywordValue))
@@ -122,8 +128,11 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
          */
         private data class Options(
             val dep: Dep,
+            val sparse: String? = null,
+            val subdir: String? = null,
             val only: List<String>? = null,
             val optional: Boolean = false,
+            val hasGitScm: Boolean = false,
         )
 
         /** The dep this tuple describes, or `null` when Mix would not fetch it here. */
@@ -135,7 +144,11 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
                 if (optional || (only != null && PROD_ENVIRONMENT !in only)) return null
             }
 
-            return dep
+            return if (hasGitScm && dep.type == Type.LIBRARY) {
+                dep.copy(path = listOfNotNull(dep.path, sparse, subdir).joinToString("/"))
+            } else {
+                dep
+            }
         }
 
         /**
@@ -157,6 +170,9 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
 
         private fun isTrue(keywordValue: Quotable): Boolean =
             keywordValue is ElixirAtomKeyword && keywordValue.text == "true"
+
+        private fun stringBody(keywordValue: Quotable): String? =
+            (keywordValue as? ElixirLine)?.body?.text
 
         private const val PROD_ENVIRONMENT = "prod"
 

--- a/src/org/elixir_lang/mix/DepGatherer.kt
+++ b/src/org/elixir_lang/mix/DepGatherer.kt
@@ -18,7 +18,10 @@ import org.elixir_lang.psi.impl.keywordValue
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.util.AccumulatorContinue
 
-class DepGatherer : DepGatherer() {
+/**
+ * @param isDependency whether the `mix.exs` being visited belongs to a dependency; see [Dep.from].
+ */
+class DepGatherer(private val isDependency: Boolean = false) : DepGatherer() {
     override fun visitFile(file: PsiFile) {
         // Caller (Resolution.packagePsiFileToDepSet) already holds a read lock via runReadAction { ... }.
         // A nested runReadAction here is redundant. Protect from inadvertent calls with
@@ -37,7 +40,7 @@ class DepGatherer : DepGatherer() {
 
             childCalls
                     .foldDepsDefinersWhile(listOf<Dep>()) { depsDefiner, acc ->
-                        AccumulatorContinue(acc + depsDefiner.deps(), true)
+                        AccumulatorContinue(acc + depsDefiner.deps(isDependency), true)
                     }
                     .accumulator
                     .let { depSet.addAll(it) }
@@ -45,7 +48,7 @@ class DepGatherer : DepGatherer() {
     }
 }
 
-private fun Call.deps(): List<Dep> = lastList()?.deps() ?: emptyList()
+private fun Call.deps(isDependency: Boolean): List<Dep> = lastList()?.deps(isDependency) ?: emptyList()
 
 private fun Call.lastList(): ElixirList? =
     foldChildrenWhile(null as ElixirList?) { child, acc ->
@@ -144,5 +147,5 @@ private fun QuotableKeywordList.depsNameArity(): NameArity? =
                             }
                 }
 
-private fun ElixirList.deps(): List<Dep> =
-    children.map { it.stripAccessExpression() }.asSequence().flatMap { Deps.from(it) }.toList()
+private fun ElixirList.deps(isDependency: Boolean): List<Dep> =
+    children.map { it.stripAccessExpression() }.asSequence().flatMap { Deps.from(it, isDependency) }.toList()

--- a/src/org/elixir_lang/mix/DepGatherer.kt
+++ b/src/org/elixir_lang/mix/DepGatherer.kt
@@ -22,6 +22,15 @@ import org.elixir_lang.util.AccumulatorContinue
  * @param isDependency whether the `mix.exs` being visited belongs to a dependency; see [Dep.from].
  */
 class DepGatherer(private val isDependency: Boolean = false) : DepGatherer() {
+    /**
+     * `Mix.Project.deps_path/1` reads `:deps_path` and expands it, and `Mix.Dep.in_dependency`
+     * pushes the result down to every dependency already absolute, so there is one `deps` directory
+     * per project tree and the top-level project owns it. `mix new --umbrella` therefore writes
+     * `deps_path: "../../deps"` into each app. Taken verbatim here; the caller resolves it.
+     */
+    override var depsPath: String? = null
+        private set
+
     override fun visitFile(file: PsiFile) {
         // Caller (Resolution.packagePsiFileToDepSet) already holds a read lock via runReadAction { ... }.
         // A nested runReadAction here is redundant. Protect from inadvertent calls with
@@ -37,6 +46,8 @@ class DepGatherer(private val isDependency: Boolean = false) : DepGatherer() {
     override fun visitElement(element: PsiElement) {
         if (element is Call && Module.`is`(element)) {
             val childCalls = element.macroChildCalls()
+
+            childCalls.projectKeywordList()?.depsPath()?.let { depsPath = it }
 
             childCalls
                     .foldDepsDefinersWhile(listOf<Dep>()) { depsDefiner, acc ->
@@ -81,6 +92,21 @@ private fun <R> Array<Call>.foldDepsDefinersWhile(
 
     return final
 }
+
+private fun Array<Call>.projectKeywordList(): QuotableKeywordList? {
+    for (call in this) {
+        ProgressManager.checkCanceled()
+
+        if (isDefiningProject(call)) {
+            call.lastKeywordList()?.let { return it }
+        }
+    }
+
+    return null
+}
+
+private fun QuotableKeywordList.depsPath(): String? =
+    (keywordValue("deps_path")?.stripAccessExpression() as? ElixirLine)?.body?.text
 
 private fun Array<Call>.depsNameArity(): NameArity? {
     var nameArity: NameArity? = null

--- a/src/org/elixir_lang/mix/Deps.kt
+++ b/src/org/elixir_lang/mix/Deps.kt
@@ -13,16 +13,16 @@ import org.elixir_lang.psi.impl.childExpressions
 import org.elixir_lang.psi.impl.stripAccessExpression
 
 object Deps {
-    fun from(depsListElement: PsiElement): Sequence<Dep> =
+    fun from(depsListElement: PsiElement, isDependency: Boolean): Sequence<Dep> =
             when (depsListElement) {
-                is ElixirTuple -> fromTuple(depsListElement)
-                is Call -> fromCall(depsListElement)
+                is ElixirTuple -> fromTuple(depsListElement, isDependency)
+                is Call -> fromCall(depsListElement, isDependency)
                 else -> emptySequence()
             }
 
 
     // `ecto_dep()` in `ecto_sql` `deps`
-    private fun fromCall(depsListElement: Call): Sequence<Dep> =
+    private fun fromCall(depsListElement: Call, isDependency: Boolean): Sequence<Dep> =
             depsListElement
                     .reference?.let { it as PsiPolyVariantReference }
                     ?.multiResolve(false)
@@ -31,36 +31,36 @@ object Deps {
                     ?.mapNotNull(ResolveResult::getElement)
                     ?.filterIsInstance<Call>()
                     ?.filter { CallDefinitionClause.`is`(it) }
-                    ?.flatMap { fromCallDefinitionClause(it) }
+                    ?.flatMap { fromCallDefinitionClause(it, isDependency) }
                     .orEmpty()
 
-    private fun fromCallDefinitionClause(callDefinitionClause: Call): Sequence<Dep> =
+    private fun fromCallDefinitionClause(callDefinitionClause: Call, isDependency: Boolean): Sequence<Dep> =
             callDefinitionClause
                     .stabBodyChildExpressions()
-                    ?.flatMap { fromChildExpression(it) }
+                    ?.flatMap { fromChildExpression(it, isDependency) }
                     ?: emptySequence()
 
-    private tailrec fun fromChildExpression(childExpression: PsiElement): Sequence<Dep> =
+    private tailrec fun fromChildExpression(childExpression: PsiElement, isDependency: Boolean): Sequence<Dep> =
             when (childExpression) {
-                is Call -> fromChildExpression(childExpression)
-                is ElixirAccessExpression -> fromChildExpression(childExpression.stripAccessExpression())
-                is ElixirTuple -> fromTuple(childExpression)
+                is Call -> fromChildExpression(childExpression, isDependency)
+                is ElixirAccessExpression -> fromChildExpression(childExpression.stripAccessExpression(), isDependency)
+                is ElixirTuple -> fromTuple(childExpression, isDependency)
                 else -> {
                     emptySequence()
                 }
             }
 
-    private fun fromChildExpression(childExpression: Call): Sequence<Dep> =
+    private fun fromChildExpression(childExpression: Call, isDependency: Boolean): Sequence<Dep> =
         if (childExpression.isCalling(KERNEL, "if")) {
-            fromIf(childExpression)
+            fromIf(childExpression, isDependency)
         } else {
             emptySequence()
         }
 
-    private fun fromTuple(tuple: ElixirTuple): Sequence<Dep> =
-            Dep.from(tuple)?.let { sequenceOf(it) }.orEmpty()
+    private fun fromTuple(tuple: ElixirTuple, isDependency: Boolean): Sequence<Dep> =
+            Dep.from(tuple, isDependency)?.let { sequenceOf(it) }.orEmpty()
 
-    private fun fromIf(`if`: Call): Sequence<Dep> {
+    private fun fromIf(`if`: Call, isDependency: Boolean): Sequence<Dep> {
         val branchStabSequences = `if`.doBlock?.let { doBlock ->
             val trueStab = doBlock.stab
             val falseStab = doBlock
@@ -73,6 +73,6 @@ object Deps {
 
         return branchStabSequences
                 .flatMap { stab -> stab.stabBody?.childExpressions().orEmpty() }
-                .flatMap { fromChildExpression(it) }
+                .flatMap { fromChildExpression(it, isDependency) }
     }
 }

--- a/src/org/elixir_lang/mix/PackageManager.kt
+++ b/src/org/elixir_lang/mix/PackageManager.kt
@@ -21,6 +21,9 @@ class PackageManager : org.elixir_lang.PackageManager {
     override val fileName: String = org.elixir_lang.mix.Project.MIX_EXS
     override fun depGatherer(): DepGatherer = org.elixir_lang.mix.DepGatherer()
 
+    override fun depGatherer(isDependency: Boolean): DepGatherer =
+        org.elixir_lang.mix.DepGatherer(isDependency)
+
     override fun depsStatus(project: Project, packageVirtualFile: VirtualFile, sdk: Sdk?): DepsStatusResult {
         if (sdk == null) {
             return DepsStatusResult.Error("No Elixir SDK configured for Mix")

--- a/src/org/elixir_lang/mix/sync/MixDepsSyncService.kt
+++ b/src/org/elixir_lang/mix/sync/MixDepsSyncService.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.elixir_lang.mix.library.CONSOLIDATED_LIBRARY_SUFFIX
 import org.elixir_lang.mix.sync.MixDepsSyncService.Companion.LOG
+import org.elixir_lang.util.awaitJpsProjectLoaded
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -77,6 +78,15 @@ class MixDepsSyncService(private val project: Project, cs: CoroutineScope) {
             syncFlow
                 .debounce(DEBOUNCE_MS.milliseconds)
                 .collect {
+                    // The `DelayedProjectSynchronizer` applies the on-disk `.iml` files after the
+                    // workspace model is restored from cache (5-13s on WSL), and anything committed
+                    // before it lands is silently overwritten - a sync that reports success and
+                    // leaves nothing behind. Sync Dependency Libraries is `isDumbAware`, so a user
+                    // can invoke it inside that window, which is exactly when libraries look
+                    // wrong enough to reach for it. Gating the one collector covers every producer.
+                    awaitJpsProjectLoaded(project)
+                    if (project.isDisposed) return@collect
+
                     supervisorScope {
                         val drainAttempt = async { drain() }
 

--- a/src/org/elixir_lang/mix/sync/MixDepsSyncService.kt
+++ b/src/org/elixir_lang/mix/sync/MixDepsSyncService.kt
@@ -1,10 +1,13 @@
 package org.elixir_lang.mix.sync
 
 import com.google.common.annotations.VisibleForTesting
+import com.intellij.ide.SaveAndSyncHandler
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.platform.ide.progress.withBackgroundProgress
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
@@ -167,6 +170,7 @@ class MixDepsSyncService(private val project: Project, cs: CoroutineScope) {
                 }
             }
 
+
             val totalMs = (System.nanoTime() - drainStartNs) / 1_000_000
             LOG.debug(
                 "MixDepsSyncService: drain complete - ${requests.size} request(s) in ${totalMs}ms " +
@@ -215,39 +219,77 @@ class MixDepsSyncService(private val project: Project, cs: CoroutineScope) {
 }
 
 /**
+ * Reduces a content-root URL to the scope token [scopedDepLibraryName] embeds in a library name.
+ *
+ * The token is made project-relative because the library name reaches version control three ways -
+ * the `name` in `.idea/libraries`, the `name` on each referencing `<orderEntry>`, and the library
+ * file's own name, which the platform derives from it - so an absolute URL stops one `.idea` being
+ * shared between clones. `$PROJECT_DIR$` cannot do this: the macro only collapses a path at the
+ * start of a value, and the file name is derived before serialization anyway.
+ *
+ * Pure string manipulation, so it is safe under a read lock.
+ *
+ * @return the path relative to the project base directory (`"."`, `"apps/child"`, `"../sibling"`),
+ *   or [contentRootUrl] unchanged when no relative path exists - no base directory, or another
+ *   drive or mount, where the dep genuinely is machine-specific.
+ */
+internal fun contentRootToken(project: Project, contentRootUrl: String): String {
+    // The "no owning root known" fallback, which must stay distinct from the project root's ".".
+    if (contentRootUrl.isEmpty()) return ""
+    val basePath = project.basePath ?: return contentRootUrl
+    return contentRootToken(FileUtil.toSystemIndependentName(basePath), contentRootUrl)
+}
+
+/**
+ * [contentRootToken] against a base path already read and normalised by the caller.
+ *
+ * A plan builder resolves a token per dep, nearly always for the same handful of roots, so hoisting
+ * the base path keeps a `Path`-to-`String` conversion and a separator scan out of that loop.
+ */
+internal fun contentRootToken(systemIndependentBasePath: String, contentRootUrl: String): String {
+    if (contentRootUrl.isEmpty()) return ""
+    val rootPath = VirtualFileManager.extractPath(contentRootUrl)
+    return FileUtil.getRelativePath(
+        systemIndependentBasePath,
+        FileUtil.toSystemIndependentName(rootPath),
+        '/',
+    ) ?: contentRootUrl
+}
+
+/**
  * Generates a deterministic, cross-platform, root-scoped library name for a Mix dep.
  *
- * The name is derived from [contentRootUrl] (a VirtualFile URL, always forward-slash) and
- * [depName]. Two content roots that each declare a dep named "phoenix" produce two distinct
- * library names, solving the cross-contamination between content roots that share the same dep name.
+ * The name is derived from [contentRootToken] and [depName]. Two content roots that each declare a
+ * dep named "phoenix" produce two distinct library names, solving the cross-contamination between
+ * content roots that share the same dep name.
  *
  * **This is the single canonical naming helper - all production and test call sites MUST use it
  * rather than inlining string formats.**
  *
- * @param contentRootUrl  The VirtualFile URL of the content root that owns the dep (e.g.
- *   `"file:///project/my_app"`). Already forward-slash from VirtualFile.url; no normalisation
- *   needed.
+ * @param contentRootToken  The scope token identifying the content root that owns the dep, as
+ *   produced by [contentRootToken] - normally project-relative (e.g. `"apps/child"`), falling back
+ *   to an absolute VirtualFile URL where no relative path exists.
  * @param depName  The Mix application/dep name (e.g. `"phoenix"`).
- * @return A scoped library name such as `"phoenix [file:///project/my_app]"`.
+ * @return A scoped library name such as `"phoenix [apps/child]"`.
  */
 @VisibleForTesting
-internal fun scopedDepLibraryName(contentRootUrl: String, depName: String): String =
-    "$depName [$contentRootUrl]"
+internal fun scopedDepLibraryName(contentRootToken: String, depName: String): String =
+    "$depName [$contentRootToken]"
 
 /**
- * Inverse of [scopedDepLibraryName]: extracts the embedded content-root URL from a root-scoped
- * library name, or returns null when [libraryName] does not have the `"<dep> [<url>]"` shape
- * (legacy unscoped names, consolidated libraries, user-created libraries).
+ * Inverse of [scopedDepLibraryName]: extracts the embedded scope token from a root-scoped library
+ * name, or returns null when [libraryName] does not have the `"<dep> [<token>]"` shape (legacy
+ * unscoped names, consolidated libraries, user-created libraries).
  *
  * Used by stale-entry pruning to decide whether an invalid library order entry references a
  * content root that is no longer part of the project.
  */
 @VisibleForTesting
-internal fun scopedLibraryNameContentRootUrl(libraryName: String): String? {
+internal fun scopedLibraryNameToken(libraryName: String): String? {
     if (!libraryName.endsWith("]")) return null
     // First occurrence, not last: dep names are Mix app atoms and can never contain " [", but
-    // the content-root URL may (a directory named "work [old]" is legal on every OS).  Matching
-    // the last occurrence would truncate such URLs and misclassify the entry as stale.
+    // the content-root token may (a directory named "work [old]" is legal on every OS).  Matching
+    // the last occurrence would truncate such tokens and misclassify the entry as stale.
     val markerIndex = libraryName.indexOf(" [")
     if (markerIndex <= 0) return null
     return libraryName.substring(markerIndex + 2, libraryName.length - 1)
@@ -262,13 +304,22 @@ internal fun scopedLibraryNameContentRootUrl(libraryName: String): String? {
 
 internal data class DeleteAllPlan(val depsUrl: String)
 
-internal data class DeleteOnePlan(val depName: String, val contentRootUrl: String?) {
+internal data class DeleteOnePlan(
+    val depName: String,
+    val contentRootUrl: String?,
+    /** [contentRootUrl] reduced by [contentRootToken]; null exactly when [contentRootUrl] is. */
+    val contentRootToken: String?,
+) {
     /**
-     * The library name to delete: scoped if [contentRootUrl] is known, otherwise the legacy
+     * The library name to delete: scoped if the owning content root is known, otherwise the legacy
      * unscoped dep name (for backwards-compatible deletion of previous version libraries).
      */
     val libraryName: String
-        get() = if (contentRootUrl != null) scopedDepLibraryName(contentRootUrl, depName) else depName
+        get() = if (contentRootToken != null) scopedDepLibraryName(contentRootToken, depName) else depName
+
+    /** The absolute-URL-scoped name used before tokens went relative, so a delete still finds it. */
+    val previousLibraryName: String?
+        get() = contentRootUrl?.let { scopedDepLibraryName(it, depName) }?.takeIf { it != libraryName }
 }
 
 internal data class ExcludeFolderPlan(
@@ -277,8 +328,14 @@ internal data class ExcludeFolderPlan(
 )
 
 internal data class LibraryRootsPlan(
-    /** The URL of the content root under which this dep lives (e.g. `file:///project/my_app`). */
+    /**
+     * The URL of the content root under which this dep lives (e.g. `file:///project/my_app`).
+     * Stays absolute because the umbrella-sharing fallback in `buildModuleDepsPlan` matches it
+     * against a module's own content-root URLs; naming uses [contentRootToken] instead.
+     */
     val contentRootUrl: String,
+    /** [contentRootUrl] reduced by [contentRootToken] - the form that appears in [libraryName]. */
+    val contentRootToken: String,
     val depName: String,
     val classRootUrls: List<String>,
     val sourceRootUrls: List<String>,
@@ -289,7 +346,15 @@ internal data class LibraryRootsPlan(
      * Two content roots with the same dep name produce distinct [libraryName] values,
      * preventing cross-contamination between unrelated projects.
      */
-    val libraryName: String get() = scopedDepLibraryName(contentRootUrl, depName)
+    val libraryName: String get() = scopedDepLibraryName(contentRootToken, depName)
+
+    /**
+     * The absolute-URL-scoped name used before tokens went relative, or null when unchanged.
+     * Computed from [contentRootUrl] rather than detected from [libraryName]: old and new names
+     * share the same `"<dep> [<token>]"` shape, so no format check could tell them apart.
+     */
+    val previousLibraryName: String?
+        get() = scopedDepLibraryName(contentRootUrl, depName).takeIf { it != libraryName }
 }
 
 internal data class ModuleDepsPlan(

--- a/src/org/elixir_lang/mix/sync/MixDepsSyncService.kt
+++ b/src/org/elixir_lang/mix/sync/MixDepsSyncService.kt
@@ -180,6 +180,16 @@ class MixDepsSyncService(private val project: Project, cs: CoroutineScope) {
                 }
             }
 
+            // The platform only flushes project settings at its own save points - frame
+            // deactivation, periodic autosave, project close - so a drain that runs in the
+            // background and is never followed by one leaves the rewritten .iml and
+            // .idea/libraries unwritten, and an IDE killed before the next save point loses them.
+            if (applyStats.librariesChanged > 0 || applyStats.modulesChanged > 0) {
+                // forceSavingAllSettings, because the default saves only components that report
+                // themselves changed and the module/library edits below do not, so the rewritten
+                // .iml and .idea/libraries were left on disk as they were.
+                SaveAndSyncHandler.getInstance().scheduleProjectSave(project, forceSavingAllSettings = true)
+            }
 
             val totalMs = (System.nanoTime() - drainStartNs) / 1_000_000
             LOG.debug(

--- a/src/org/elixir_lang/mix/sync/MixLibraryReconcileStartupActivity.kt
+++ b/src/org/elixir_lang/mix/sync/MixLibraryReconcileStartupActivity.kt
@@ -1,0 +1,37 @@
+package org.elixir_lang.mix.sync
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import org.elixir_lang.util.awaitJpsProjectLoaded
+
+/**
+ * Re-syncs Mix libraries at startup, but only when they no longer describe what is on disk.
+ *
+ * An already-configured project enqueues nothing when it opens, so changes made while the IDE was
+ * closed - a deleted `deps/` above all - would otherwise never be noticed. Escalating through
+ * [MixLibraryReconciler] rather than always syncing keeps the usual open free of the full
+ * deps/`_build` scan.
+ *
+ * Waits for the JPS model first. The IDE loads the workspace model from a binary cache at startup
+ * and only afterwards applies the real `.iml` state over it, so both halves of this would otherwise
+ * be wrong: the check would read cached state, and any resulting sync would be silently discarded
+ * when the on-disk model landed on top of it.
+ */
+class MixLibraryReconcileStartupActivity : ProjectActivity, DumbAware {
+    override suspend fun execute(project: Project) {
+        awaitJpsProjectLoaded(project)
+        if (project.isDisposed) return
+
+        if (MixLibraryReconciler.needsResync(project)) {
+            LOG.debug("Mix libraries disagree with the project's content roots; requesting a full sync")
+            project.service<MixDepsSyncService>().enqueue(SyncRequest.All)
+        }
+    }
+
+    private companion object {
+        private val LOG = logger<MixLibraryReconcileStartupActivity>()
+    }
+}

--- a/src/org/elixir_lang/mix/sync/MixLibraryReconciler.kt
+++ b/src/org/elixir_lang/mix/sync/MixLibraryReconciler.kt
@@ -1,0 +1,66 @@
+package org.elixir_lang.mix.sync
+
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.roots.impl.libraries.LibraryEx
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import org.elixir_lang.mix.library.Kind
+
+/**
+ * Decides whether the Mix libraries a project was left with still describe what is on disk, and asks
+ * for a full re-sync only when they do not.
+ *
+ * Nothing re-syncs an already-configured project at startup, and the service is otherwise driven
+ * purely by VFS events - so a `deps/` directory removed while the IDE was closed leaves libraries
+ * pointing at nothing, with order entries that stay *valid* (the library object still exists) and are
+ * therefore invisible to stale-entry pruning.
+ *
+ * Answering it by simply syncing everything would undo the pipeline's main cost saving: a full sync
+ * canonicalises `_build/<env>/lib/<dep>/ebin` per dep per build environment, which is real
+ * filesystem I/O, and in the steady state the diff that follows emits no write ops at all. This check
+ * reads only library state already held in memory, so the common case - nothing wrong - costs no
+ * directory traversal and no symlink resolution.
+ */
+internal object MixLibraryReconciler {
+
+    /**
+     * Whether [project]'s Mix libraries disagree with the project's current content roots.
+     *
+     * Reports true when a Mix-Kind library has a root the VFS cannot resolve, or carries a scope
+     * token naming a content root the project no longer has - which also covers names written before
+     * scope tokens became project-relative, so those migrate on the next open rather than lazily.
+     *
+     * Accuracy is bounded by the VFS: a deletion the refresh has not yet observed still reads as
+     * valid, so this is a cheap trigger rather than a guarantee.
+     */
+    suspend fun needsResync(project: Project): Boolean = readAction {
+        if (project.isDisposed) return@readAction false
+
+        // Only the form the plugin writes today counts as current - the same test the write plan
+        // applies. Accepting an older form here would make a project whose libraries are entirely
+        // in that form look healthy, which is precisely the project that needs the re-sync.
+        val currentTokens = ProjectRootManager.getInstance(project).contentRoots
+            .mapTo(HashSet()) { contentRootToken(project, it.url) }
+
+        val mixLibraries = LibraryTablesRegistrar.getInstance().getLibraryTable(project).libraries
+            .filterIsInstance<LibraryEx>()
+            .filter { it.kind == Kind && !it.isDisposed }
+
+        val trigger = mixLibraries.firstOrNull { libraryEx ->
+            val danglingRoot = libraryEx.getInvalidRootUrls(OrderRootType.CLASSES).isNotEmpty() ||
+                libraryEx.getInvalidRootUrls(OrderRootType.SOURCES).isNotEmpty()
+
+            // A null token is an unscoped or consolidated name, neither of which this check owns.
+            val foreignScope = libraryEx.name
+                ?.let { scopedLibraryNameToken(it) }
+                ?.let { token -> token !in currentTokens }
+                ?: false
+
+            danglingRoot || foreignScope
+        }
+
+        trigger != null
+    }
+}

--- a/src/org/elixir_lang/mix/sync/SyncPlanBuilder.kt
+++ b/src/org/elixir_lang/mix/sync/SyncPlanBuilder.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
@@ -307,7 +308,9 @@ internal suspend fun buildSyncPlan(project: Project, requests: CoalescedRequests
 
     return SyncPlan(
         deleteAlls = requests.deleteAlls.map { DeleteAllPlan(it.depsUrl) },
-        deleteOnes = requests.deleteOnes.map { DeleteOnePlan(it.depName, it.contentRootUrl) },
+        deleteOnes = requests.deleteOnes.map {
+            DeleteOnePlan(it.depName, it.contentRootUrl, it.contentRootUrl?.let { url -> contentRootToken(project, url) })
+        },
         libraryPlans = libraryPlans,
         modulePlans = modulePlans,
         consolidatedPlans = consolidatedPlans,
@@ -567,13 +570,15 @@ internal suspend fun buildModuleDepsPlan(
     // run, so that the missingLibraryDeps path creates a placeholder library for it.
     val externalLibNames: Map<String, String> = externalLibraryPlans.associateBy({ it.depName }, { it.libraryName })
     val libraryDeps: Set<String> = readAction {
+        val basePath = project.basePath?.let { FileUtil.toSystemIndependentName(it) }
+        fun token(url: String) = basePath?.let { contentRootToken(it, url) } ?: url
         val mixExsRoots by lazy { contentRoots.filter { it.findFileByRelativePath("mix.exs") != null } }
         deps.filter { it.type == Dep.Type.LIBRARY }.mapTo(LinkedHashSet()) { dep ->
             val owningRoot = contentRoots.firstOrNull { root ->
                 root.findFileByRelativePath(dep.path)?.isValid == true
             }
             if (owningRoot != null) {
-                scopedDepLibraryName(owningRoot.url, dep.application)
+                scopedDepLibraryName(token(owningRoot.url), dep.application)
             } else {
                 externalLibNames[dep.application]
                     ?: requestedLibraryPlans
@@ -598,7 +603,9 @@ internal suspend fun buildModuleDepsPlan(
                         .maxByOrNull { it.contentRootUrl.length }
                         ?.libraryName
                     ?: scopedDepLibraryName(
-                        mixExsRoots.firstOrNull()?.url ?: contentRoots.firstOrNull()?.url ?: "",
+                        (mixExsRoots.firstOrNull()?.url ?: contentRoots.firstOrNull()?.url)
+                            ?.let { url -> token(url) }
+                            ?: "",
                         dep.application
                     )
             }
@@ -677,6 +684,8 @@ internal fun buildLibraryRootsPlansInCurrentContext(project: Project, deps: Coll
             .mapNotNull { it.findChild("_build") }
     }
 
+    val basePath = project.basePath?.let { FileUtil.toSystemIndependentName(it) }
+
     return deps
         .filter { it.isValid && it.isDirectory }
         .map { dep ->
@@ -727,6 +736,7 @@ internal fun buildLibraryRootsPlansInCurrentContext(project: Project, deps: Coll
 
             LibraryRootsPlan(
                 contentRootUrl = contentRootUrl,
+                contentRootToken = basePath?.let { contentRootToken(it, contentRootUrl) } ?: contentRootUrl,
                 depName = depName,
                 classRootUrls = classRoots.map { it.url }.distinct(),
                 sourceRootUrls = dep.children

--- a/src/org/elixir_lang/mix/sync/WritePlanApplicator.kt
+++ b/src/org/elixir_lang/mix/sync/WritePlanApplicator.kt
@@ -1,6 +1,7 @@
 package org.elixir_lang.mix.sync
 
 import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
@@ -9,6 +10,8 @@ import com.intellij.openapi.roots.libraries.Library
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.VfsUtilCore
 import org.elixir_lang.mix.library.Kind
+
+private val LOG = logger<ApplyStats>()
 
 /**
  * Counts of model objects changed during one [applyWritePlan] call.  Used for drain-complete
@@ -178,15 +181,24 @@ private fun applyModuleWriteOp(
     moduleManager: ModuleManager,
     libraryTable: com.intellij.openapi.roots.libraries.LibraryTable,
 ) {
-    // Stale-entry pruning - remove the invalid project-level entries scheduled by buildWritePlan.
-    // Re-check isValid at apply time: if a concurrent write action created the referenced library
-    // after the read-phase snapshot, the entry is no longer invalid and must be kept.
+    // Remove the entries scheduled by buildWritePlan.  Validity is deliberately not re-checked:
+    // these are removed because their scope token is not a current content root, which has nothing
+    // to do with whether the library still exists - and for entries left by an older naming scheme
+    // it usually does, so a validity guard here would silently drop every removal.
     if (op.removeStaleLibraryDeps.isNotEmpty()) {
+        var removed = 0
         for (entry in modifiableModel.orderEntries.filterIsInstance<LibraryOrderEntry>()) {
             ProgressManager.checkCanceled()
-            if (!entry.isValid && entry.libraryName in op.removeStaleLibraryDeps) {
+            if (entry.libraryName in op.removeStaleLibraryDeps) {
                 modifiableModel.removeOrderEntry(entry)
+                removed++
             }
+        }
+        if (LOG.isDebugEnabled) {
+            LOG.debug(
+                "applyWritePlan[${op.moduleName}]: removed $removed of " +
+                    "${op.removeStaleLibraryDeps.size} planned library entries"
+            )
         }
     }
 

--- a/src/org/elixir_lang/mix/sync/WritePlanBuilder.kt
+++ b/src/org/elixir_lang/mix/sync/WritePlanBuilder.kt
@@ -35,12 +35,12 @@ internal data class LibraryWriteOp(
  * contains names whose dep-module is absent or disposed at plan-build time.  [addLibraryDeps] and
  * [addInvalidLibraryDeps] follow the same convention for project libraries.
  *
- * [removeStaleLibraryDeps] is the single removal case the pipeline performs on existing entries:
- * INVALID project-level library entries whose root-scoped name embeds a content-root URL that is
- * no longer a project content root.  Such entries can never become valid again - no sync will
- * recreate a library scoped to a root that left the project (e.g. after the project moved on disk
- * or a WSL distro rename changed every file URL) - so they are permanently dead weight.  All other
- * existing entries are never removed by the sync pipeline.
+ * [removeStaleLibraryDeps] is project-level entries carrying the `"<dep> [<token>]"` shape this
+ * plugin writes - nothing else produces it - whose token is not a current content root.  Either the
+ * root left the project (it moved on disk, or a WSL distro rename changed every file URL), or the
+ * token names a current root in a scheme the plugin no longer writes, which is how an entry left by
+ * an older version is recognised as superseded.  An entry without that shape is never removed: it
+ * may be a user-created reference the sync has no claim over.
  */
 internal data class ModuleWriteOp(
     val moduleName: String,
@@ -146,14 +146,19 @@ private fun buildWritePlanInCurrentContext(project: Project, syncPlan: SyncPlan)
         ProgressManager.checkCanceled()
         // depsUrl is always "<contentRootUrl>/deps"; strip the suffix to derive scoped-name suffix.
         val contentRootUrl = deleteAll.depsUrl.removeSuffix("/deps")
-        val scopedSuffix = " [$contentRootUrl]"
+        // Both scope schemes: a project last synced by an older version names its libraries after
+        // the absolute URL, and matching only today's token would leave every one of them behind.
+        val scopedSuffixes = setOf(
+            " [${contentRootToken(project, contentRootUrl)}]",
+            " [$contentRootUrl]",
+        )
         // Append "/" so VfsUtilCore.isEqualOrAncestor is path-boundary-safe (Strategy 2 mirror).
         val depsPrefixUrl = if (deleteAll.depsUrl.endsWith("/")) deleteAll.depsUrl else "${deleteAll.depsUrl}/"
 
         for ((name, snap) in libSnap) {
             ProgressManager.checkCanceled()
             // Strategy 1: scoped-name + Kind (catches empty placeholders and class-only libs).
-            val matchesScoped = name.endsWith(scopedSuffix) && snap.isKind
+            val matchesScoped = snap.isKind && scopedSuffixes.any { name.endsWith(it) }
             // Strategy 2: source-root ancestor check (backwards-compat for legacy unscoped libs).
             val matchesSources = snap.sourceUrls.isNotEmpty() &&
                 snap.sourceUrls.all { VfsUtilCore.isEqualOrAncestor(depsPrefixUrl, it) }
@@ -179,6 +184,13 @@ private fun buildWritePlanInCurrentContext(project: Project, syncPlan: SyncPlan)
         // unscoped library (only if it is a Mix-Kind library to avoid touching user libraries).
         if (deleteOne.depName != deleteOne.libraryName && libSnap[deleteOne.depName]?.isKind == true) {
             librariesToRemove += deleteOne.depName
+        }
+        // And the absolute-URL-scoped name from before tokens went relative, so a delete still
+        // finds its target in a project last synced by an older plugin version.
+        deleteOne.previousLibraryName?.let { previousName ->
+            if (libSnap[previousName]?.isKind == true) {
+                librariesToRemove += previousName
+            }
         }
     }
 
@@ -252,6 +264,15 @@ private fun buildWritePlanInCurrentContext(project: Project, syncPlan: SyncPlan)
             val legacy = libSnap[plan.depName]
             if (legacy != null && legacy.isKind) {
                 legacyLibrariesToRemove += plan.depName
+            }
+        }
+
+        // Same cleanup one format later, for the absolute-URL-scoped name used before tokens went
+        // relative. Removing it invalidates its order entries, which stale-entry pruning then
+        // clears from the .iml.
+        plan.previousLibraryName?.let { previousName ->
+            if (libSnap[previousName]?.isKind == true) {
+                legacyLibrariesToRemove += previousName
             }
         }
     }
@@ -351,10 +372,12 @@ private fun buildWritePlanInCurrentContext(project: Project, syncPlan: SyncPlan)
         (libSnap.keys - allLibrariesToRemoveSet) + plannedLibraryNames + placeholderLibraries
 
     val moduleManager = ModuleManager.getInstance(project)
-    // Current content-root URLs, used to recognise stale root-scoped library entries: a scoped
-    // name embedding a URL outside this set references a root that left the project.
-    val projectContentRootUrls = ProjectRootManager.getInstance(project).contentRoots
-        .mapTo(HashSet()) { it.url }
+    // Current content-root scope tokens, used to recognise stale root-scoped library entries: a
+    // scoped name embedding a token outside this set references a root that left the project - or
+    // names the same root in a scheme the plugin no longer writes, which is how an entry left by
+    // an older version is recognised as superseded rather than current.
+    val projectContentRootTokens = ProjectRootManager.getInstance(project).contentRoots
+        .mapTo(HashSet()) { contentRootToken(project, it.url) }
     val moduleNames = (syncPlan.modulePlans.map { it.moduleName } +
         syncPlan.libraryPlans.flatMap { it.excludeFolders }.map { it.moduleName } +
         syncPlan.consolidatedPlans.mapNotNull { it.ownerModuleName })
@@ -443,15 +466,31 @@ private fun buildWritePlanInCurrentContext(project: Project, syncPlan: SyncPlan)
         // valid again - no sync will ever recreate a library scoped to a root that left the
         // project.  Entries scoped to a CURRENT content root are the deliberate placeholder
         // wiring for declared-but-unfetched deps and stay untouched, as do entries without
-        // the `name [url]` scoped-name shape (potentially user-created libraries).
-        val removeStaleLibraryDeps = rootManager.orderEntries
-            .filterIsInstance<LibraryOrderEntry>()
-            .filter { !it.isValid && it.libraryLevel == LibraryTablesRegistrar.PROJECT_LEVEL }
-            .mapNotNull { it.libraryName }
-            .filterTo(LinkedHashSet()) { name ->
-                scopedLibraryNameContentRootUrl(name)
-                    ?.let { embeddedUrl -> embeddedUrl !in projectContentRootUrls } == true
+        // the `name [token]` scoped-name shape (potentially user-created libraries).
+        // Only entries the plugin itself writes are ever removed, and the `"<dep> [<token>]"` shape
+        // is what identifies them - nothing else produces it, so a name without it may be a
+        // user-created reference and is left strictly alone.
+        //
+        // Of those, an entry is dead when its token is not a current content root: either the root
+        // left the project (it moved on disk, or a WSL distro rename changed every file URL), or it
+        // names a still-current root in a scheme the plugin has stopped writing, which is how the
+        // entries left by an older version are recognised. Validity does not come into it - the
+        // superseded ones are usually valid, since their libraries still exist.
+        val removeStaleLibraryDeps = LinkedHashSet<String>()
+
+        for (entry in rootManager.orderEntries.filterIsInstance<LibraryOrderEntry>()) {
+            ProgressManager.checkCanceled()
+            if (entry.libraryLevel != LibraryTablesRegistrar.PROJECT_LEVEL) continue
+            val name = entry.libraryName ?: continue
+            if (name in addLibraryDeps || name in addInvalidLibraryDeps) continue
+            if (modulePlan != null && name in modulePlan.libraryDeps) continue
+            if (consolidatedLibsByModule[moduleName].orEmpty().contains(name)) continue
+
+            if (scopedLibraryNameToken(name)?.let { it !in projectContentRootTokens } == true) {
+                removeStaleLibraryDeps += name
             }
+        }
+
 
         if (addModuleDeps.isNotEmpty() || addInvalidModuleDeps.isNotEmpty() ||
             addLibraryDeps.isNotEmpty() || addInvalidLibraryDeps.isNotEmpty() ||

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -46,6 +46,10 @@ class Resolution(
             val projectRootVirtualFiles = rootVirtualFiles.toHashSet()
             val rootVirtualFileToDepSet = mutableMapOf<VirtualFile, Set<Dep>>()
             val depToRootVirtualFile = mutableMapOf<Dep, VirtualFile?>()
+            // The deps directory each reached file resolves through. Deliberately not folded into
+            // projectRootVirtualFiles: that set also decides isDependency, so adding a dep root to
+            // it would stop Mix's only:/optional: filter applying to that dep's own deps.
+            val rootVirtualFileToDepsDirectory = mutableMapOf<VirtualFile, VirtualFile>()
 
             while (rootVirtualFileQueue.isNotEmpty() && !progressIndicator.isCanceled) {
                 ProgressManager.checkCanceled()
@@ -59,6 +63,14 @@ class Resolution(
                         isDependency = rootVirtualFile !in projectRootVirtualFiles,
                     )
 
+                    // `Mix.Project.in_project` applies the inherited `deps_path` as post-config, so
+                    // it overrides whatever the file itself declares: a dependency uses the deps
+                    // directory of the project that reached it, never one of its own.
+                    val depsDirectory = rootVirtualFileToDepsDirectory[rootVirtualFile]
+                        ?: declaredDepsPath?.let { rootVirtualFile.findFileByRelativePath(it) }
+                        ?: owningProjectRoot(rootVirtualFile, projectRootVirtualFiles)
+                            ?.findFileByRelativePath(MIX_DEPS_DIRECTORY_NAME)
+
                     for (dep in depSet) {
                         if (progressIndicator.isCanceled) {
                             break
@@ -70,20 +82,22 @@ class Resolution(
                         if (dep.type == Dep.Type.LIBRARY) {
                             if (!depToRootVirtualFile.contains(dep)) {
                                 val depRootVirtualFile =
-                                    depRootVirtualFile(
-                                        dep,
-                                        rootVirtualFile,
-                                        projectRootVirtualFiles,
-                                        declaredDepsPath
-                                    )
+                                    depRootVirtualFile(dep, rootVirtualFile, depsDirectory)
 
                                 depToRootVirtualFile[dep] = depRootVirtualFile
 
-                                if (depRootVirtualFile != null &&
-                                    !rootVirtualFileToDepSet.contains(depRootVirtualFile) &&
-                                    !rootVirtualFileQueue.contains(depRootVirtualFile)
-                                ) {
-                                    rootVirtualFileQueue.add(depRootVirtualFile)
+                                if (depRootVirtualFile != null) {
+                                    // Mix checks a dependency's own deps out beside it, so the
+                                    // directory that held this one holds everything it declares.
+                                    depsDirectory?.let {
+                                        rootVirtualFileToDepsDirectory.putIfAbsent(depRootVirtualFile, it)
+                                    }
+
+                                    if (!rootVirtualFileToDepSet.contains(depRootVirtualFile) &&
+                                        !rootVirtualFileQueue.contains(depRootVirtualFile)
+                                    ) {
+                                        rootVirtualFileQueue.add(depRootVirtualFile)
+                                    }
                                 }
                             }
                         }
@@ -116,21 +130,11 @@ class Resolution(
         private fun depRootVirtualFile(
             dep: Dep,
             declaringRootVirtualFile: VirtualFile,
-            projectRootVirtualFiles: Set<VirtualFile>,
-            declaredDepsPath: String?
+            depsDirectory: VirtualFile?
         ): VirtualFile? {
             if (dep.path.startsWith(MIX_DEPS_DIRECTORY_PREFIX)) {
-                val relativeToDepsDirectory = dep.path.removePrefix(MIX_DEPS_DIRECTORY_PREFIX)
-
-                // A declared `deps_path:` is the file saying outright where its deps live, so it
-                // beats anything inferred from the directory layout.
-                declaredDepsPath
-                    ?.let { declaringRootVirtualFile.findFileByRelativePath(it) }
-                    ?.findFileByRelativePath(relativeToDepsDirectory)
-                    ?.let { return it }
-
-                owningProjectRoot(declaringRootVirtualFile, projectRootVirtualFiles)
-                    ?.findFileByRelativePath(dep.path)
+                depsDirectory
+                    ?.findFileByRelativePath(dep.path.removePrefix(MIX_DEPS_DIRECTORY_PREFIX))
                     ?.let { return it }
             }
 
@@ -252,6 +256,7 @@ class Resolution(
     }
 }
 
+private const val MIX_DEPS_DIRECTORY_NAME = "deps"
 private const val MIX_DEPS_DIRECTORY_PREFIX = "deps/"
 private const val UMBRELLA_APPS_DIRECTORY_NAME = "apps"
 

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -36,6 +36,12 @@ class Resolution(
         ): Resolution {
             val rootVirtualFileQueue: Queue<VirtualFile> = ArrayDeque<VirtualFile>()
             rootVirtualFileQueue.addAll(rootVirtualFiles)
+            // Anything reached that was not handed in got here by following a Dep.Type.LIBRARY dep,
+            // so Mix would resolve its deps as a dependency's. Membership rather than dequeue order
+            // decides it, so a root reads the same however the queue is drained. Umbrella apps are
+            // handed in by the caller alongside the roots, and MODULE deps are never walked, so
+            // neither can be mistaken for a dependency.
+            val projectRootVirtualFiles = rootVirtualFiles.toHashSet()
             val rootVirtualFileToDepSet = mutableMapOf<VirtualFile, Set<Dep>>()
             val depToRootVirtualFile = mutableMapOf<Dep, VirtualFile?>()
 
@@ -44,7 +50,12 @@ class Resolution(
                 val rootVirtualFile = rootVirtualFileQueue.remove()
 
                 if (!rootVirtualFileToDepSet.containsKey(rootVirtualFile)) {
-                    val depSet = rootVirtualFileToDepSet(psiManager, progressIndicator, rootVirtualFile)
+                    val depSet = rootVirtualFileToDepSet(
+                        psiManager,
+                        progressIndicator,
+                        rootVirtualFile,
+                        isDependency = rootVirtualFile !in projectRootVirtualFiles,
+                    )
 
                     for (dep in depSet) {
                         if (progressIndicator.isCanceled) {
@@ -80,7 +91,8 @@ class Resolution(
         private suspend fun rootVirtualFileToDepSet(
             psiManager: PsiManager,
             progressIndicator: ProgressIndicator,
-            rootVirtualFile: VirtualFile
+            rootVirtualFile: VirtualFile,
+            isDependency: Boolean
         ): Set<Dep> {
             progressIndicator.text2 = "Finding package file under ${rootVirtualFile.path}"
             val packageManagerVirtualFile = virtualFile(rootVirtualFile)
@@ -88,7 +100,13 @@ class Resolution(
             return if (packageManagerVirtualFile != null) {
                 val (packageManager, packageVirtualFile) = packageManagerVirtualFile
 
-                packageVirtualFileToDepSet(psiManager, progressIndicator, packageManager, packageVirtualFile)
+                packageVirtualFileToDepSet(
+                    psiManager,
+                    progressIndicator,
+                    packageManager,
+                    packageVirtualFile,
+                    isDependency
+                )
             } else {
                 emptySet()
             }
@@ -98,7 +116,8 @@ class Resolution(
             psiManager: PsiManager,
             progressIndicator: ProgressIndicator,
             packageManager: PackageManager,
-            packageVirtualFile: VirtualFile
+            packageVirtualFile: VirtualFile,
+            isDependency: Boolean
         ): Set<Dep> {
             // WARA: acquires the read lock without blocking the EDT. If a write action preempts,
             // readAction restarts the lambda. IncorrectOperationException can occur when the
@@ -114,7 +133,7 @@ class Resolution(
             return if (packagePsiFile != null && !progressIndicator.isCanceled) {
                 progressIndicator.text2 = "Finding deps in ${packagePsiFile.virtualFile.path}"
 
-                packagePsiFileToDepSet(packageManager, packagePsiFile)
+                packagePsiFileToDepSet(packageManager, packagePsiFile, isDependency)
             } else {
                 emptySet()
             }
@@ -134,12 +153,16 @@ class Resolution(
          */
         private suspend fun packagePsiFileToDepSet(
             packageManager: PackageManager,
-            packagePsiFile: PsiFile
+            packagePsiFile: PsiFile,
+            isDependency: Boolean
         ): Set<Dep> =
             readAction {
-                getCachedValue(packagePsiFile, DEP_SET) {
+                // Two keys, because the dep set a file yields now depends on how the file was
+                // reached, while a CachedValue outlives the resolution that populated it: one
+                // module's run can hand in a root that another's reaches as a dependency.
+                getCachedValue(packagePsiFile, if (isDependency) DEPENDENCY_DEP_SET else PROJECT_DEP_SET) {
                     packageManager
-                        .depGatherer()
+                        .depGatherer(isDependency)
                         .apply { packagePsiFile.accept(this) }
                         .depSet.toSet()
                         .let { CachedValueProvider.Result.create(it, packagePsiFile) }
@@ -148,4 +171,5 @@ class Resolution(
     }
 }
 
-private val DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("DEP_SET")
+private val PROJECT_DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("PROJECT_DEP_SET")
+private val DEPENDENCY_DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("DEPENDENCY_DEP_SET")

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.readAction
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
@@ -67,7 +68,8 @@ class Resolution(
                            Module deps handle transitivity while Library deps don't */
                         if (dep.type == Dep.Type.LIBRARY) {
                             if (!depToRootVirtualFile.contains(dep)) {
-                                val depRootVirtualFile = dep.virtualFile(rootVirtualFile)
+                                val depRootVirtualFile =
+                                    depRootVirtualFile(dep, rootVirtualFile, projectRootVirtualFiles)
 
                                 depToRootVirtualFile[dep] = depRootVirtualFile
 
@@ -86,6 +88,67 @@ class Resolution(
             }
 
             return Resolution(rootVirtualFileToDepSet, depToRootVirtualFile)
+        }
+
+        /**
+         * The directory Mix would check [dep] out into.
+         *
+         * `Mix.Project.deps_config/1` hands every dependency the *top-level* project's `deps_path`,
+         * already expanded, so a hex or git dep declared by a dependency is checked out beside it
+         * under the project - `deps/<parent>/deps/<child>` is a directory no Mix configuration
+         * produces. Looking there ended the walk one level below every project root.
+         *
+         * An explicit `path:` dep is the exception and keeps the old base: `Mix.SCM.Path` expands it
+         * against the directory of whatever declared it, so `"../sibling"` inside a dependency
+         * really is relative to that dependency.
+         *
+         * The search is confined to the one project that owns the declaring file, so two content
+         * roots that both have `deps/<name>` cannot be confused for one another. The lookup stays on
+         * [VirtualFile.findFileByRelativePath] because a `deps/` path needs no upward traversal,
+         * leaving [Dep.virtualFile]'s refresh-based resolution for the paths that do.
+         */
+        private fun depRootVirtualFile(
+            dep: Dep,
+            declaringRootVirtualFile: VirtualFile,
+            projectRootVirtualFiles: Set<VirtualFile>
+        ): VirtualFile? {
+            val owningProjectRoot = if (dep.path.startsWith(MIX_DEPS_DIRECTORY_PREFIX)) {
+                owningProjectRoot(declaringRootVirtualFile, projectRootVirtualFiles)
+            } else {
+                null
+            }
+
+            return owningProjectRoot?.findFileByRelativePath(dep.path)
+                ?: dep.virtualFile(declaringRootVirtualFile)
+        }
+
+        /**
+         * The content root of the Mix project whose `deps` directory Mix would install into.
+         *
+         * That is the innermost root containing [declaringRootVirtualFile], except for an umbrella
+         * app: an app shares the umbrella's `deps`, `_build` and lock file and never has its own, so
+         * a `deps` directory beside its `mix.exs` is debris from before it joined the umbrella.
+         * Every other content root is a project in its own right and keeps its own `deps`, including
+         * one that merely happens to sit inside another.
+         */
+        private fun owningProjectRoot(
+            declaringRootVirtualFile: VirtualFile,
+            projectRootVirtualFiles: Set<VirtualFile>
+        ): VirtualFile? {
+            var root = projectRootVirtualFiles
+                .filter { VfsUtilCore.isAncestor(it, declaringRootVirtualFile, false) }
+                .maxByOrNull { it.path.length }
+                ?: return null
+
+            while (true) {
+                val umbrella = root.parent
+                    ?.takeIf { it.name == UMBRELLA_APPS_DIRECTORY_NAME }
+                    ?.parent
+                    ?.takeIf { it in projectRootVirtualFiles }
+                    ?: return root
+
+                root = umbrella
+            }
         }
 
         private suspend fun rootVirtualFileToDepSet(
@@ -170,6 +233,9 @@ class Resolution(
             }
     }
 }
+
+private const val MIX_DEPS_DIRECTORY_PREFIX = "deps/"
+private const val UMBRELLA_APPS_DIRECTORY_NAME = "apps"
 
 private val PROJECT_DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("PROJECT_DEP_SET")
 private val DEPENDENCY_DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("DEPENDENCY_DEP_SET")

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.util.CachedValuesManager.getCachedValue
 import com.intellij.util.IncorrectOperationException
 import org.elixir_lang.PackageManager
 import org.elixir_lang.mix.Dep
+import org.elixir_lang.mix.Project.MIX_EXS
 import org.elixir_lang.package_manager.virtualFile
 import java.util.*
 
@@ -51,7 +52,7 @@ class Resolution(
                 val rootVirtualFile = rootVirtualFileQueue.remove()
 
                 if (!rootVirtualFileToDepSet.containsKey(rootVirtualFile)) {
-                    val depSet = rootVirtualFileToDepSet(
+                    val (depSet, declaredDepsPath) = rootVirtualFileToPackageDeps(
                         psiManager,
                         progressIndicator,
                         rootVirtualFile,
@@ -69,7 +70,12 @@ class Resolution(
                         if (dep.type == Dep.Type.LIBRARY) {
                             if (!depToRootVirtualFile.contains(dep)) {
                                 val depRootVirtualFile =
-                                    depRootVirtualFile(dep, rootVirtualFile, projectRootVirtualFiles)
+                                    depRootVirtualFile(
+                                        dep,
+                                        rootVirtualFile,
+                                        projectRootVirtualFiles,
+                                        declaredDepsPath
+                                    )
 
                                 depToRootVirtualFile[dep] = depRootVirtualFile
 
@@ -110,16 +116,25 @@ class Resolution(
         private fun depRootVirtualFile(
             dep: Dep,
             declaringRootVirtualFile: VirtualFile,
-            projectRootVirtualFiles: Set<VirtualFile>
+            projectRootVirtualFiles: Set<VirtualFile>,
+            declaredDepsPath: String?
         ): VirtualFile? {
-            val owningProjectRoot = if (dep.path.startsWith(MIX_DEPS_DIRECTORY_PREFIX)) {
+            if (dep.path.startsWith(MIX_DEPS_DIRECTORY_PREFIX)) {
+                val relativeToDepsDirectory = dep.path.removePrefix(MIX_DEPS_DIRECTORY_PREFIX)
+
+                // A declared `deps_path:` is the file saying outright where its deps live, so it
+                // beats anything inferred from the directory layout.
+                declaredDepsPath
+                    ?.let { declaringRootVirtualFile.findFileByRelativePath(it) }
+                    ?.findFileByRelativePath(relativeToDepsDirectory)
+                    ?.let { return it }
+
                 owningProjectRoot(declaringRootVirtualFile, projectRootVirtualFiles)
-            } else {
-                null
+                    ?.findFileByRelativePath(dep.path)
+                    ?.let { return it }
             }
 
-            return owningProjectRoot?.findFileByRelativePath(dep.path)
-                ?: dep.virtualFile(declaringRootVirtualFile)
+            return dep.virtualFile(declaringRootVirtualFile)
         }
 
         /**
@@ -141,29 +156,32 @@ class Resolution(
                 ?: return null
 
             while (true) {
+                // An umbrella imported one module per app hands in only `apps/<app>`, so requiring
+                // the umbrella root to be among them would strand every such app. A `mix.exs` above
+                // an `apps` directory is an umbrella whether or not the caller named it.
                 val umbrella = root.parent
                     ?.takeIf { it.name == UMBRELLA_APPS_DIRECTORY_NAME }
                     ?.parent
-                    ?.takeIf { it in projectRootVirtualFiles }
+                    ?.takeIf { it in projectRootVirtualFiles || it.findChild(MIX_EXS) != null }
                     ?: return root
 
                 root = umbrella
             }
         }
 
-        private suspend fun rootVirtualFileToDepSet(
+        private suspend fun rootVirtualFileToPackageDeps(
             psiManager: PsiManager,
             progressIndicator: ProgressIndicator,
             rootVirtualFile: VirtualFile,
             isDependency: Boolean
-        ): Set<Dep> {
+        ): PackageDeps {
             progressIndicator.text2 = "Finding package file under ${rootVirtualFile.path}"
             val packageManagerVirtualFile = virtualFile(rootVirtualFile)
 
             return if (packageManagerVirtualFile != null) {
                 val (packageManager, packageVirtualFile) = packageManagerVirtualFile
 
-                packageVirtualFileToDepSet(
+                packageVirtualFileToPackageDeps(
                     psiManager,
                     progressIndicator,
                     packageManager,
@@ -171,17 +189,17 @@ class Resolution(
                     isDependency
                 )
             } else {
-                emptySet()
+                PackageDeps.EMPTY
             }
         }
 
-        private suspend fun packageVirtualFileToDepSet(
+        private suspend fun packageVirtualFileToPackageDeps(
             psiManager: PsiManager,
             progressIndicator: ProgressIndicator,
             packageManager: PackageManager,
             packageVirtualFile: VirtualFile,
             isDependency: Boolean
-        ): Set<Dep> {
+        ): PackageDeps {
             // WARA: acquires the read lock without blocking the EDT. If a write action preempts,
             // readAction restarts the lambda. IncorrectOperationException can occur when the
             // VirtualFile is no longer valid (e.g., deleted while we waited for the lock).
@@ -196,9 +214,9 @@ class Resolution(
             return if (packagePsiFile != null && !progressIndicator.isCanceled) {
                 progressIndicator.text2 = "Finding deps in ${packagePsiFile.virtualFile.path}"
 
-                packagePsiFileToDepSet(packageManager, packagePsiFile, isDependency)
+                packagePsiFileToPackageDeps(packageManager, packagePsiFile, isDependency)
             } else {
-                emptySet()
+                PackageDeps.EMPTY
             }
         }
 
@@ -214,11 +232,11 @@ class Resolution(
          * The [org.elixir_lang.package_manager.DepGatherer] is constructed freshly per WARA attempt (via [PackageManager.depGatherer])
          * so partial results from a cancelled attempt are never reused.
          */
-        private suspend fun packagePsiFileToDepSet(
+        private suspend fun packagePsiFileToPackageDeps(
             packageManager: PackageManager,
             packagePsiFile: PsiFile,
             isDependency: Boolean
-        ): Set<Dep> =
+        ): PackageDeps =
             readAction {
                 // Two keys, because the dep set a file yields now depends on how the file was
                 // reached, while a CachedValue outlives the resolution that populated it: one
@@ -227,7 +245,7 @@ class Resolution(
                     packageManager
                         .depGatherer(isDependency)
                         .apply { packagePsiFile.accept(this) }
-                        .depSet.toSet()
+                        .let { PackageDeps(it.depSet.toSet(), it.depsPath) }
                         .let { CachedValueProvider.Result.create(it, packagePsiFile) }
                 }
             }
@@ -237,5 +255,17 @@ class Resolution(
 private const val MIX_DEPS_DIRECTORY_PREFIX = "deps/"
 private const val UMBRELLA_APPS_DIRECTORY_NAME = "apps"
 
-private val PROJECT_DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("PROJECT_DEP_SET")
-private val DEPENDENCY_DEP_SET: Key<CachedValue<Set<Dep>>> = Key.create<CachedValue<Set<Dep>>>("DEPENDENCY_DEP_SET")
+/**
+ * What one package file yields: the deps it declares, and the `deps_path:` it declares them to live
+ * under, if any.
+ */
+private data class PackageDeps(val depSet: Set<Dep>, val depsPath: String?) {
+    companion object {
+        val EMPTY = PackageDeps(emptySet(), null)
+    }
+}
+
+private val PROJECT_DEP_SET: Key<CachedValue<PackageDeps>> =
+    Key.create<CachedValue<PackageDeps>>("PROJECT_DEP_SET")
+private val DEPENDENCY_DEP_SET: Key<CachedValue<PackageDeps>> =
+    Key.create<CachedValue<PackageDeps>>("DEPENDENCY_DEP_SET")

--- a/src/org/elixir_lang/mix/watcher/Resolution.kt
+++ b/src/org/elixir_lang/mix/watcher/Resolution.kt
@@ -38,17 +38,17 @@ class Resolution(
         ): Resolution {
             val rootVirtualFileQueue: Queue<VirtualFile> = ArrayDeque<VirtualFile>()
             rootVirtualFileQueue.addAll(rootVirtualFiles)
-            // Anything reached that was not handed in got here by following a Dep.Type.LIBRARY dep,
-            // so Mix would resolve its deps as a dependency's. Membership rather than dequeue order
-            // decides it, so a root reads the same however the queue is drained. Umbrella apps are
-            // handed in by the caller alongside the roots, and MODULE deps are never walked, so
-            // neither can be mistaken for a dependency.
+            // Anything reached by following a Dep.Type.LIBRARY dep is a dependency, and Mix resolves
+            // its deps as one. A MODULE dep names an app of the same umbrella, which is a project
+            // Mix is building rather than one it fetched, so reaching a root that way joins this set
+            // instead. Membership rather than dequeue order decides it, so a root reads the same
+            // however the queue is drained.
             val projectRootVirtualFiles = rootVirtualFiles.toHashSet()
             val rootVirtualFileToDepSet = mutableMapOf<VirtualFile, Set<Dep>>()
             val depToRootVirtualFile = mutableMapOf<Dep, VirtualFile?>()
             // The deps directory each reached file resolves through. Deliberately not folded into
-            // projectRootVirtualFiles: that set also decides isDependency, so adding a dep root to
-            // it would stop Mix's only:/optional: filter applying to that dep's own deps.
+            // projectRootVirtualFiles: that set also decides isDependency, so adding a library dep's
+            // root to it would stop Mix's only:/optional: filter applying to that dep's own deps.
             val rootVirtualFileToDepsDirectory = mutableMapOf<VirtualFile, VirtualFile>()
 
             while (rootVirtualFileQueue.isNotEmpty() && !progressIndicator.isCanceled) {
@@ -63,13 +63,14 @@ class Resolution(
                         isDependency = rootVirtualFile !in projectRootVirtualFiles,
                     )
 
+                    val owningProjectRoot = owningProjectRoot(rootVirtualFile, projectRootVirtualFiles)
+
                     // `Mix.Project.in_project` applies the inherited `deps_path` as post-config, so
                     // it overrides whatever the file itself declares: a dependency uses the deps
                     // directory of the project that reached it, never one of its own.
                     val depsDirectory = rootVirtualFileToDepsDirectory[rootVirtualFile]
                         ?: declaredDepsPath?.let { rootVirtualFile.findFileByRelativePath(it) }
-                        ?: owningProjectRoot(rootVirtualFile, projectRootVirtualFiles)
-                            ?.findFileByRelativePath(MIX_DEPS_DIRECTORY_NAME)
+                        ?: owningProjectRoot?.findFileByRelativePath(MIX_DEPS_DIRECTORY_NAME)
 
                     for (dep in depSet) {
                         if (progressIndicator.isCanceled) {
@@ -77,27 +78,29 @@ class Resolution(
                         }
                         ProgressManager.checkCanceled()
 
-                        /* Don't need to check module dep because it will already be in `rootVirtualFiles` AND
-                           Module deps handle transitivity while Library deps don't */
-                        if (dep.type == Dep.Type.LIBRARY) {
-                            if (!depToRootVirtualFile.contains(dep)) {
-                                val depRootVirtualFile =
-                                    depRootVirtualFile(dep, rootVirtualFile, depsDirectory)
+                        if (!depToRootVirtualFile.contains(dep)) {
+                            val depRootVirtualFile =
+                                depRootVirtualFile(dep, rootVirtualFile, depsDirectory, owningProjectRoot)
 
-                                depToRootVirtualFile[dep] = depRootVirtualFile
+                            depToRootVirtualFile[dep] = depRootVirtualFile
 
-                                if (depRootVirtualFile != null) {
-                                    // Mix checks a dependency's own deps out beside it, so the
-                                    // directory that held this one holds everything it declares.
-                                    depsDirectory?.let {
-                                        rootVirtualFileToDepsDirectory.putIfAbsent(depRootVirtualFile, it)
-                                    }
+                            if (depRootVirtualFile != null) {
+                                if (dep.type == Dep.Type.MODULE) {
+                                    // Registering it before it is dequeued is what settles its
+                                    // isDependency, which is read off this set.
+                                    projectRootVirtualFiles.add(depRootVirtualFile)
+                                }
 
-                                    if (!rootVirtualFileToDepSet.contains(depRootVirtualFile) &&
-                                        !rootVirtualFileQueue.contains(depRootVirtualFile)
-                                    ) {
-                                        rootVirtualFileQueue.add(depRootVirtualFile)
-                                    }
+                                // Mix checks a dependency's own deps out beside it, so the
+                                // directory that held this one holds everything it declares.
+                                depsDirectory?.let {
+                                    rootVirtualFileToDepsDirectory.putIfAbsent(depRootVirtualFile, it)
+                                }
+
+                                if (!rootVirtualFileToDepSet.contains(depRootVirtualFile) &&
+                                    !rootVirtualFileQueue.contains(depRootVirtualFile)
+                                ) {
+                                    rootVirtualFileQueue.add(depRootVirtualFile)
                                 }
                             }
                         }
@@ -111,12 +114,16 @@ class Resolution(
         }
 
         /**
-         * The directory Mix would check [dep] out into.
+         * The directory Mix would resolve [dep] to.
          *
          * `Mix.Project.deps_config/1` hands every dependency the *top-level* project's `deps_path`,
          * already expanded, so a hex or git dep declared by a dependency is checked out beside it
          * under the project - `deps/<parent>/deps/<child>` is a directory no Mix configuration
          * produces. Looking there ended the walk one level below every project root.
+         *
+         * An `in_umbrella:` dep is checked out nowhere - it is already an app of the umbrella that
+         * owns the declaring app, so its `apps/<name>` is relative to the umbrella root and not to
+         * the app that wrote it. `apps/<app>/apps/<sibling>` is a directory no umbrella produces.
          *
          * An explicit `path:` dep is the exception and keeps the old base: `Mix.SCM.Path` expands it
          * against the directory of whatever declared it, so `"../sibling"` inside a dependency
@@ -124,18 +131,26 @@ class Resolution(
          *
          * The search is confined to the one project that owns the declaring file, so two content
          * roots that both have `deps/<name>` cannot be confused for one another. The lookup stays on
-         * [VirtualFile.findFileByRelativePath] because a `deps/` path needs no upward traversal,
-         * leaving [Dep.virtualFile]'s refresh-based resolution for the paths that do.
+         * [VirtualFile.findFileByRelativePath] because neither a `deps/` nor an `apps/` path needs
+         * upward traversal, leaving [Dep.virtualFile]'s refresh-based resolution for the paths that
+         * do.
          */
         private fun depRootVirtualFile(
             dep: Dep,
             declaringRootVirtualFile: VirtualFile,
-            depsDirectory: VirtualFile?
+            depsDirectory: VirtualFile?,
+            owningProjectRoot: VirtualFile?
         ): VirtualFile? {
             if (dep.path.startsWith(MIX_DEPS_DIRECTORY_PREFIX)) {
                 depsDirectory
                     ?.findFileByRelativePath(dep.path.removePrefix(MIX_DEPS_DIRECTORY_PREFIX))
                     ?.let { return it }
+            }
+
+            // A `path:` written after `in_umbrella:` wins the path while leaving the type, so the
+            // prefix rather than the type is what says the umbrella owns this one.
+            if (dep.type == Dep.Type.MODULE && dep.path.startsWith(UMBRELLA_APPS_DIRECTORY_PREFIX)) {
+                owningProjectRoot?.findFileByRelativePath(dep.path)?.let { return it }
             }
 
             return dep.virtualFile(declaringRootVirtualFile)
@@ -259,6 +274,7 @@ class Resolution(
 private const val MIX_DEPS_DIRECTORY_NAME = "deps"
 private const val MIX_DEPS_DIRECTORY_PREFIX = "deps/"
 private const val UMBRELLA_APPS_DIRECTORY_NAME = "apps"
+private const val UMBRELLA_APPS_DIRECTORY_PREFIX = "apps/"
 
 /**
  * What one package file yields: the deps it declares, and the `deps_path:` it declares them to live

--- a/src/org/elixir_lang/notification/setup_sdk/Notifier.kt
+++ b/src/org/elixir_lang/notification/setup_sdk/Notifier.kt
@@ -214,6 +214,18 @@ object Notifier {
             .notify(project)
     }
 
+    fun dependencyLibrarySyncScheduled(project: Project) {
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup("Elixir")
+            .createNotification(
+                "Syncing Elixir dependency libraries",
+                "Rescanning every content root's deps and _build",
+                NotificationType.INFORMATION
+            )
+            .notify(project)
+    }
+
     fun mixDepsInstallError(project: Project, moduleName: String, errorMessage: String) {
         NotificationGroupManager
             .getInstance()

--- a/src/org/elixir_lang/package_manager/DepGatherer.kt
+++ b/src/org/elixir_lang/package_manager/DepGatherer.kt
@@ -5,4 +5,14 @@ import org.elixir_lang.mix.Dep
 
 abstract class DepGatherer : PsiElementVisitor() {
     val depSet: MutableSet<Dep> = mutableSetOf()
+
+    /**
+     * The dependency directory the package file names, verbatim and relative to the file, or `null`
+     * when it names none and the package manager's default applies.
+     *
+     * Open with a `null` default so a package manager that has no such notion - or that lives
+     * outside this repository, like the rebar3 one registered by the Erlang plugin - keeps working
+     * without overriding it.
+     */
+    open val depsPath: String? = null
 }

--- a/src/org/elixir_lang/sdk/ElixirSdkLibraryTreeStructureProvider.kt
+++ b/src/org/elixir_lang/sdk/ElixirSdkLibraryTreeStructureProvider.kt
@@ -18,6 +18,7 @@ import com.intellij.psi.PsiManager
 import org.elixir_lang.jps.shared.ElixirSdkTypeId
 import org.elixir_lang.jps.shared.ErlangSdkTypeId
 import org.elixir_lang.mix.library.CONSOLIDATED_LIBRARY_SUFFIX
+import org.elixir_lang.mix.sync.scopedLibraryNameToken
 
 /**
  * Lifts an Elixir/Erlang SDK "ebin" class root node in External Libraries to the application
@@ -70,7 +71,7 @@ internal class ElixirSdkLibraryTreeStructureProvider : TreeStructureProvider, Du
                         when {
                             libName?.endsWith(CONSOLIDATED_LIBRARY_SUFFIX) == true ->
                                 ConsolidatedLibraryNode(node, settings)
-                            libName != null && " [file:///" in libName ->
+                            libName != null && scopedLibraryNameToken(libName) != null ->
                                 ScopedDepLibraryNode(node, settings)
                             else -> node
                         }
@@ -244,11 +245,12 @@ private class ConsolidatedLibraryNode(
 }
 
 /**
- * Wraps a scoped dep [NamedLibraryElementNode] whose name contains a `[file:///...]` suffix,
+ * Wraps a scoped dep [NamedLibraryElementNode] whose name carries a `[<scope>]` suffix,
  * overriding [update] to display the dep name without the verbose URL and instead show the
  * content root directory as a grey location string.
  *
- * Example: `"phoenix [file:///project/apps/my_app]"` → displays as `phoenix` with `(my_app)` in grey.
+ * Example: `"phoenix [apps/my_app]"` displays as `phoenix` with `my_app` in grey; a dep scoped to
+ * the project root displays as `phoenix` alone.
  */
 private class ScopedDepLibraryNode(
     wrapped: NamedLibraryElementNode,
@@ -257,11 +259,18 @@ private class ScopedDepLibraryNode(
     override fun update(presentation: PresentationData) {
         super.update(presentation)
         val name = presentation.presentableText ?: return
-        val bracketIdx = name.indexOf(" [file:///")
-        if (bracketIdx < 0) return
+        // Parsed through the naming helper rather than by matching a literal prefix: the scope
+        // token is a project-relative path, and only falls back to a `file://` URL where no
+        // relative path can express it.
+        val token = scopedLibraryNameToken(name) ?: return
+        val bracketIdx = name.indexOf(" [")
+        if (bracketIdx <= 0) return
         presentation.presentableText = name.substring(0, bracketIdx)
-        // Show only the final path segment of the content root URL as the location hint
-        val url = name.substring(bracketIdx + 2, name.length - 1)
-        presentation.locationString = url.trimEnd('/').substringAfterLast('/')
+        // Final segment only, as a location hint. The project's own root is "." and needs no hint -
+        // every dep without one sits there.
+        presentation.locationString = token
+            .trimEnd('/')
+            .substringAfterLast('/')
+            .takeUnless { it == "." || it.isEmpty() }
     }
 }

--- a/tests/org/elixir_lang/DepsWatcherTest.kt
+++ b/tests/org/elixir_lang/DepsWatcherTest.kt
@@ -13,6 +13,7 @@ import org.elixir_lang.mix.library.CONSOLIDATED_LIBRARY_SUFFIX
 import org.elixir_lang.mix.sync.MixDepsSyncService
 import org.elixir_lang.mix.sync.MixSyncTestHelpers.drainDirectly
 import org.elixir_lang.mix.sync.SyncRequest
+import org.elixir_lang.mix.sync.contentRootToken
 import org.elixir_lang.mix.sync.scopedDepLibraryName
 import org.elixir_lang.psi.ElixirTuple
 
@@ -473,7 +474,10 @@ class DepsWatcherTest : PlatformTestCase() {
      * The content root is the grandparent of the dep directory (<contentRoot>/deps/<depName>).
      */
     private fun depLibraryName(depRoot: VirtualFile): String =
-        scopedDepLibraryName(depRoot.parent?.parent?.url ?: "", depRoot.name)
+        scopedDepLibraryName(
+            depRoot.parent?.parent?.url?.let { contentRootToken(project, it) } ?: "",
+            depRoot.name,
+        )
 
     private fun classRootUrls(libraryName: String): kotlin.collections.List<String> {
         val library = LibraryTablesRegistrar.getInstance().getLibraryTable(project).getLibraryByName(libraryName)

--- a/tests/org/elixir_lang/mix/DepTest.kt
+++ b/tests/org/elixir_lang/mix/DepTest.kt
@@ -78,6 +78,37 @@ class DepTest : PlatformTestCase() {
         assertEquals(Dep.Type.MODULE, deps.single()?.type)
     }
 
+    // ---------------------------------------------------------------------
+    // Options written as an explicit list
+    // ---------------------------------------------------------------------
+
+    fun testBracketedPathIsHonoured() {
+        val (deps, errorTitles) = depsFrom("{:d, [path: \"../d\"]}")
+
+        assertEmpty("`path` is handled, bracketed or not", errorTitles)
+        assertEquals("../d", deps.single()?.path)
+    }
+
+    fun testBracketedInUmbrellaIsHonoured() {
+        val (deps, _) = depsFrom("{:d, [in_umbrella: true]}")
+
+        assertEquals("apps/d", deps.single()?.path)
+        assertEquals(Dep.Type.MODULE, deps.single()?.type)
+    }
+
+    /** An unknown option must still be reported when bracketed, or the tripwire has a blind spot. */
+    fun testBracketedUnknownOptionIsReported() {
+        val (_, errorTitles) = depsFrom("{:d, \"~> 1.0\", [not_a_mix_dep_option: true]}")
+
+        assertEquals(
+            listOf(
+                "Don't know if Mix.Dep option `not_a_mix_dep_option` is important for determining " +
+                        "location of dependency"
+            ),
+            errorTitles
+        )
+    }
+
     /**
      * Parses [depTuples] as the `deps` of a `mix.exs` and runs [Dep.from] over each tuple, returning
      * the deps in source order alongside the title of every error [Dep] logged.

--- a/tests/org/elixir_lang/mix/DepTest.kt
+++ b/tests/org/elixir_lang/mix/DepTest.kt
@@ -24,9 +24,8 @@ class DepTest : PlatformTestCase() {
      * named constants are misspellings that widely installed packages ship, referenced by name rather
      * than spelled out so a future reader does not "correct" them.
      *
-     * `sparse` and `subdir` are on [Dep.from]'s ignored list but are deliberately absent here,
-     * because they do not belong on it: `Mix.SCM.Git` joins each onto the dep's destination, so Mix
-     * checks the dep out at `deps/<name>/<option>`. Tracked on #3928.
+     * `sparse` and `subdir` are absent because they are not path-neutral - `Mix.SCM.Git` joins each
+     * onto the dep's destination. They are handled options, covered by their own cases below.
      *
      * `only` and `optional` stay here because neither moves the dep, but they are no longer *merely*
      * path-neutral: inside a dependency's own `mix.exs` either can drop the dep entirely, which is
@@ -79,6 +78,76 @@ class DepTest : PlatformTestCase() {
         assertEmpty("`in_umbrella` is handled, so it must not be reported", errorTitles)
         assertEquals("apps/my_dep", deps.single()?.path)
         assertEquals(Dep.Type.MODULE, deps.single()?.type)
+    }
+
+    // ---------------------------------------------------------------------
+    // `sparse:` / `subdir:` - both join onto the dep's destination
+    // ---------------------------------------------------------------------
+
+    fun testSparseAppendsToDepsPath() {
+        val (deps, errorTitles) = depsFrom("{:d, git: \"u\", sparse: \"s\"}")
+
+        assertEmpty("`sparse` is handled, so it must not be reported", errorTitles)
+        assertEquals("deps/d/s", deps.single()?.path)
+    }
+
+    fun testSubdirAppendsToDepsPath() {
+        val (deps, errorTitles) = depsFrom("{:d, git: \"u\", subdir: \"sd\"}")
+
+        assertEmpty("`subdir` is handled, so it must not be reported", errorTitles)
+        assertEquals("deps/d/sd", deps.single()?.path)
+    }
+
+    fun testSparseAndSubdirBothAppend() {
+        val (deps, _) = depsFrom("{:d, git: \"u\", sparse: \"s\", subdir: \"sd\"}")
+
+        assertEquals("deps/d/s/sd", deps.single()?.path)
+    }
+
+    /**
+     * `Mix.SCM.Git.accepts_options` pipes `sparse_opts()` then `subdir_opts()`, so the order is
+     * Mix's, not the source's. Written reversed so inheriting the fold's order fails.
+     */
+    fun testSparseIsAppliedBeforeSubdirWhateverTheSourceOrder() {
+        val (deps, _) = depsFrom("{:d, git: \"u\", subdir: \"sd\", sparse: \"s\"}")
+
+        assertEquals("deps/d/s/sd", deps.single()?.path)
+    }
+
+    fun testSubdirAppliesToAGithubDep() {
+        val (deps, _) = depsFrom("{:d, github: \"o/r\", subdir: \"sd\"}")
+
+        assertEquals("deps/d/sd", deps.single()?.path)
+    }
+
+    /**
+     * `Mix.SCM.Git.accepts_options` returns nil without `git:`/`github:`, so `Mix.SCM.Path` wins and
+     * sets the destination from `path:` alone - `subdir` never applies.
+     */
+    fun testSubdirIsIgnoredForAPathDep() {
+        val (deps, _) = depsFrom("{:d, path: \"vendor/d\", subdir: \"sd\"}")
+
+        assertEquals("vendor/d", deps.single()?.path)
+    }
+
+    fun testSubdirIsIgnoredWithoutAnScmOption() {
+        val (deps, _) = depsFrom("{:d, subdir: \"sd\"}")
+
+        assertEquals("deps/d", deps.single()?.path)
+    }
+
+    fun testSubdirIsIgnoredForAnInUmbrellaDep() {
+        val (deps, _) = depsFrom("{:d, in_umbrella: true, subdir: \"sd\"}")
+
+        assertEquals("apps/d", deps.single()?.path)
+        assertEquals(Dep.Type.MODULE, deps.single()?.type)
+    }
+
+    /** A non-literal value cannot be read, so it is a no-op - as `path:` already treats a call. */
+    fun testNonLiteralSubdirIsANoOp() {
+        val (deps, _) = depsFrom("{:d, git: \"u\", subdir: helper()}")
+
+        assertEquals("deps/d", deps.single()?.path)
     }
 
     // ---------------------------------------------------------------------
@@ -182,6 +251,12 @@ class DepTest : PlatformTestCase() {
 
         assertEquals("apps/d", deps.single()?.path)
         assertEquals(Dep.Type.MODULE, deps.single()?.type)
+    }
+
+    fun testBracketedSubdirIsHonoured() {
+        val (deps, _) = depsFrom("{:d, [git: \"u\", subdir: \"sd\"]}")
+
+        assertEquals("deps/d/sd", deps.single()?.path)
     }
 
     /** An unknown option must still be reported when bracketed, or the tripwire has a blind spot. */

--- a/tests/org/elixir_lang/mix/DepTest.kt
+++ b/tests/org/elixir_lang/mix/DepTest.kt
@@ -26,8 +26,11 @@ class DepTest : PlatformTestCase() {
      *
      * `sparse` and `subdir` are on [Dep.from]'s ignored list but are deliberately absent here,
      * because they do not belong on it: `Mix.SCM.Git` joins each onto the dep's destination, so Mix
-     * checks the dep out at `deps/<name>/<option>`. Adding either here would assert that the current
-     * answer is correct. Tracked on #3928; when it is fixed they join the handled options below.
+     * checks the dep out at `deps/<name>/<option>`. Tracked on #3928.
+     *
+     * `only` and `optional` stay here because neither moves the dep, but they are no longer *merely*
+     * path-neutral: inside a dependency's own `mix.exs` either can drop the dep entirely, which is
+     * what the `isDependency` cases below assert.
      */
     private val pathNeutralOptions = listOf(
         "allow_pre", "app", "branch", "commit", "compile", "depth", "env", "git", "github", "hex",
@@ -79,8 +82,93 @@ class DepTest : PlatformTestCase() {
     }
 
     // ---------------------------------------------------------------------
+    // `only:` / `optional:` inside a dependency's own mix.exs
+    // ---------------------------------------------------------------------
+
+    fun testEnvironmentRestrictedDepOfADepIsDropped() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", only: [:test]}", isDependency = true)
+
+        assertNull("`only:` excluding :prod must drop the dep", deps.single())
+    }
+
+    fun testSingleAtomEnvironmentRestrictedDepOfADepIsDropped() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", only: :test}", isDependency = true)
+
+        assertNull("The single-atom `only:` form must drop the dep too", deps.single())
+    }
+
+    fun testOptionalDepOfADepIsDropped() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", optional: true}", isDependency = true)
+
+        assertNull("`optional: true` must drop the dep", deps.single())
+    }
+
+    /** The two gates are independent: clearing the environment one does not rescue an optional dep. */
+    fun testOptionalDepOfADepIsDroppedEvenWhenOnlyIncludesProd() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", optional: true, only: [:prod]}", isDependency = true)
+
+        assertNull("`optional: true` must drop the dep whatever `only:` says", deps.single())
+    }
+
+    fun testProdOnlyDepOfADepIsKept() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", only: [:prod]}", isDependency = true)
+
+        assertEquals("deps/d", deps.single()?.path)
+    }
+
+    fun testDepOfADepIsKeptWhenOnlyIncludesProdAmongOthers() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", only: [:dev, :prod]}", isDependency = true)
+
+        assertEquals("deps/d", deps.single()?.path)
+    }
+
+    fun testOptionalFalseDepOfADepIsKept() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", optional: false}", isDependency = true)
+
+        assertEquals("deps/d", deps.single()?.path)
+    }
+
+    /**
+     * Every `only:` shape the plugin cannot read must keep the dep. Dropping one that is physically
+     * present costs resolution and completion; keeping one Mix never fetches costs an empty
+     * placeholder library, which is the status quo.
+     */
+    fun testUnreadableOnlyValuesKeepTheDep() {
+        val unreadable = listOf(
+            "only: :\"prod\"",
+            "only: true",
+            "only: @envs",
+            "only: Mix.env()",
+            "only: [:dev] ++ other()",
+        )
+
+        unreadable.forEach { option ->
+            val (deps, _) = depsFrom("{:d, \"~> 1.0\", $option}", isDependency = true)
+
+            assertEquals("`$option` cannot be read, so the dep must be kept", "deps/d", deps.single()?.path)
+        }
+    }
+
+    // ---------------------------------------------------------------------
     // Options written as an explicit list
     // ---------------------------------------------------------------------
+
+    /**
+     * `{:dep, "~> 1.0", [optional: true]}` is the same declaration as one without the brackets, and
+     * packages in the wild write both - `db_connection` brackets its `optional:` where `ecto` does
+     * not. Every option was dropped for the bracketed form, so nothing below was ever read.
+     */
+    fun testBracketedOptionalIsHonoured() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", [optional: true]}", isDependency = true)
+
+        assertNull("Bracketed `optional: true` must drop the dep", deps.single())
+    }
+
+    fun testBracketedOnlyIsHonoured() {
+        val (deps, _) = depsFrom("{:d, \"~> 1.0\", [only: [:test]]}", isDependency = true)
+
+        assertNull("Bracketed `only:` excluding :prod must drop the dep", deps.single())
+    }
 
     fun testBracketedPathIsHonoured() {
         val (deps, errorTitles) = depsFrom("{:d, [path: \"../d\"]}")
@@ -113,7 +201,7 @@ class DepTest : PlatformTestCase() {
      * Parses [depTuples] as the `deps` of a `mix.exs` and runs [Dep.from] over each tuple, returning
      * the deps in source order alongside the title of every error [Dep] logged.
      */
-    private fun depsFrom(depTuples: String): Pair<List<Dep?>, List<String>> {
+    private fun depsFrom(depTuples: String, isDependency: Boolean = false): Pair<List<Dep?>, List<String>> {
         val (deps, loggedErrors) = captureLoggedErrors {
             val psiFile = myFixture.configureByText(
                 "mix.exs",
@@ -130,7 +218,7 @@ class DepTest : PlatformTestCase() {
                 """.trimIndent()
             )
 
-            PsiTreeUtil.findChildrenOfType(psiFile, ElixirTuple::class.java).map { Dep.from(it) }
+            PsiTreeUtil.findChildrenOfType(psiFile, ElixirTuple::class.java).map { Dep.from(it, isDependency) }
         }
 
         return Pair(

--- a/tests/org/elixir_lang/mix/DepsCheckerServiceTestBase.kt
+++ b/tests/org/elixir_lang/mix/DepsCheckerServiceTestBase.kt
@@ -124,7 +124,7 @@ abstract class DepsCheckerServiceTestBase : PlatformTestCase() {
      * if [kotlinx.coroutines.runBlocking] were called directly on the EDT test thread.
      */
     protected fun <T> runSuspendOnPooledThread(block: suspend () -> T): T =
-        MixSyncTestHelpers.runSuspendOnPooledThread(block)
+        MixSyncTestHelpers.runSuspendOnPooledThread(block = block)
 
     /**
      * Polls [condition] in a tight loop, pumping the IDE event queue on each iteration

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceHeavyTestBase.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceHeavyTestBase.kt
@@ -132,5 +132,5 @@ abstract class MixDepsSyncServiceHeavyTestBase : HeavyPlatformTestCase() {
      * pumping its event queue. Delegates to [MixSyncTestHelpers.runSuspendOnPooledThread].
      */
     protected fun <T> runSuspendOnPooledThread(block: suspend () -> T): T =
-        MixSyncTestHelpers.runSuspendOnPooledThread(block)
+        MixSyncTestHelpers.runSuspendOnPooledThread(block = block)
 }

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceIsolationHeavyTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceIsolationHeavyTest.kt
@@ -46,8 +46,8 @@ class MixDepsSyncServiceIsolationHeavyTest : MixDepsSyncServiceHeavyTestBase() {
      *   root; umbrella_b/ is NOT an ancestor of umbrella_a/apps/child_a → filtered; umbrella_a/ IS → picked
      */
     fun testUmbrellaFallback_twoModuleSeparatedUmbrellas_childModuleWiredToOwningUmbrella() {
-        val libNameA = scopedDepLibraryName(umbrellaAVf.url, "phoenix")
-        val libNameB = scopedDepLibraryName(umbrellaBVf.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, umbrellaAVf.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, umbrellaBVf.url), "phoenix")
         assertFalse("Sanity: two umbrella roots must produce distinct library names", libNameA == libNameB)
 
         val service = project.service<MixDepsSyncService>()

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceMultiUmbrellaHeavyTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceMultiUmbrellaHeavyTest.kt
@@ -42,8 +42,8 @@ class MixDepsSyncServiceMultiUmbrellaHeavyTest : MixDepsSyncServiceHeavyTestBase
      * `umbrella_a/`, so it is excluded and receives no phoenix library entry.
      */
     fun testAffectedModuleNames_depRootFanOutIncludesOnlyAncestorChild() {
-        val libNameA = scopedDepLibraryName(umbrellaAVf.url, "phoenix")
-        val libNameB = scopedDepLibraryName(umbrellaBVf.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, umbrellaAVf.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, umbrellaBVf.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         service.clearPendingForTesting()
@@ -103,8 +103,8 @@ class MixDepsSyncServiceMultiUmbrellaHeavyTest : MixDepsSyncServiceHeavyTestBase
      * child_a's wiring. This test verifies BOTH children independently.
      */
     fun testFullTwoSidedCrossRootWiringIsolation() {
-        val libNameA = scopedDepLibraryName(umbrellaAVf.url, "phoenix")
-        val libNameB = scopedDepLibraryName(umbrellaBVf.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, umbrellaAVf.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, umbrellaBVf.url), "phoenix")
         assertFalse("Sanity: two umbrella roots must produce distinct library names", libNameA == libNameB)
 
         val service = project.service<MixDepsSyncService>()
@@ -163,8 +163,8 @@ class MixDepsSyncServiceMultiUmbrellaHeavyTest : MixDepsSyncServiceHeavyTestBase
      * `phoenix [umbrella_a/apps/child_a]` instead of the correct `phoenix \[umbrella_a\]`.
      */
     fun testSyncModuleOnly_ancestorWalkProducesCorrectlyScopedLibrary() {
-        val correctLibName = scopedDepLibraryName(umbrellaAVf.url, "phoenix")
-        val wrongLibName = scopedDepLibraryName(childAVf.url, "phoenix")
+        val correctLibName = scopedDepLibraryName(contentRootToken(project, umbrellaAVf.url), "phoenix")
+        val wrongLibName = scopedDepLibraryName(contentRootToken(project, childAVf.url), "phoenix")
         assertFalse("Sanity: correct and wrong library names must differ", correctLibName == wrongLibName)
 
         val service = project.service<MixDepsSyncService>()

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServicePruneStaleEntriesHeavyTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServicePruneStaleEntriesHeavyTest.kt
@@ -121,7 +121,7 @@ class MixDepsSyncServicePruneStaleEntriesHeavyTest : HeavyPlatformTestCase() {
         )
 
         // And the correctly-scoped replacement must be wired (the prune must not interfere).
-        val currentName = scopedDepLibraryName(rootVf.url, "phoenix")
+        val currentName = scopedDepLibraryName(contentRootToken(project, rootVf.url), "phoenix")
         assertTrue(
             "The current-root-scoped library '$currentName' must still be wired. Order entries: $entries",
             entries.contains(currentName)
@@ -134,7 +134,7 @@ class MixDepsSyncServicePruneStaleEntriesHeavyTest : HeavyPlatformTestCase() {
      * the dep is fetched and the library is created - the prune must leave it alone.
      */
     fun testInvalidEntryForCurrentRootIsPreserved() {
-        val unfetchedName = scopedDepLibraryName(rootVf.url, "ecto")
+        val unfetchedName = scopedDepLibraryName(contentRootToken(project, rootVf.url), "ecto")
         addInvalidProjectLibraryEntry(unfetchedName)
 
         drainForRootMixExs()

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceSiblingAppHeavyTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceSiblingAppHeavyTest.kt
@@ -1,0 +1,176 @@
+package org.elixir_lang.mix.sync
+
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.ModuleOrderEntry
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.common.runAll
+import java.io.File
+import java.util.concurrent.Callable
+
+/**
+ * Heavy tests for [MixDepsSyncService] covering an umbrella imported one module per app, where one
+ * app declares another with `in_umbrella:`:
+ * ```
+ *   module_app_a  content-root: umbrella/apps/app_a/
+ *   module_app_b  content-root: umbrella/apps/app_b/
+ *
+ *   umbrella/
+ *     mix.exs                  (apps_path: "apps", declares no deps)
+ *     deps/phoenix/lib/
+ *     _build/dev/lib/phoenix/ebin/
+ *     apps/app_a/mix.exs       (declares {:app_b, in_umbrella: true})
+ *     apps/app_b/mix.exs       (declares {:phoenix, ">= 0.0.0"})
+ * ```
+ *
+ * The umbrella root is deliberately not a content root of any module - that is the import shape
+ * [#3990](https://github.com/KronicDeth/intellij-elixir/issues/3990) reports, and it is what makes
+ * `app_a`'s own content root the only place the resolver starts from.
+ */
+class MixDepsSyncServiceSiblingAppHeavyTest : HeavyPlatformTestCase() {
+
+    private lateinit var umbrellaVf: VirtualFile
+    private lateinit var appAMixExs: VirtualFile
+
+    override fun setUp() {
+        super.setUp()
+
+        val umbrellaDir = createTempDir("sibling_umbrella")
+        FileUtil.writeToFile(
+            File(umbrellaDir, "mix.exs"),
+            "defmodule SiblingUmbrella.MixProject do\n" +
+                "  use Mix.Project\n\n" +
+                "  def project do\n" +
+                "    [apps_path: \"apps\"]\n" +
+                "  end\nend\n"
+        )
+        File(umbrellaDir, "deps/phoenix/lib").mkdirs()
+        File(umbrellaDir, "_build/dev/lib/phoenix/ebin").mkdirs()
+        File(umbrellaDir, "apps/app_a").mkdirs()
+        FileUtil.writeToFile(
+            File(umbrellaDir, "apps/app_a/mix.exs"),
+            "defmodule AppA.MixProject do\n" +
+                "  use Mix.Project\n\n" +
+                "  def project do\n" +
+                "    [app: :app_a, version: \"0.1.0\", deps: deps()]\n" +
+                "  end\n\n" +
+                "  def deps do\n" +
+                "    [{:app_b, in_umbrella: true}]\n" +
+                "  end\nend\n"
+        )
+        File(umbrellaDir, "apps/app_b").mkdirs()
+        FileUtil.writeToFile(
+            File(umbrellaDir, "apps/app_b/mix.exs"),
+            "defmodule AppB.MixProject do\n" +
+                "  use Mix.Project\n\n" +
+                "  def project do\n" +
+                "    [app: :app_b, version: \"0.1.0\", deps: deps()]\n" +
+                "  end\n\n" +
+                "  def deps do\n" +
+                "    [{:phoenix, \">= 0.0.0\"}]\n" +
+                "  end\nend\n"
+        )
+
+        val umbrellaVfRaw = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(umbrellaDir)
+            ?: error("sibling_umbrella not found in VFS after refresh")
+        VfsUtil.markDirtyAndRefresh(false, true, true, umbrellaVfRaw)
+        umbrellaVf = umbrellaVfRaw
+
+        appAMixExs = umbrellaVf.findFileByRelativePath("apps/app_a/mix.exs")
+            ?: error("sibling_umbrella/apps/app_a/mix.exs not found in VFS after refresh")
+
+        // One module per app, and no module for the umbrella root - the app dirs are the only
+        // content roots there are.
+        PsiTestUtil.addContentRoot(
+            createModule("module_app_a"),
+            umbrellaVf.findFileByRelativePath("apps/app_a")!!
+        )
+        PsiTestUtil.addContentRoot(
+            createModule("module_app_b"),
+            umbrellaVf.findFileByRelativePath("apps/app_b")!!
+        )
+    }
+
+    override fun tearDown() {
+        runAll(
+            { MixSyncTestHelpers.removeAllLibraries(project) },
+            { super.tearDown() },
+        )
+    }
+
+    private fun module(name: String): Module =
+        ModuleManager.getInstance(project).findModuleByName(name) ?: error("$name not found")
+
+    private fun libraryEntryNames(moduleName: String): List<String> =
+        ReadAction.nonBlocking(Callable {
+            ModuleRootManager.getInstance(module(moduleName)).orderEntries
+                .filterIsInstance<LibraryOrderEntry>()
+                .mapNotNull { it.libraryName }
+        }).executeSynchronously()
+
+    private fun moduleEntryNames(moduleName: String): List<String> =
+        ReadAction.nonBlocking(Callable {
+            ModuleRootManager.getInstance(module(moduleName)).orderEntries
+                .filterIsInstance<ModuleOrderEntry>()
+                .map { it.moduleName }
+        }).executeSynchronously()
+
+    private fun drainForAppA() {
+        val service = project.service<MixDepsSyncService>()
+        service.clearPendingForTesting()
+        service.enqueue(SyncRequest.MixFile(appAMixExs))
+        MixSyncTestHelpers.drainDirectly(service)
+    }
+
+    /**
+     * `phoenix` is declared only by `app_b`, and `app_a` reaches it by declaring `app_b`. Without
+     * walking the sibling's own `mix.exs`, `app_a`'s module gets no entry for it and every alias
+     * `app_a` writes against a `phoenix` module is unresolved - the report on #3990.
+     *
+     * `app_b`'s own entry is asserted alongside it as the precondition: a run that wired nothing at
+     * all would otherwise satisfy nothing here.
+     */
+    fun testSiblingsDepIsWiredToTheDeclaringAppsModule() {
+        val libName = scopedDepLibraryName(contentRootToken(project, umbrellaVf.url), "phoenix")
+
+        drainForAppA()
+
+        assertTrue(
+            "Precondition: app_b declares {:phoenix, ...} directly, so its own module must be " +
+                "wired to '$libName'. Order entries: ${libraryEntryNames("module_app_b")}",
+            libraryEntryNames("module_app_b").contains(libName),
+        )
+        assertTrue(
+            "app_a reaches phoenix through {:app_b, in_umbrella: true}, and a module order entry " +
+                "carries no unexported library, so app_a needs '$libName' in its own right. " +
+                "Order entries: ${libraryEntryNames("module_app_a")}",
+            libraryEntryNames("module_app_a").contains(libName),
+        )
+    }
+
+    /**
+     * The sibling is a module of this project, so it stays a module order entry rather than
+     * becoming a library of its own - the library entry above is in addition to it, not instead.
+     */
+    fun testSiblingRemainsAModuleOrderEntry() {
+        drainForAppA()
+
+        assertTrue(
+            "app_b is a module of the project. Module dep entries: ${moduleEntryNames("module_app_a")}",
+            moduleEntryNames("module_app_a").contains("app_b"),
+        )
+        assertFalse(
+            "app_b must not also be wired as a library. Order entries: ${libraryEntryNames("module_app_a")}",
+            libraryEntryNames("module_app_a").any { it.contains("app_b") },
+        )
+    }
+}

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceSingleModuleUmbrellaHeavyTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceSingleModuleUmbrellaHeavyTest.kt
@@ -128,7 +128,7 @@ class MixDepsSyncServiceSingleModuleUmbrellaHeavyTest : HeavyPlatformTestCase() 
      * unresolved module aliases for all app-declared deps in single-module umbrellas).
      */
     fun testRootMixFileSync_wiresAppDeclaredDepToUmbrellaModule() {
-        val libName = scopedDepLibraryName(umbrellaVf.url, "phoenix")
+        val libName = scopedDepLibraryName(contentRootToken(project, umbrellaVf.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         service.clearPendingForTesting()
@@ -160,7 +160,7 @@ class MixDepsSyncServiceSingleModuleUmbrellaHeavyTest : HeavyPlatformTestCase() 
      * trigger dependency wiring in a single-module umbrella.
      */
     fun testAppMixFileEvent_resolvesToOwningUmbrellaModuleAndWires() {
-        val libName = scopedDepLibraryName(umbrellaVf.url, "phoenix")
+        val libName = scopedDepLibraryName(contentRootToken(project, umbrellaVf.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         service.clearPendingForTesting()
@@ -186,7 +186,7 @@ class MixDepsSyncServiceSingleModuleUmbrellaHeavyTest : HeavyPlatformTestCase() 
      * at all (otherwise this test would pass vacuously against the pre-fix code).
      */
     fun testInUmbrellaSiblingDep_doesNotCreateModuleOrderEntryOnOwnModule() {
-        val libName = scopedDepLibraryName(umbrellaVf.url, "phoenix")
+        val libName = scopedDepLibraryName(contentRootToken(project, umbrellaVf.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         service.clearPendingForTesting()

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
@@ -1381,6 +1381,30 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
 
 
     // ------------------------------------------------------------------
+    // Sync Dependency Libraries action
+    // ------------------------------------------------------------------
+
+    /**
+     * The action is the only way a user can force a full rescan: nothing else enqueues
+     * [SyncRequest.All] outside first-time project configuration, and `mix deps.get` on already
+     * fetched deps changes nothing on disk, so it produces no VFS events either.
+     */
+    fun testSyncDependencyLibrariesAction_enqueuesAll() {
+        val service = project.service<MixDepsSyncService>()
+        service.clearPendingForTesting()
+        assertEquals(0, service.pendingCount)
+
+        org.elixir_lang.action.SyncDependencyLibrariesAction().actionPerformed(
+            com.intellij.testFramework.TestActionEvent.createTestEvent(
+                com.intellij.openapi.actionSystem.impl.SimpleDataContext
+                    .getProjectContext(project)
+            )
+        )
+
+        assertEquals("The action must enqueue exactly one request", 1, service.pendingCount)
+        service.clearPendingForTesting()
+    }
+    // ------------------------------------------------------------------
     // contentRootToken
     // ------------------------------------------------------------------
 

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
@@ -596,6 +596,38 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
     }
 
     /**
+     * A dep that only a *dependency's* `mix.exs` declares, under options Mix honours by not fetching
+     * it, must not become a library.
+     *
+     * This is the whole point of the filter, seen from where the user sees it: such a library can
+     * never gain roots, because no `mix deps.get` in any environment will create the directory. The
+     * declaration is `cachex`'s own, which is what put `benchee` in a real project's
+     * `.idea/libraries`.
+     */
+    fun testDepDeclaredOnlyByADependencyUnderOnlyProducesNoLibrary() {
+        val myApp = MixTestFixtures.createMixRootWithDeps(myFixture, "filtered_app", "cachex")
+        MixTestFixtures.addDeps(myFixture, "filtered_app", "cachex")
+        MixTestFixtures.createDepMixExs(
+            myFixture,
+            "filtered_app/deps/cachex",
+            "{:benchee, \"~> 1.0\", optional: true, only: [:bench]}",
+        )
+
+        val service = project.service<MixDepsSyncService>()
+        val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+
+        service.clearPendingForTesting()
+        service.enqueue(SyncRequest.MixFile(myApp.findChild("mix.exs")!!))
+        drainDirectly(service)
+
+        assertNull(
+            "A dep Mix will never fetch must not become a library. " +
+                "Libraries: ${libraryTable.libraries.mapNotNull { it.name }}",
+            libraryTable.libraries.firstOrNull { it.name?.startsWith("benchee") == true },
+        )
+    }
+
+    /**
      * A `SyncRequest.SyncRoot` (produced by resolving a `BuildPath` event for a registered content
      * root) scopes the sync to that single content root's deps, not all content roots.
      *

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.roots.LibraryOrderEntry
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
 import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
@@ -118,7 +119,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         val depRoot = myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix")
         myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix/lib")
         MixTestFixtures.addBuildArtifacts(myFixture, "my_app", "dev", "phoenix")
-        val phoenixLibName = scopedDepLibraryName(myApp.url, "phoenix")
+        val phoenixLibName = scopedDepLibraryName(contentRootToken(project, myApp.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -174,8 +175,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         val ectoRoot = myFixture.tempDirFixture.findOrCreateDir("my_app/deps/ecto")
         myFixture.tempDirFixture.findOrCreateDir("my_app/deps/ecto/lib")
         MixTestFixtures.addBuildArtifacts(myFixture, "my_app", "dev", "phoenix", "ecto")
-        val phoenixLibName = scopedDepLibraryName(myApp.url, "phoenix")
-        val ectoLibName = scopedDepLibraryName(myApp.url, "ecto")
+        val phoenixLibName = scopedDepLibraryName(contentRootToken(project, myApp.url), "phoenix")
+        val ectoLibName = scopedDepLibraryName(contentRootToken(project, myApp.url), "ecto")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -219,7 +220,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         val depRoot = myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix")
         myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix/lib")
         MixTestFixtures.addBuildArtifacts(myFixture, "my_app", "dev", "phoenix")
-        val phoenixLibName = scopedDepLibraryName(root.url, "phoenix")
+        val phoenixLibName = scopedDepLibraryName(contentRootToken(project, root.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -264,8 +265,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         MixTestFixtures.addBuildArtifacts(myFixture, "project_a", "dev", "phoenix")
         MixTestFixtures.addBuildArtifacts(myFixture, "project_b", "dev", "phoenix")
 
-        val libNameA = scopedDepLibraryName(rootA.url, "phoenix")
-        val libNameB = scopedDepLibraryName(rootB.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, rootA.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, rootB.url), "phoenix")
 
         // The two scoped names must be distinct.
         assertFalse(
@@ -303,8 +304,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         MixTestFixtures.addBuildArtifacts(myFixture, "project_a", "dev", "phoenix")
         MixTestFixtures.addBuildArtifacts(myFixture, "project_b", "dev", "phoenix")
 
-        val libNameA = scopedDepLibraryName(rootA.url, "phoenix")
-        val libNameB = scopedDepLibraryName(rootB.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, rootA.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, rootB.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -346,8 +347,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         MixTestFixtures.addBuildArtifacts(myFixture, "project_a", "dev", "phoenix")
         MixTestFixtures.addBuildArtifacts(myFixture, "project_b", "dev", "phoenix")
 
-        val libNameA = scopedDepLibraryName(rootA.url, "phoenix")
-        val libNameB = scopedDepLibraryName(rootB.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, rootA.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, rootB.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -392,8 +393,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         // project_b has no phoenix ebin artifact.
         myFixture.tempDirFixture.findOrCreateDir("project_b/_build/dev/consolidated")
 
-        val libNameA = scopedDepLibraryName(rootA.url, "phoenix")
-        val libNameB = scopedDepLibraryName(rootB.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, rootA.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, rootB.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -428,7 +429,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         val depRoot = myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix")
         myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix/lib")
         MixTestFixtures.addBuildArtifacts(myFixture, "my_app", "dev", "phoenix")
-        val phoenixLibName = scopedDepLibraryName(myApp.url, "phoenix")
+        val phoenixLibName = scopedDepLibraryName(contentRootToken(project, myApp.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -478,7 +479,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         val depRoot = myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix")
         myFixture.tempDirFixture.findOrCreateDir("my_app/deps/phoenix/lib")
         MixTestFixtures.addBuildArtifacts(myFixture, "my_app", "dev", "phoenix")
-        val scopedLibName = scopedDepLibraryName(myApp.url, "phoenix")
+        val scopedLibName = scopedDepLibraryName(contentRootToken(project, myApp.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -611,8 +612,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         MixTestFixtures.addBuildArtifacts(myFixture, "project_a", "dev", "phoenix")
         MixTestFixtures.addBuildArtifacts(myFixture, "project_b", "dev", "phoenix")
 
-        val libNameA = scopedDepLibraryName(rootA.url, "phoenix")
-        val libNameB = scopedDepLibraryName(rootB.url, "phoenix")
+        val libNameA = scopedDepLibraryName(contentRootToken(project, rootA.url), "phoenix")
+        val libNameB = scopedDepLibraryName(contentRootToken(project, rootB.url), "phoenix")
 
         val service = project.service<MixDepsSyncService>()
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
@@ -666,7 +667,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         // Seed the library table:
         //   (a) scoped placeholder with Kind but NO roots (simulates an unfetched dep)
         //   (b) user library without Kind (must survive delete)
-        val placeholderName = scopedDepLibraryName(contentRootUrl, "placeholder_dep")
+        val placeholderName = scopedDepLibraryName(contentRootToken(project, contentRootUrl), "placeholder_dep")
         WriteAction.run<Throwable> {
             val model = libraryTable.modifiableModel
             model.createLibrary(placeholderName, MixLibraryKind)  // placeholder - no roots added
@@ -805,7 +806,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
 
         // Seed: create the phoenix library so we can verify it is re-created by the SyncRoot.
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
-        val phoenixLibName = scopedDepLibraryName(app.url, "phoenix")
+        val phoenixLibName = scopedDepLibraryName(contentRootToken(project, app.url), "phoenix")
         service.enqueue(SyncRequest.DepRoot(myFixture.tempDirFixture.getFile("app/deps/phoenix")!!))
         drainDirectly(service)
         assertNotNull("phoenix library must exist after seed", libraryTable.getLibraryByName(phoenixLibName))
@@ -931,7 +932,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         PsiTestUtil.addContentRoot(myFixture.module, myApp)
 
         val contentRootUrl = myApp.url
-        val libName = scopedDepLibraryName(contentRootUrl, "phoenix")
+        val rootToken = contentRootToken(project, contentRootUrl)
+        val libName = scopedDepLibraryName(rootToken, "phoenix")
 
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
 
@@ -951,6 +953,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
             libraryPlans = listOf(
                 LibraryRootsPlan(
                     contentRootUrl = contentRootUrl,
+                    contentRootToken = rootToken,
                     depName = "phoenix",
                     classRootUrls = emptyList(),
                     sourceRootUrls = listOf(libNew.url),
@@ -987,7 +990,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         PsiTestUtil.addContentRoot(myFixture.module, myApp)
 
         val contentRootUrl = myApp.url
-        val libName = scopedDepLibraryName(contentRootUrl, "phoenix")
+        val rootToken = contentRootToken(project, contentRootUrl)
+        val libName = scopedDepLibraryName(rootToken, "phoenix")
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
 
         // Seed with the exact same source roots as the plan.
@@ -1005,6 +1009,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
             libraryPlans = listOf(
                 LibraryRootsPlan(
                     contentRootUrl = contentRootUrl,
+                    contentRootToken = rootToken,
                     depName = "phoenix",
                     classRootUrls = emptyList(),
                     sourceRootUrls = listOf(libDir.url),
@@ -1036,7 +1041,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
      */
     fun testApplyWritePlan_nonExistentModuleSkippedGracefully() {
         val contentRootUrl = myFixture.tempDirFixture.findOrCreateDir("stale_test").url
-        val libName = scopedDepLibraryName(contentRootUrl, "phoenix")
+        val libName = scopedDepLibraryName(contentRootToken(project, contentRootUrl), "phoenix")
 
         val writePlan = WritePlan(
             librariesToRemove = emptyList(),
@@ -1102,7 +1107,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         service.enqueue(SyncRequest.DepRoot(depsPhoenix))
         drainDirectly(service)
 
-        val libName = scopedDepLibraryName(myApp.url, "phoenix")
+        val libName = scopedDepLibraryName(contentRootToken(project, myApp.url), "phoenix")
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
         val lib = libraryTable.getLibraryByName(libName)
 
@@ -1139,7 +1144,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         PsiTestUtil.addContentRoot(myFixture.module, myApp)
 
         val contentRootUrl = myApp.url
-        val libName = scopedDepLibraryName(contentRootUrl, "placeholder_dep")
+        val libName = scopedDepLibraryName(contentRootToken(project, contentRootUrl), "placeholder_dep")
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
 
         // Seed the library so it exists in the snapshot.
@@ -1202,7 +1207,8 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         PsiTestUtil.addContentRoot(myFixture.module, myApp)
 
         val contentRootUrl = myApp.url
-        val libName = scopedDepLibraryName(contentRootUrl, "phoenix")
+        val rootToken = contentRootToken(project, contentRootUrl)
+        val libName = scopedDepLibraryName(rootToken, "phoenix")
         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
 
         // Seed the library with the same roots the re-sync will request - this is the critical
@@ -1221,10 +1227,11 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         // same roots (simulating a delete event immediately followed by a re-sync event in the
         // same coalesced drain).
         val syncPlan = SyncPlan(
-            deleteOnes = listOf(DeleteOnePlan("phoenix", contentRootUrl)),
+            deleteOnes = listOf(DeleteOnePlan("phoenix", contentRootUrl, rootToken)),
             libraryPlans = listOf(
                 LibraryRootsPlan(
                     contentRootUrl = contentRootUrl,
+                    contentRootToken = rootToken,
                     depName = "phoenix",
                     classRootUrls = emptyList(),
                     sourceRootUrls = listOf(libDir.url),
@@ -1260,9 +1267,169 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         WriteAction.run<Throwable> { libraryTable.getLibraryByName(libName)?.let { libraryTable.removeLibrary(it) } }
     }
 
+    /**
+     * Deleting a deps directory must remove that root's libraries under either scope scheme. The
+     * match is by name suffix, so a project last synced by an older version - whose names carry the
+     * absolute URL - would otherwise keep every library it had.
+     */
+    fun testBuildWritePlan_deleteAllRemovesBothScopeSchemes() {
+        val myApp = myFixture.tempDirFixture.findOrCreateDir("delete_all_schemes")
+        myFixture.tempDirFixture.findOrCreateDir("delete_all_schemes/deps")
+        PsiTestUtil.addContentRoot(myFixture.module, myApp)
+
+        val contentRootUrl = myApp.url
+        val currentName = scopedDepLibraryName(contentRootToken(project, contentRootUrl), "phoenix")
+        val olderSchemeName = scopedDepLibraryName(contentRootUrl, "ecto")
+
+        WriteAction.run<Throwable> {
+            val model = LibraryTablesRegistrar.getInstance().getLibraryTable(project).modifiableModel
+            model.createLibrary(currentName, MixLibraryKind)
+            if (olderSchemeName != currentName) model.createLibrary(olderSchemeName, MixLibraryKind)
+            model.commit()
+        }
+
+        val plan = SyncPlan(deleteAlls = listOf(DeleteAllPlan("$contentRootUrl/deps")))
+        val writePlan = runSuspendOnPooledThread { buildWritePlan(project, plan) }
+
+        assertTrue(
+            "The current scheme's library must be removed. Removing: ${writePlan.librariesToRemove}",
+            currentName in writePlan.librariesToRemove
+        )
+        assertTrue(
+            "A library named by the older scheme must be removed too. " +
+                "Removing: ${writePlan.librariesToRemove}",
+            olderSchemeName in writePlan.librariesToRemove
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // One dep, one library entry per module
+    // ------------------------------------------------------------------
+
+    /**
+     * An entry the plugin wrote under an older scope scheme must be removed once the dep is wired
+     * under the current one, or a module collects an entry per scheme the plugin has shipped.
+     * Recognised by the `"<dep> [<token>]"` shape, so a bare name - possibly a user's own library -
+     * is left strictly alone.
+     */
+    fun testBuildWritePlan_removesEntriesScopedByAnOlderScheme() {
+        val myApp = myFixture.tempDirFixture.findOrCreateDir("supersede_app")
+        val ebin = myFixture.tempDirFixture.findOrCreateDir("supersede_app/_build/dev/lib/phoenix/ebin")
+        PsiTestUtil.addContentRoot(myFixture.module, myApp)
+
+        val contentRootUrl = myApp.url
+        val rootToken = contentRootToken(project, contentRootUrl)
+        val newName = scopedDepLibraryName(rootToken, "phoenix")
+        val legacyUnscoped = "phoenix"
+        // A token that is not a current content root, which is the shape every superseded scheme
+        // takes once the plugin stops writing it.  Deliberately a *valid* library: the removal used
+        // to be guarded on invalidity, which is exactly what let these accumulate.
+        val supersededName = scopedDepLibraryName("file:///gone/previous/scheme/root", "phoenix")
+        assertFalse("Fixture needs the two names to differ", newName == supersededName)
+
+        WriteAction.run<Throwable> {
+            val model = LibraryTablesRegistrar.getInstance().getLibraryTable(project).modifiableModel
+            model.createLibrary(legacyUnscoped, MixLibraryKind)
+            model.createLibrary(supersededName, MixLibraryKind)
+            model.commit()
+            ModuleRootModificationUtil.updateModel(myFixture.module) { rootModel ->
+                val table = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+                rootModel.addLibraryEntry(table.getLibraryByName(legacyUnscoped)!!)
+                rootModel.addLibraryEntry(table.getLibraryByName(supersededName)!!)
+            }
+        }
+
+        val plan = SyncPlan(
+            libraryPlans = listOf(
+                LibraryRootsPlan(
+                    contentRootUrl = contentRootUrl,
+                    contentRootToken = rootToken,
+                    depName = "phoenix",
+                    classRootUrls = listOf(ebin.url),
+                    sourceRootUrls = emptyList(),
+                    excludeFolders = emptyList(),
+                )
+            ),
+            modulePlans = listOf(
+                ModuleDepsPlan(
+                    moduleName = myFixture.module.name,
+                    moduleDeps = emptySet(),
+                    libraryDeps = setOf(newName),
+                    externalLibraryPlans = emptyList(),
+                )
+            ),
+        )
+
+        val writePlan = runSuspendOnPooledThread { buildWritePlan(project, plan) }
+        val op = writePlan.moduleWriteOps.single { it.moduleName == myFixture.module.name }
+
+        assertTrue("The current scoped name must be wired", newName in op.addLibraryDeps)
+        assertFalse(
+            "A bare name may be a user library and must be left alone. Removed: ${op.removeStaleLibraryDeps}",
+            legacyUnscoped in op.removeStaleLibraryDeps
+        )
+        assertTrue(
+            "The entry scoped by the older scheme must be removed even though its library is valid. " +
+                "Removed: ${op.removeStaleLibraryDeps}",
+            supersededName in op.removeStaleLibraryDeps
+        )
+        assertFalse(
+            "The entry being wired must never be removed",
+            newName in op.removeStaleLibraryDeps
+        )
+    }
+
+
+    // ------------------------------------------------------------------
+    // contentRootToken
+    // ------------------------------------------------------------------
+
+    /**
+     * A content root under the project base directory scopes to its relative path, matching the
+     * `$PROJECT_DIR$/apps/child` the platform already writes for that library's roots.
+     */
+    fun testContentRootToken_belowProjectBaseIsRelative() {
+        val basePath = projectBasePath()
+        assertEquals("apps/child", contentRootToken(project, "file://$basePath/apps/child"))
+    }
+
+    /** The base directory itself is ".", never "" - "" is the separate "no owning root" fallback. */
+    fun testContentRootToken_projectBaseIsDot() {
+        val basePath = projectBasePath()
+        assertEquals(".", contentRootToken(project, "file://$basePath"))
+    }
+
+    /**
+     * A Mix module that is part of the project but sits outside its base directory scopes to a
+     * `../`-prefixed path.  `PathMacroManager.addFileHierarchyReplacements` walks to the filesystem
+     * root, so the platform writes such a library's roots as `$PROJECT_DIR$/../...` - the name has to
+     * relocate on that same boundary or it would be less shareable than the roots it names.
+     */
+    fun testContentRootToken_outsideProjectBaseIsParentRelative() {
+        val basePath = projectBasePath()
+        val parent = basePath.substringBeforeLast('/', "")
+        assertTrue("Test needs a project base with a parent directory, got '$basePath'", parent.contains('/'))
+        val token = contentRootToken(project, "file://$parent/sibling_mix_app")
+        assertTrue("Expected a ../-prefixed token, got '$token'", token.startsWith("../"))
+        assertTrue("Expected the module directory in the token, got '$token'", token.endsWith("sibling_mix_app"))
+    }
+
+    /** No relative path can span two drives or mounts, so the absolute URL is kept unchanged. */
+    fun testContentRootToken_unrelatedRootKeepsAbsoluteUrl() {
+        val url = "file://nonexistent-mount-0/elsewhere/mix_app"
+        assertEquals(url, contentRootToken(project, url))
+    }
+
     // ------------------------------------------------------------------
     // Helpers
     // ------------------------------------------------------------------
+
+    /** Asserted rather than skipped: a silent return would pass without testing anything. */
+    private fun projectBasePath(): String {
+        val basePath = project.basePath
+        assertNotNull("Test fixture must provide a project base path", basePath)
+        return basePath!!
+    }
 
     /**
      * Runs an arbitrary [suspend] block on a pooled thread while the EDT (test thread) continues

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
@@ -1379,7 +1379,6 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         )
     }
 
-
     // ------------------------------------------------------------------
     // Sync Dependency Libraries action
     // ------------------------------------------------------------------
@@ -1404,6 +1403,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
         assertEquals("The action must enqueue exactly one request", 1, service.pendingCount)
         service.clearPendingForTesting()
     }
+
     // ------------------------------------------------------------------
     // contentRootToken
     // ------------------------------------------------------------------

--- a/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixDepsSyncServiceTest.kt
@@ -1492,7 +1492,7 @@ class MixDepsSyncServiceTest : PlatformTestCase() {
      * pumping its event queue.  Delegates to [MixSyncTestHelpers.runSuspendOnPooledThread].
      */
     private fun <T> runSuspendOnPooledThread(block: suspend () -> T): T =
-        MixSyncTestHelpers.runSuspendOnPooledThread(block)
+        MixSyncTestHelpers.runSuspendOnPooledThread(block = block)
 
     /**
      * Calls [MixDepsSyncService.drain] directly on a pooled thread (bypassing the 250 ms debounce),

--- a/tests/org/elixir_lang/mix/sync/MixLibraryReconcilerTest.kt
+++ b/tests/org/elixir_lang/mix/sync/MixLibraryReconcilerTest.kt
@@ -1,0 +1,135 @@
+package org.elixir_lang.mix.sync
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.mix.library.Kind as MixLibraryKind
+
+/**
+ * Tests for the startup escalation check.
+ *
+ * The steady-state answer is the one that matters for cost: a project whose libraries are fine must
+ * not trigger a full sync, because that would reintroduce the deps/`_build` scan on every open.
+ */
+class MixLibraryReconcilerTest : PlatformTestCase() {
+
+    /**
+     * Each case asserts on the whole library table, so it must start empty. Cleaning only in
+     * tearDown leaves the result depending on method order, which JUnit 3 does not fix.
+     */
+    override fun setUp() {
+        super.setUp()
+        MixSyncTestHelpers.removeAllLibraries(project)
+    }
+
+    override fun tearDown() {
+        runAll(
+            { MixTestFixtures.removeAllContentRoots(myFixture) },
+            { MixSyncTestHelpers.removeAllLibraries(project) },
+            { super.tearDown() }
+        )
+    }
+
+    private fun reconcilerNeedsResync(): Boolean =
+        MixSyncTestHelpers.runSuspendOnPooledThread { MixLibraryReconciler.needsResync(project) }
+
+    private fun createMixLibrary(name: String, classRootUrl: String?) {
+        WriteAction.run<Throwable> {
+            val model = LibraryTablesRegistrar.getInstance().getLibraryTable(project).modifiableModel
+            val library = model.createLibrary(name, MixLibraryKind)
+            classRootUrl?.let {
+                library.modifiableModel.let { lm ->
+                    lm.addRoot(it, OrderRootType.CLASSES)
+                    lm.commit()
+                }
+            }
+            model.commit()
+        }
+    }
+
+    fun testNoLibrariesNeedsNoResync() {
+        assertFalse("An empty library table must not trigger a full sync", reconcilerNeedsResync())
+    }
+
+    /** The common case, and the one the cost argument rests on. */
+    fun testCurrentRootScopedLibraryWithLiveRootsNeedsNoResync() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("reconcile_ok")
+        val ebin = myFixture.tempDirFixture.findOrCreateDir("reconcile_ok/_build/dev/lib/phoenix/ebin")
+        PsiTestUtil.addContentRoot(myFixture.module, root)
+
+        createMixLibrary(scopedDepLibraryName(contentRootToken(project, root.url), "phoenix"), ebin.url)
+
+        assertFalse("A library scoped to a current root with live roots must not resync", reconcilerNeedsResync())
+    }
+
+    /** A placeholder for a declared-but-unfetched dep is deliberate and has no roots to dangle. */
+    fun testPlaceholderWithNoRootsNeedsNoResync() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("reconcile_placeholder")
+        PsiTestUtil.addContentRoot(myFixture.module, root)
+
+        createMixLibrary(scopedDepLibraryName(contentRootToken(project, root.url), "unfetched"), null)
+
+        assertFalse("An empty placeholder must not trigger a full sync", reconcilerNeedsResync())
+    }
+
+    /** deps/ removed while the IDE was closed: the library survives, its roots do not. */
+    fun testDanglingRootNeedsResync() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("reconcile_dangling")
+        PsiTestUtil.addContentRoot(myFixture.module, root)
+
+        createMixLibrary(
+            scopedDepLibraryName(contentRootToken(project, root.url), "phoenix"),
+            "${root.url}/_build/dev/lib/phoenix/ebin",
+        )
+
+        assertTrue("A library root the VFS cannot resolve must trigger a full sync", reconcilerNeedsResync())
+    }
+
+    /**
+     * A library scoped by an older scheme to a root that is *still current* must be detected. This
+     * is the whole-project upgrade case: every name is in the old form, so treating that form as
+     * current would report the one project that most needs re-syncing as healthy.
+     */
+    fun testLibraryScopedByOlderSchemeToCurrentRootNeedsResync() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("reconcile_old_scheme")
+        PsiTestUtil.addContentRoot(myFixture.module, root)
+
+        val currentToken = contentRootToken(project, root.url)
+        val olderScheme = "file:///previous/scheme/${root.name}"
+        assertFalse("Fixture needs the two schemes to differ", currentToken == olderScheme)
+
+        createMixLibrary(scopedDepLibraryName(olderScheme, "phoenix"), null)
+
+        assertTrue(
+            "A name scoped by a superseded scheme must trigger a full sync",
+            reconcilerNeedsResync()
+        )
+    }
+
+    /**
+     * A name scoped to a root the project no longer has - which is also the shape of every name
+     * written before scope tokens became project-relative, so upgrades migrate on the next open.
+     */
+    fun testForeignScopeTokenNeedsResync() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("reconcile_foreign")
+        PsiTestUtil.addContentRoot(myFixture.module, root)
+
+        createMixLibrary(scopedDepLibraryName("file:///gone/elsewhere/mix_root", "phoenix"), null)
+
+        assertTrue("A scope token naming no current content root must trigger a full sync", reconcilerNeedsResync())
+    }
+
+    /** Unscoped and consolidated names are not this check's business. */
+    fun testUnscopedAndConsolidatedNamesNeedNoResync() {
+        val root = myFixture.tempDirFixture.findOrCreateDir("reconcile_unscoped")
+        PsiTestUtil.addContentRoot(myFixture.module, root)
+
+        createMixLibrary("phoenix", null)
+        createMixLibrary("reconcile_unscoped (consolidated)", null)
+
+        assertFalse("Names without a scope token must not trigger a full sync", reconcilerNeedsResync())
+    }
+}

--- a/tests/org/elixir_lang/mix/sync/MixSyncTestHelpers.kt
+++ b/tests/org/elixir_lang/mix/sync/MixSyncTestHelpers.kt
@@ -27,7 +27,7 @@ internal object MixSyncTestHelpers {
      * [com.intellij.openapi.application.readAction] / [com.intellij.openapi.application.edtWriteAction])
      * and would deadlock if invoked via plain [runBlocking] from the EDT test thread.
      */
-    fun <T> runSuspendOnPooledThread(block: suspend () -> T): T {
+    fun <T> runSuspendOnPooledThread(timeoutMillis: Long = 10_000L, block: suspend () -> T): T {
         var result: T? = null
         var error: Throwable? = null
         val done = AtomicBoolean(false)
@@ -42,10 +42,10 @@ internal object MixSyncTestHelpers {
             }
             done.set(true)
         }
-        val deadline = System.currentTimeMillis() + 10_000L
+        val deadline = System.currentTimeMillis() + timeoutMillis
         while (!done.get()) {
             if (System.currentTimeMillis() >= deadline) {
-                throw AssertionError("runSuspendOnPooledThread timed out after 10 s")
+                throw AssertionError("runSuspendOnPooledThread timed out after ${timeoutMillis} ms")
             }
             PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
         }

--- a/tests/org/elixir_lang/mix/sync/MixTestFixtures.kt
+++ b/tests/org/elixir_lang/mix/sync/MixTestFixtures.kt
@@ -130,6 +130,40 @@ object MixTestFixtures {
     }
 
     /**
+     * Writes a `mix.exs` at [rootPath] declaring [depTuples] verbatim, and does **not** register a
+     * content root - the shape of a dependency's own package file.
+     *
+     * The tuples are source text rather than names so a caller can attach the option under test,
+     * which [createMixRootWithDeps]'s bare `{:name, ">= 0.0.0"}` output cannot express.
+     */
+    fun createDepMixExs(fixture: CodeInsightTestFixture, rootPath: String, depTuples: String): VirtualFile {
+        val root = fixture.tempDirFixture.findOrCreateDir(rootPath)
+        val application = rootPath.substringAfterLast('/')
+        val moduleName = application.split("_").joinToString("") { it.replaceFirstChar(Char::uppercase) }
+
+        fixture.tempDirFixture.createFile(
+            "$rootPath/mix.exs",
+            "defmodule ${moduleName}.MixProject do\n" +
+                "  use Mix.Project\n" +
+                "\n" +
+                "  def project do\n" +
+                "    [\n" +
+                "      app: :$application,\n" +
+                "      version: \"0.1.0\",\n" +
+                "      deps: deps()\n" +
+                "    ]\n" +
+                "  end\n" +
+                "\n" +
+                "  def deps do\n" +
+                "    [$depTuples]\n" +
+                "  end\n" +
+                "end\n"
+        )
+
+        return root
+    }
+
+    /**
      * Creates multiple independent (non-nested) Mix project roots.
      *
      * Each root path gets a `mix.exs`. Suitable for multi-module workspace fixtures and for the

--- a/tests/org/elixir_lang/mix/sync/ScopedLibraryNameTest.kt
+++ b/tests/org/elixir_lang/mix/sync/ScopedLibraryNameTest.kt
@@ -3,7 +3,7 @@ package org.elixir_lang.mix.sync
 import junit.framework.TestCase
 
 /**
- * Unit tests for [scopedLibraryNameContentRootUrl], the inverse of [scopedDepLibraryName].
+ * Unit tests for [scopedLibraryNameToken], the inverse of [scopedDepLibraryName].
  *
  * The parser guards stale-entry pruning: a wrong parse can misclassify an invalid placeholder
  * entry scoped to a CURRENT content root as stale and delete it, so the edge cases here matter.
@@ -12,12 +12,12 @@ class ScopedLibraryNameTest : TestCase() {
 
     fun testRoundTripsScopedDepLibraryName() {
         val url = "file:///home/dev/workspace/my_project"
-        assertEquals(url, scopedLibraryNameContentRootUrl(scopedDepLibraryName(url, "phoenix")))
+        assertEquals(url, scopedLibraryNameToken(scopedDepLibraryName(url, "phoenix")))
     }
 
     fun testRoundTripsWslUrl() {
         val url = "file:////wsl.localhost/Ubuntu-24.04/home/dev/workspace/my_project"
-        assertEquals(url, scopedLibraryNameContentRootUrl(scopedDepLibraryName(url, "ecto")))
+        assertEquals(url, scopedLibraryNameToken(scopedDepLibraryName(url, "ecto")))
     }
 
     /**
@@ -28,23 +28,47 @@ class ScopedLibraryNameTest : TestCase() {
      */
     fun testRoundTripsUrlContainingBracketMarker() {
         val url = "file:///home/dev/work [old]/my_project"
-        assertEquals(url, scopedLibraryNameContentRootUrl(scopedDepLibraryName(url, "phoenix")))
+        assertEquals(url, scopedLibraryNameToken(scopedDepLibraryName(url, "phoenix")))
+    }
+
+    /**
+     * The relative form is what reaches version control, so a regression here is a regression in
+     * whether `.idea` can be shared between clones.
+     */
+    fun testRoundTripsRelativeToken() {
+        assertEquals("apps/child", scopedLibraryNameToken(scopedDepLibraryName("apps/child", "phoenix")))
+    }
+
+    fun testRoundTripsProjectRootToken() {
+        assertEquals(".", scopedLibraryNameToken(scopedDepLibraryName(".", "phoenix")))
+    }
+
+    fun testRoundTripsSiblingToken() {
+        assertEquals("../shared_lib", scopedLibraryNameToken(scopedDepLibraryName("../shared_lib", "phoenix")))
+    }
+
+    /**
+     * The "no owning root known" fallback must stay distinct from the project root's `"."`, or
+     * every rootless module's placeholder would be scoped to the project root.
+     */
+    fun testRoundTripsEmptyToken() {
+        assertEquals("", scopedLibraryNameToken(scopedDepLibraryName("", "phoenix")))
     }
 
     fun testUnscopedNameReturnsNull() {
-        assertNull(scopedLibraryNameContentRootUrl("phoenix"))
+        assertNull(scopedLibraryNameToken("phoenix"))
     }
 
     fun testConsolidatedLibraryNameReturnsNull() {
-        assertNull(scopedLibraryNameContentRootUrl("my_project (consolidated)"))
+        assertNull(scopedLibraryNameToken("my_project (consolidated)"))
     }
 
     fun testNameWithMarkerButNoClosingBracketReturnsNull() {
-        assertNull(scopedLibraryNameContentRootUrl("phoenix [file:///home/dev/my_project"))
+        assertNull(scopedLibraryNameToken("phoenix [file:///home/dev/my_project"))
     }
 
     fun testNameStartingWithMarkerReturnsNull() {
         // markerIndex == 0 means there is no dep-name prefix - not a scoped name.
-        assertNull(scopedLibraryNameContentRootUrl(" [file:///home/dev/my_project]"))
+        assertNull(scopedLibraryNameToken(" [file:///home/dev/my_project]"))
     }
 }

--- a/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
+++ b/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
@@ -292,6 +292,28 @@ class TransitiveResolutionTest : PlatformTestCase() {
     }
 
     /**
+     * The deps directory an app resolves through owns everything reached through it, however deep.
+     *
+     * A two-level chain passes as soon as the app itself can find the umbrella's `deps`, so it
+     * cannot tell whether that answer carries. The third level is the discriminating one: its
+     * declaring root is `deps/<dep>`, which no handed-in root is an ancestor of. Refs
+     * [#3986](https://github.com/KronicDeth/intellij-elixir/issues/3986).
+     */
+    fun testDepsOfDepsResolveAtEveryDepthWhenOnlyTheAppIsHandedIn() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val app = mixProject("$u/apps/app_a", "{:level_one, \">= 0.0.0\"}")
+        mixProject("$u/deps/level_one", "{:level_two, \">= 0.0.0\"}")
+        mixProject("$u/deps/level_two", "{:level_three, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(app)
+
+        assertTrue("The app's own dep is reached: $applications", "level_one" in applications)
+        assertTrue("A dep of that dep is reached: $applications", "level_two" in applications)
+        assertTrue("The chain does not stop at two levels: $applications", "level_three" in applications)
+    }
+
+    /**
      * `deps_path:` is not umbrella-only - any project may move its deps directory, and then
      * `deps/<name>` beside the `mix.exs` is not where Mix checks anything out.
      */

--- a/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
+++ b/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
@@ -313,6 +313,106 @@ class TransitiveResolutionTest : PlatformTestCase() {
         assertTrue("The chain does not stop at two levels: $applications", "level_three" in applications)
     }
 
+    // -----------------------------------------------------------------
+    // Across an `in_umbrella:` sibling
+    // -----------------------------------------------------------------
+
+    /**
+     * Since Elixir 1.15.0 the compiler prunes the code path to the apps the project's own declared
+     * deps reach, so `{:app_b, in_umbrella: true}` is what makes everything `app_b` declares
+     * available to `app_a`. Nothing walked into `app_b`'s `mix.exs`, so those deps reached no
+     * module of the project and Go to Definition had nowhere to land. Refs
+     * [#3990](https://github.com/KronicDeth/intellij-elixir/issues/3990).
+     */
+    fun testSiblingsDepsAreReachedThroughAnInUmbrellaDep() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val appA = mixProject("$u/apps/app_a", "{:app_b, in_umbrella: true}")
+        mixProject("$u/apps/app_b", "{:shared, \">= 0.0.0\"}")
+        mixProject("$u/deps/shared", "")
+
+        val applications = applicationsFrom(appA)
+
+        assertTrue("The sibling itself stays reachable: $applications", "app_b" in applications)
+        assertTrue("What the sibling declares is reached: $applications", "shared" in applications)
+    }
+
+    /**
+     * `apps/<name>` is relative to the umbrella root, never to the app that wrote it - there is no
+     * `apps/app_a/apps/app_b`. The case above passes for either base whenever the umbrella root
+     * happens to be handed in; handing in only the app is what discriminates.
+     */
+    fun testSiblingIsFoundUnderTheUmbrellaWhenOnlyTheAppIsHandedIn() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val appA = mixProject("$u/apps/app_a", "{:app_b, in_umbrella: true}")
+        mixProject("$u/apps/app_b", "{:from_sibling, \">= 0.0.0\"}")
+        mixProject("$u/deps/from_sibling", "")
+
+        assertTrue(
+            "The sibling resolves under the umbrella, not under the declaring app",
+            "from_sibling" in applicationsFrom(appA),
+        )
+    }
+
+    /**
+     * Mix's reachability is transitive through the declared-dep graph - `Mix.AppLoader.load_apps/5`
+     * walks each dep's own children - so a sibling's sibling, and the deps that one declares, are
+     * available too.
+     */
+    fun testSiblingsAreWalkedTransitively() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val appA = mixProject("$u/apps/app_a", "{:app_b, in_umbrella: true}")
+        mixProject("$u/apps/app_b", "{:app_c, in_umbrella: true}")
+        mixProject("$u/apps/app_c", "{:deep, \">= 0.0.0\"}")
+        mixProject("$u/deps/deep", "")
+
+        val applications = applicationsFrom(appA)
+
+        assertTrue("A sibling's own sibling is reached: $applications", "app_c" in applications)
+        assertTrue("And what that one declares: $applications", "deep" in applications)
+    }
+
+    /**
+     * Umbrella apps declaring each other is an ordinary shape, so the walk has to terminate on a
+     * cycle rather than resolve one. A `deps/` graph is acyclic, so nothing before this could
+     * produce one.
+     */
+    fun testMutualInUmbrellaDepsTerminate() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val appA = mixProject("$u/apps/app_a", "{:app_b, in_umbrella: true}")
+        mixProject("$u/apps/app_b", "{:app_a, in_umbrella: true}, {:shared, \">= 0.0.0\"}")
+        mixProject("$u/deps/shared", "")
+
+        assertEquals(setOf("app_a", "app_b", "shared"), applicationsFrom(appA))
+    }
+
+    /**
+     * A sibling is an app of the project being built, not something Mix fetched, so its deps are
+     * read at a project position: `mix deps.get` fetches every environment's for an umbrella app,
+     * and an optional dep of one is the umbrella's to resolve. Reaching a sibling through a MODULE
+     * dep must not demote it to a dependency's `:prod`-only reading.
+     */
+    fun testASiblingsDepsAreReadAtAProjectPosition() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val appA = mixProject("$u/apps/app_a", "{:app_b, in_umbrella: true}")
+        mixProject(
+            "$u/apps/app_b",
+            "{:mox, \">= 0.0.0\", only: [:test]},\n" +
+                "{:jason, \">= 0.0.0\", optional: true}"
+        )
+        mixProject("$u/deps/mox", "")
+        mixProject("$u/deps/jason", "")
+
+        val applications = applicationsFrom(appA)
+
+        assertTrue("An umbrella app's environment-restricted dep is kept: $applications", "mox" in applications)
+        assertTrue("So is its optional one: $applications", "jason" in applications)
+    }
+
     /**
      * `deps_path:` is not umbrella-only - any project may move its deps directory, and then
      * `deps/<name>` beside the `mix.exs` is not where Mix checks anything out.

--- a/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
+++ b/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
@@ -21,10 +21,16 @@ import org.elixir_lang.mix.watcher.TransitiveResolution.transitiveResolution
  */
 class TransitiveResolutionTest : PlatformTestCase() {
 
-    /** The dep applications reachable from [roots], which is what the sync pipeline consumes. */
+    /**
+     * The dep applications reachable from [roots], which is what the sync pipeline consumes.
+     *
+     * The longer deadline is for the fixture, not the product: a case here walks a chain of
+     * `mix.exs` files and each one is parsed from scratch, where the helper's default assumes a
+     * single file.
+     */
     private fun applicationsFrom(vararg roots: VirtualFile): Set<String> =
         MixSyncTestHelpers
-            .runSuspendOnPooledThread {
+            .runSuspendOnPooledThread(timeoutMillis = 60_000L) {
                 transitiveResolution(PsiManager.getInstance(project), EmptyProgressIndicator(), *roots)
             }
             .map(Dep::application)
@@ -147,6 +153,105 @@ class TransitiveResolutionTest : PlatformTestCase() {
         )
 
         assertEquals(setOf("cachex", "jumper"), applicationsFrom(root))
+    }
+
+    // -----------------------------------------------------------------
+    // Where a dep's own deps are looked for
+    // -----------------------------------------------------------------
+
+    /**
+     * Mix converges every hex and git dep into the top-level project's `deps_path`, which
+     * `Mix.Project.deps_config/1` passes down already expanded to an absolute path. So a dep
+     * declared by a dependency is checked out *beside* it under the project, never nested inside
+     * it - `deps/cachex/deps/jumper` is a directory no Mix configuration produces.
+     *
+     * Resolving it there anyway ends the walk one level below every project root, so nothing deeper
+     * than a direct dep's own deps is ever seen.
+     */
+    fun testTransitiveDepsAreReachedThroughTheProjectsDepsDirectory() {
+        val path = nextFixturePath()
+        val root = mixProject(path, "{:cachex, \">= 0.0.0\"}")
+        mixProject("$path/deps/cachex", "{:jumper, \">= 0.0.0\"}")
+        mixProject("$path/deps/jumper", "{:mime, \">= 0.0.0\"}")
+        mixProject("$path/deps/mime", "")
+
+        assertEquals(setOf("cachex", "jumper", "mime"), applicationsFrom(root))
+    }
+
+    /**
+     * An explicit `path:` dep is the exception: `Mix.SCM.Path` expands it against the directory of
+     * the project that declared it, so one declared by a dependency really is relative to that
+     * dependency. Guards against resolving every dep against the project root.
+     */
+    fun testExplicitRelativePathDepOfADepIsResolvedAgainstTheDeclaringDep() {
+        val path = nextFixturePath()
+        val root = mixProject(path, "{:cachex, \">= 0.0.0\"}")
+        mixProject("$path/deps/cachex", "{:vendored, path: \"../vendored\"}")
+        mixProject("$path/deps/vendored", "{:deep, \">= 0.0.0\"}")
+        mixProject("$path/deps/deep", "")
+
+        assertEquals(setOf("cachex", "vendored", "deep"), applicationsFrom(root))
+    }
+
+    /**
+     * Two content roots that both carry `deps/shared` must not be confused for one another, which
+     * is the cross-root contamination scoped library names exist to prevent.
+     */
+    fun testDepResolutionStaysInTheDeclaringRoot() {
+        val a = nextFixturePath()
+        val b = nextFixturePath()
+        val rootA = mixProject(a, "{:dep_a, \">= 0.0.0\"}")
+        mixProject("$a/deps/dep_a", "{:shared, \">= 0.0.0\"}")
+        mixProject("$a/deps/shared", "{:only_in_a, \">= 0.0.0\"}")
+        val rootB = mixProject(b, "")
+        mixProject("$b/deps/shared", "{:only_in_b, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(rootA, rootB)
+
+        assertTrue(
+            "`shared` must resolve under the root that owns the dep declaring it: $applications",
+            "only_in_a" in applications,
+        )
+        assertFalse(
+            "`shared` must not resolve under an unrelated content root: $applications",
+            "only_in_b" in applications,
+        )
+    }
+
+    /**
+     * An umbrella app shares the umbrella's `deps`, `_build` and lock file, so it has no `deps` of
+     * its own and Mix never creates one. A directory there is debris from before the app joined the
+     * umbrella, and must not be preferred over the umbrella's.
+     */
+    fun testUmbrellaAppDepsResolveUnderTheUmbrella() {
+        val u = nextFixturePath()
+        val umbrella = mixProject(u, "", "      apps_path: \"apps\",\n")
+        val app = mixProject("$u/apps/app_a", "{:shared, \">= 0.0.0\"}")
+        mixProject("$u/deps/shared", "{:from_umbrella, \">= 0.0.0\"}")
+        mixProject("$u/apps/app_a/deps/shared", "{:from_app, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(umbrella, app)
+
+        assertTrue("The umbrella's deps own the app's deps: $applications", "from_umbrella" in applications)
+        assertFalse("An app's own deps directory is debris: $applications", "from_app" in applications)
+    }
+
+    /**
+     * A content root that is not an umbrella app is its own Mix project, so it keeps its own `deps`
+     * rather than deferring to a root it happens to sit inside. Guards against answering the case
+     * above by always taking the outermost root.
+     */
+    fun testNestedProjectRootKeepsItsOwnDeps() {
+        val p = nextFixturePath()
+        val outer = mixProject(p, "")
+        val inner = mixProject("$p/vendor/lib_a", "{:shared, \">= 0.0.0\"}")
+        mixProject("$p/deps/shared", "{:from_outer, \">= 0.0.0\"}")
+        mixProject("$p/vendor/lib_a/deps/shared", "{:from_inner, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(outer, inner)
+
+        assertTrue("A standalone nested project owns its deps: $applications", "from_inner" in applications)
+        assertFalse("It must not borrow the enclosing root's deps: $applications", "from_outer" in applications)
     }
 
     // -----------------------------------------------------------------

--- a/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
+++ b/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
@@ -1,0 +1,252 @@
+package org.elixir_lang.mix.watcher
+
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.mix.Dep
+import org.elixir_lang.mix.sync.MixSyncTestHelpers
+import org.elixir_lang.mix.watcher.TransitiveResolution.transitiveResolution
+
+/**
+ * Pins which deps [transitiveResolution] reaches, at each of the three positions a `mix.exs` can
+ * occupy: a project root, an umbrella app, and a dependency's own file.
+ *
+ * Every dep reached becomes a library the sync pipeline believes the project should have, so a dep
+ * Mix will never fetch becomes an empty placeholder library that no `mix deps.get` can fill.
+ * `only:` and `optional:` decide that, and both are **positional** - neither is a reason to drop a
+ * dep on its own. Mix fetches every environment's deps for a project it is building and exempts
+ * umbrella apps outright, while a dependency's own deps are resolved in `:prod` and are not entitled
+ * to its optional ones.
+ */
+class TransitiveResolutionTest : PlatformTestCase() {
+
+    /** The dep applications reachable from [roots], which is what the sync pipeline consumes. */
+    private fun applicationsFrom(vararg roots: VirtualFile): Set<String> =
+        MixSyncTestHelpers
+            .runSuspendOnPooledThread {
+                transitiveResolution(PsiManager.getInstance(project), EmptyProgressIndicator(), *roots)
+            }
+            .map(Dep::application)
+            .toSet()
+
+    /**
+     * Writes a `mix.exs` at [path] declaring [depTuples] verbatim, with [extraProjectKeys] added to
+     * `project/0` for the `apps_path:` an umbrella root needs.
+     *
+     * The tuples are source text rather than names so a case can attach the option under test.
+     */
+    private fun mixProject(path: String, depTuples: String, extraProjectKeys: String = ""): VirtualFile {
+        val directory = myFixture.tempDirFixture.findOrCreateDir(path)
+        val application = path.substringAfterLast('/')
+        val moduleName = application.split("_").joinToString("") { it.replaceFirstChar(Char::uppercase) }
+
+        // DepGatherer needs `deps: deps()` in project/0 before it will read `def deps`.
+        myFixture.tempDirFixture.createFile(
+            "$path/mix.exs",
+            "defmodule " + moduleName + ".MixProject do\n" +
+                "  use Mix.Project\n" +
+                "\n" +
+                "  def project do\n" +
+                "    [\n" +
+                "      app: :" + application + ",\n" +
+                "      version: \"0.1.0\",\n" +
+                extraProjectKeys +
+                "      deps: deps()\n" +
+                "    ]\n" +
+                "  end\n" +
+                "\n" +
+                "  def deps do\n" +
+                "    [" + depTuples + "]\n" +
+                "  end\n" +
+                "end\n"
+        )
+
+        return directory
+    }
+
+    /**
+     * Fixture directories are keyed on the test name, plus a counter so a case that asserts over
+     * several declarations does not write `mix.exs` into a directory it already used.
+     */
+    private var fixtureCount = 0
+
+    private fun nextFixturePath(): String = "${name}_${fixtureCount++}"
+
+    /** Resolution when the project root itself declares [depTuple]. */
+    private fun projectRootDeclaring(depTuple: String): Set<String> =
+        applicationsFrom(mixProject(nextFixturePath(), depTuple))
+
+    /** Resolution when an umbrella app declares [depTuple], resolved as the plugin resolves one. */
+    private fun umbrellaAppDeclaring(depTuple: String): Set<String> {
+        val path = nextFixturePath()
+        val umbrella = mixProject(path, "", "      apps_path: \"apps\",\n")
+        val app = mixProject("$path/apps/app_a", depTuple)
+
+        return applicationsFrom(umbrella, app)
+    }
+
+    /** Resolution when a dependency's own `mix.exs` declares [depTuple]. Always includes `cachex`. */
+    private fun dependencyDeclaring(depTuple: String): Set<String> {
+        val path = nextFixturePath()
+        val root = mixProject(path, "{:cachex, \">= 0.0.0\"}")
+        mixProject("$path/deps/cachex", depTuple)
+
+        return applicationsFrom(root)
+    }
+
+    private fun assertReachedAtProjectPositions(depTuple: String, application: String) {
+        assertEquals(
+            "A project root's own dep must be reached: $depTuple",
+            setOf(application),
+            projectRootDeclaring(depTuple),
+        )
+        assertEquals(
+            "An umbrella app's own dep must be reached: $depTuple",
+            setOf(application),
+            umbrellaAppDeclaring(depTuple),
+        )
+    }
+
+    private fun assertReachedInsideADep(depTuple: String, application: String) {
+        assertEquals(
+            "A dep Mix would fetch must be reached: $depTuple",
+            setOf("cachex", application),
+            dependencyDeclaring(depTuple),
+        )
+    }
+
+    private fun assertNotReachedInsideADep(depTuple: String) {
+        assertEquals(
+            "A dep Mix would not fetch must not be reached: $depTuple",
+            setOf("cachex"),
+            dependencyDeclaring(depTuple),
+        )
+    }
+
+    // -----------------------------------------------------------------
+    // Baseline
+    // -----------------------------------------------------------------
+
+    /** Without this the rest assert nothing: an option cannot be filtered out of a walk that never happens. */
+    fun testDepDeclaredByADepIsReached() {
+        val root = mixProject("reaches", "{:cachex, \">= 0.0.0\"}")
+        mixProject("reaches/deps/cachex", "{:jumper, \">= 0.0.0\"}")
+
+        assertEquals(setOf("cachex", "jumper"), applicationsFrom(root))
+    }
+
+    /** `cachex`'s own declarations: one real dep beside two that Mix will never fetch here. */
+    fun testOnlyTheFetchableDepsOfADepAreReached() {
+        val root = mixProject("mixed", "{:cachex, \">= 0.0.0\"}")
+        mixProject(
+            "mixed/deps/cachex",
+            "{:jumper, \"~> 1.0\"},\n" +
+                "{:excoveralls, \"~> 0.11\", optional: true, only: [:cover]},\n" +
+                "{:benchee, \"~> 1.0\", optional: true, only: [:bench]}"
+        )
+
+        assertEquals(setOf("cachex", "jumper"), applicationsFrom(root))
+    }
+
+    // -----------------------------------------------------------------
+    // Reached at every position
+    // -----------------------------------------------------------------
+
+    fun testUnrestrictedDepIsReachedEverywhere() {
+        assertReachedAtProjectPositions("{:jason, \">= 0.0.0\"}", "jason")
+        assertReachedInsideADep("{:jason, \">= 0.0.0\"}", "jason")
+    }
+
+    /** `:prod` is the environment a dep's own deps are resolved in, so this excludes nothing. */
+    fun testProdOnlyDepIsReachedEverywhere() {
+        assertReachedAtProjectPositions("{:jason, \">= 0.0.0\", only: [:prod]}", "jason")
+        assertReachedInsideADep("{:jason, \">= 0.0.0\", only: [:prod]}", "jason")
+    }
+
+    fun testSingleAtomProdOnlyDepIsReachedEverywhere() {
+        assertReachedAtProjectPositions("{:jason, \">= 0.0.0\", only: :prod}", "jason")
+        assertReachedInsideADep("{:jason, \">= 0.0.0\", only: :prod}", "jason")
+    }
+
+    fun testOnlyListIncludingProdIsReachedEverywhere() {
+        assertReachedAtProjectPositions("{:jason, \">= 0.0.0\", only: [:dev, :prod]}", "jason")
+        assertReachedInsideADep("{:jason, \">= 0.0.0\", only: [:dev, :prod]}", "jason")
+    }
+
+    fun testOptionalFalseDepIsReachedEverywhere() {
+        assertReachedAtProjectPositions("{:jason, \">= 0.0.0\", optional: false}", "jason")
+        assertReachedInsideADep("{:jason, \">= 0.0.0\", optional: false}", "jason")
+    }
+
+    /**
+     * Every `only:` shape the plugin cannot read must keep the dep at every position. Dropping a dep
+     * that is physically present costs resolution and completion; keeping one Mix never fetches
+     * costs an empty placeholder library, which is the status quo.
+     */
+    fun testUnreadableOnlyValuesAreReachedEverywhere() {
+        listOf(
+            "only: :\"prod\"",
+            "only: true",
+            "only: @envs",
+            "only: Mix.env()",
+            "only: [:dev] ++ other()",
+        ).forEach { option ->
+            assertReachedInsideADep("{:jason, \">= 0.0.0\", $option}", "jason")
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Reached at a project position, dropped inside a dep
+    // -----------------------------------------------------------------
+
+    fun testEnvironmentRestrictedDepIsReachedAtProjectPositions() {
+        assertReachedAtProjectPositions("{:mox, \">= 0.0.0\", only: [:test]}", "mox")
+    }
+
+    fun testEnvironmentRestrictedDepOfADepIsNotReached() {
+        assertNotReachedInsideADep("{:mox, \">= 0.0.0\", only: [:test]}")
+    }
+
+    fun testSingleAtomEnvironmentRestrictedDepIsReachedAtProjectPositions() {
+        assertReachedAtProjectPositions("{:mox, \">= 0.0.0\", only: :test}", "mox")
+    }
+
+    fun testSingleAtomEnvironmentRestrictedDepOfADepIsNotReached() {
+        assertNotReachedInsideADep("{:mox, \">= 0.0.0\", only: :test}")
+    }
+
+    fun testMultiEnvironmentRestrictedDepIsReachedAtProjectPositions() {
+        assertReachedAtProjectPositions("{:mox, \">= 0.0.0\", only: [:dev, :test]}", "mox")
+    }
+
+    fun testMultiEnvironmentRestrictedDepOfADepIsNotReached() {
+        assertNotReachedInsideADep("{:mox, \">= 0.0.0\", only: [:dev, :test]}")
+    }
+
+    fun testOptionalDepIsReachedAtProjectPositions() {
+        assertReachedAtProjectPositions("{:jason, \">= 0.0.0\", optional: true}", "jason")
+    }
+
+    fun testOptionalDepOfADepIsNotReached() {
+        assertNotReachedInsideADep("{:jason, \">= 0.0.0\", optional: true}")
+    }
+
+    /** The two gates are independent: clearing the environment one does not rescue an optional dep. */
+    fun testOptionalProdOnlyDepOfADepIsNotReached() {
+        assertNotReachedInsideADep("{:jason, \">= 0.0.0\", optional: true, only: [:prod]}")
+    }
+
+    /**
+     * An `in_umbrella:` dep inside a third-party dependency is an app of *that* umbrella and can
+     * never be a module of this project. Left reachable it becomes an invalid module order entry in
+     * the user's `.iml`, which is what a `subdir:` monorepo dep would otherwise produce.
+     */
+    fun testInUmbrellaDepIsReachedAtProjectPositions() {
+        assertReachedAtProjectPositions("{:sib, in_umbrella: true}", "sib")
+    }
+
+    fun testInUmbrellaDepOfADepIsNotReached() {
+        assertNotReachedInsideADep("{:sib, in_umbrella: true}")
+    }
+}

--- a/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
+++ b/tests/org/elixir_lang/mix/watcher/TransitiveResolutionTest.kt
@@ -254,6 +254,57 @@ class TransitiveResolutionTest : PlatformTestCase() {
         assertFalse("It must not borrow the enclosing root's deps: $applications", "from_outer" in applications)
     }
 
+    /**
+     * The umbrella root is not always handed in. An umbrella imported one module per app gives each
+     * app module only `apps/<app>` as a content root, so that is the whole root set the resolver
+     * sees, and the app's deps still live under the umbrella. Refs
+     * [#3986](https://github.com/KronicDeth/intellij-elixir/issues/3986).
+     */
+    fun testUmbrellaAppDepsResolveUnderTheUmbrellaWhenOnlyTheAppIsHandedIn() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val app = mixProject("$u/apps/app_a", "{:shared, \">= 0.0.0\"}")
+        mixProject("$u/deps/shared", "{:from_umbrella, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(app)
+
+        assertTrue("The umbrella owns the app's deps: $applications", "from_umbrella" in applications)
+    }
+
+    /**
+     * `mix new --umbrella` writes `deps_path: "../../deps"` into every app, and
+     * `Mix.Project.deps_path/1` expands it, so the app states outright where its deps live. Reading
+     * it settles the case without inferring anything from directory names.
+     */
+    fun testDeclaredDepsPathIsHonouredWhenOnlyTheAppIsHandedIn() {
+        val u = nextFixturePath()
+        mixProject(u, "", "      apps_path: \"apps\",\n")
+        val app = mixProject(
+            "$u/apps/app_a",
+            "{:shared, \">= 0.0.0\"}",
+            "      deps_path: \"../../deps\",\n"
+        )
+        mixProject("$u/deps/shared", "{:from_umbrella, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(app)
+
+        assertTrue("A declared deps_path names the deps directory: $applications", "from_umbrella" in applications)
+    }
+
+    /**
+     * `deps_path:` is not umbrella-only - any project may move its deps directory, and then
+     * `deps/<name>` beside the `mix.exs` is not where Mix checks anything out.
+     */
+    fun testDeclaredDepsPathIsHonouredOutsideAnUmbrella() {
+        val p = nextFixturePath()
+        val root = mixProject(p, "{:shared, \">= 0.0.0\"}", "      deps_path: \"vendor_deps\",\n")
+        mixProject("$p/vendor_deps/shared", "{:from_vendor, \">= 0.0.0\"}")
+
+        val applications = applicationsFrom(root)
+
+        assertTrue("A relocated deps directory is searched: $applications", "from_vendor" in applications)
+    }
+
     // -----------------------------------------------------------------
     // Reached at every position
     // -----------------------------------------------------------------


### PR DESCRIPTION
Fixes #3926. Fixes #3986. Fixes #3990.

A Mix dep's project library was named `<dep> [<absolute content root URL>]`. That name is also the file name the platform derives for `.idea/libraries`, and what every `<orderEntry>` repeats, so none of it survived a different checkout path. `$PROJECT_DIR$` cannot help: path macros only collapse a path at the start of an attribute value, and the file name is derived before serialization. The scope is now relative to the project base directory — the same anchor `$PROJECT_DIR$` resolves to.

Names written by older versions are replaced on the next sync. Only the `<dep> [<token>]` shape this plugin writes is ever touched; a bare name may be a user's own library and is left alone.

Also here, because the rename is not usable without them:

- **Tools > Elixir > Sync Dependency Libraries**, since nothing but a `deps/` change or first-time project setup could rebuild libraries, leaving a project with wrong ones no way back. The Elixir actions move into a `Tools > Elixir` submenu at the same time.
- **Repair on project open**, escalating to a full sync only when libraries and content roots disagree, so a healthy project does no dependency scanning. It waits for the JPS model first — the IDE applies the real `.iml` over the cached model seconds after open, and would otherwise discard the sync.

Testing that action surfaced the resolution defects that made the libraries wrong in the first place. The changelog lists them individually; two were reported separately and are fixed here because they are the same walk:

- **#3986** — an umbrella imported one module per app never found a dependency's own dependencies, because each app module knows only its own directory while `deps` lives at the umbrella root.
- **#3990** — nothing read what an `in_umbrella:` sibling declares, so a dependency reached through one was wired to no module at all. Mix has made those available since Elixir 1.15.0.

Verified against real projects: a single-root one migrated 43 old-scheme entries and persisted without a manual save; a two-root umbrella with an out-of-tree sibling module produced `.` and `../<sibling>` scopes; and three umbrella reproducers, reimported from scratch, now agree with `mix compile` on every alias — including the control where an app must *not* see a sibling's deps it does not declare.

Remaining clean-up — order entries left by deps removed from `mix.exs`, and orphaned libraries scoped outside every content root — is deferred to #3927.
