### PR TITLE
fix(completion): offer function names when a statement follows the dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 
 ### Bug Fixes
 
+- [#3993](https://github.com/KronicDeth/intellij-elixir/pull/3993) [@sh41](https://github.com/sh41)
+  - **Function names are offered after a `.` even when another statement follows it.** Fixes [#3219](https://github.com/KronicDeth/intellij-elixir/issues/3219).
+
 - [#3991](https://github.com/KronicDeth/intellij-elixir/pull/3991) [@sh41](https://github.com/sh41)
   - **The `+++` and `---` operators are now parsed.** Fixes [#2755](https://github.com/KronicDeth/intellij-elixir/issues/2755).
 

--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
@@ -25,7 +25,10 @@ class CallDefinitionClause : CompletionProvider<CompletionParameters>() {
                         val previousElement = parameters.originalFile.findElementAt(originalPositionOffset - 1)
 
                         if (previousElement != null && previousElement.node.elementType === ElixirTypes.DOT_OPERATOR) {
-                            previousElement.parent.prevSibling
+                            // A trailing dot has no grammar production, so error recovery only wraps it in a
+                            // dotInfixOperator when what follows can complete the call. When a sibling statement
+                            // follows instead, the dot stays a loose leaf beside its qualifier.
+                            previousElement.prevSibling ?: previousElement.parent.prevSibling
                         } else {
                             null
                         }

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/following_statement_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/following_statement_declaration.ex
@@ -1,0 +1,4 @@
+defmodule Prefix.FollowingStatementDeclaration do
+  def public_function1(), do: :a
+  def public_function2(), do: :b
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/following_statement_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/following_statement_usage.ex
@@ -1,0 +1,8 @@
+defmodule Prefix.FollowingStatementUsage do
+  alias Prefix.FollowingStatementDeclaration
+
+  def hello do
+    FollowingStatementDeclaration.<caret>
+    :world
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/last_statement_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/last_statement_usage.ex
@@ -1,0 +1,8 @@
+defmodule Prefix.LastStatementUsage do
+  alias Prefix.FollowingStatementDeclaration
+
+  def hello do
+    :world
+    FollowingStatementDeclaration.<caret>
+  end
+end

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -182,6 +182,20 @@ public class CallDefinitionClauseTest extends PlatformTestCase {
         assertEquals("(value, fallback) when is_binary(value) (/src/no_bare_head_fallback_declaration.ex defmodule Prefix.NoBareHeadFallbackDeclaration)", lookupElementPresentation.getTailText());
     }
 
+    public void testQualifiedFunctionOfferedWhenLastStatementInBlock() {
+        myFixture.configureByFiles("last_statement_usage.ex", "following_statement_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        assertCompletionOffersExactly(myFixture.getLookupElementStrings(), "public_function1", "public_function2");
+    }
+
+    public void testQualifiedFunctionOfferedWhenAnotherStatementFollowsInBlock() {
+        myFixture.configureByFiles("following_statement_usage.ex", "following_statement_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        assertCompletionOffersExactly(myFixture.getLookupElementStrings(), "public_function1", "public_function2");
+    }
+
     /*
      * Protected Instance Methods
      */


### PR DESCRIPTION
Fixes #3219.

Typing a qualified call anywhere but last in its block offered only the qualifier's nested module names, never its functions. Two independent paths fill that popup, which is why it was half-populated rather than empty: `Variants.filteredLookupElements` supplies nested module names and resolved the qualifier fine at both caret positions, while `CallDefinitionClause` supplies function names and fired at only one.

## Cause

A trailing dot has no production in the grammar, so what the parser builds around it depends on what follows the caret. The PSI for the two positions, dumped side by side:

| | caret last, before `end` | caret first, `:world` follows |
|---|---|---|
| recovery | takes the following `end` as the call's name | reports an error at `:world` |
| enclosing node | `UNMATCHED_QUALIFIED_NO_ARGUMENTS_CALL` | none — the dot is a loose leaf under the block body |
| `dot.parent` | `ElixirDotInfixOperator` | `ElixirStabBody` |
| `dot.parent.prevSibling` | the qualifier | **null** |

`CallDefinitionClause.maybeModularName` assumed the first shape and reached the qualifier by going up to the dot's parent and across to its previous sibling. In the second shape that walk goes one level too high, returns null, and the provider contributes nothing. The heuristic had been unchanged since 2018.

## Fix

Take the element immediately before the dot when there is one, and fall back to the old walk otherwise. The fallback is the previous behaviour byte for byte: `dotInfixOperator ::= DOT_OPERATOR` is a single token, so in the well-formed shape the dot leaf has nothing before it. The new branch only fires in the error-recovery case that was broken.

## Tests

Every one of the 14 caret fixtures under `call_definition_clause/` places the caret as the last statement in its block, immediately before `end`. None had a sibling statement after the completion site, so the suite could not have caught a position-dependent defect.

Two fixtures now cover both positions. Against unpatched `main` the following-statement test fails with `expected:<[public_function1, public_function2]> but was:<[]>` while the control passes; with the fix both pass. Full suite green: 7139 tests, 0 failures.
