### PR TITLE
fix(ci): stamp a pull request build with a commit that exists

### DIFF
--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -375,7 +375,21 @@ jobs:
         id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          # The pull request's head commit, not `github.ref`. On a `pull_request` event `github.ref`
+          # is `refs/pull/<n>/merge`, a merge commit GitHub synthesises for the run: it exists on no
+          # branch, is recreated whenever the base moves, and its committer date is when GitHub made
+          # it rather than when anything was written. This is the only job that stamps a version -
+          # versioning.GitSourceIdValueSource reads `HEAD` for the `<commit time>.<commit>` that ends
+          # up in `intellij-elixir-<version>.zip` and in `<version>` in plugin.xml, which is the sole
+          # field identifying the built code in a Marketplace exception report - so checking out the
+          # merge commit stamps the artifact with a SHA nobody can look up. Checking out the head
+          # commit makes the stamp a commit that is actually in the pull request.
+          #
+          # The test jobs deliberately keep `github.ref`: they publish no version, and testing the
+          # merge result is what catches a pull request that breaks against a moved base.
+          #
+          # Empty for every other trigger, so those fall through to the ref they already used.
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
       - name: Setup Build Environment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,9 @@
 
 ### Build / CI
 
+- [#3994](https://github.com/KronicDeth/intellij-elixir/pull/3994) [@sh41](https://github.com/sh41)
+  - **A pull request build's plugin artifact is now stamped with a commit that exists.**
+
 - [#3969](https://github.com/KronicDeth/intellij-elixir/pull/3969) [@sh41](https://github.com/sh41)
   - **The quoter daemon is now started on every test run, not just the first in a checkout.** Its files
     made `startQuoter` look up to date, but the daemon it starts is stopped again when the build ends,


### PR DESCRIPTION
On a `pull_request` event `github.ref` is `refs/pull/<n>/merge`, a merge commit GitHub synthesises for the run. Every job in `shared-test.yml` checked that out, so `versioning.GitSourceIdValueSource` read it from `HEAD` and stamped `intellij-elixir-<version>.zip` — and `<version>` in `plugin.xml` — with a SHA that is on no branch, is recreated whenever the base moves, and is dated when GitHub built the merge rather than when anything was written.

That version string is the only field identifying the built code in a Marketplace exception report, which is the whole reason it carries a commit and a commit time. A synthetic merge SHA cannot be looked up, and the timestamp beside it is a build clock again — the failure `GitSourceIdValueSource` exists to prevent.

`build-plugin` is the only job that produces a versioned filename, and it now checks out `${{ inputs.ref || github.event.pull_request.head.sha || github.ref }}`. The head commit is a real commit in the pull request and its committer date is a real source date, so both halves of the stamp mean something. No Gradle change: `GitSourceIdValueSource` was already correct, it was being handed a fake `HEAD`.

Every other trigger falls through to the ref it already used — `inputs.ref` for the `workflow_call` from `tag.yml`, `github.ref` for push-to-main via `release.yml` and for `workflow_dispatch`.

The test matrix deliberately keeps `github.ref`. Those jobs publish no version, and building the merge result is what catches a pull request that breaks against a base that has moved. The consequence is that on a pull request with a stale base the artifact's tree and the tested tree differ; identifying the artifact honestly is worth more than that, and the merge build still runs beside it.
