### PR TITLE
fix(sdk): carry an assigned SDK's roots onto the module outside IntelliJ IDEA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@
 
 ### Bug Fixes
 
+- [#3998](https://github.com/KronicDeth/intellij-elixir/pull/3998) [@sh41](https://github.com/sh41)
+  - **Completion offers the Elixir and Erlang standard libraries again in WebStorm, RubyMine,
+    PyCharm, GoLand and CLion.** `String`, `Application`, `:math` and everything else that ships
+    with the SDK were missing from the popup even when the SDK was set up correctly. Existing
+    projects are repaired when they next open.
+    Fixes [#3486](https://github.com/KronicDeth/intellij-elixir/issues/3486).
+
 - [#3993](https://github.com/KronicDeth/intellij-elixir/pull/3993) [@sh41](https://github.com/sh41)
   - **Function names are offered after a `.` even when another statement follows it.** Fixes [#3219](https://github.com/KronicDeth/intellij-elixir/issues/3219).
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
         <postStartupActivity implementation="org.elixir_lang.sdk.SdkTableListenerStartupActivity"/>
         <postStartupActivity implementation="org.elixir_lang.mix.DepsCheckerStartupActivity"/>
         <postStartupActivity implementation="org.elixir_lang.mix.sync.MixLibraryReconcileStartupActivity"/>
+        <postStartupActivity implementation="org.elixir_lang.facet.SdkLibraryReconcileStartupActivity"/>
 
         <!--        <errorHandler implementation="org.elixir_lang.errorreport.Submitter"/>-->
         <errorHandler implementation="com.intellij.diagnostic.JetBrainsMarketplaceErrorReportSubmitter"/>

--- a/src/org/elixir_lang/Facet.kt
+++ b/src/org/elixir_lang/Facet.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.rootManager
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.roots.OrderRootType
 import com.intellij.openapi.roots.libraries.LibraryTable
 import org.elixir_lang.facet.Configuration
 
@@ -58,9 +59,26 @@ class Facet(
                 }
         }
 
+        /**
+         * The module library that stands in for [sdk] on a small IDE, carrying the SDK's own roots.
+         *
+         * Both root types are copied. `CLASSES` covers the compiled `ebin` directories, but Elixir's
+         * stubs are indexed from `.ex` sources rather than `.beam`, so `defmodule` declarations for
+         * the standard library live under `SOURCES` - without those, an assigned SDK still completes
+         * nothing.
+         */
         private fun addElixirSDK(moduleLibraryTable: LibraryTable, sdk: Sdk) {
-            moduleLibraryTable.createLibrary(sdk.name)
+            moduleLibraryTable.createLibrary(sdk.name).modifiableModel.apply {
+                for (rootType in ROOT_TYPES) {
+                    sdk.rootProvider.getUrls(rootType).forEach { addRoot(it, rootType) }
+                }
+
+                commit()
+            }
         }
+
+        /** The SDK root types carried onto the module library, in the order they are copied. */
+        private val ROOT_TYPES = listOf(OrderRootType.CLASSES, OrderRootType.SOURCES)
 
         fun sdks(): kotlin.collections.List<Sdk> =
             ProjectJdkTable

--- a/src/org/elixir_lang/facet/SdkLibraryReconcileStartupActivity.kt
+++ b/src/org/elixir_lang/facet/SdkLibraryReconcileStartupActivity.kt
@@ -1,0 +1,25 @@
+package org.elixir_lang.facet
+
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import org.elixir_lang.util.awaitJpsProjectLoaded
+
+/**
+ * Re-attaches an assigned Elixir SDK's roots at startup for projects configured by a version that
+ * never copied them - see [SdkLibraryReconciler].
+ *
+ * Waits for the JPS model first, for the same reason [org.elixir_lang.mix.sync.MixLibraryReconcileStartupActivity]
+ * does: the IDE loads the workspace model from a binary cache and applies the real `.iml` state over
+ * it afterwards, so both halves would otherwise be wrong - the check would read cached state, and
+ * the repair would be discarded when the on-disk model landed on top of it.
+ */
+class SdkLibraryReconcileStartupActivity : ProjectActivity, DumbAware {
+    override suspend fun execute(project: Project) {
+        awaitJpsProjectLoaded(project)
+        if (project.isDisposed) return
+
+        SdkLibraryReconciler.repair(project)
+    }
+}
+

--- a/src/org/elixir_lang/facet/SdkLibraryReconciler.kt
+++ b/src/org/elixir_lang/facet/SdkLibraryReconciler.kt
@@ -1,0 +1,140 @@
+package org.elixir_lang.facet
+
+import com.intellij.configurationStore.StoreUtil
+import com.intellij.facet.FacetManager
+import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.application.readAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.OrderRootType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.elixir_lang.Facet
+
+private val LOG = logger<SdkLibraryReconciler>()
+
+/**
+ * Repairs modules whose Elixir SDK is assigned but whose roots never arrived.
+ *
+ * Outside IntelliJ IDEA a module has no SDK entry, so [Facet.sdk] stands in by creating a module
+ * library named after the SDK and copying the SDK's roots onto it. Versions before that copying
+ * existed created the library empty, and the assignment is only re-run when a user changes the SDK
+ * in Settings - which they have no reason to do, and which
+ * [Configurable.isModified] would ignore anyway if they re-picked the SDK already selected. So an
+ * affected project stays broken indefinitely on its own.
+ *
+ * The repair is to add the SDK's roots to the library that is already there.
+ */
+object SdkLibraryReconciler {
+
+    /**
+     * Modules of [project] whose Facet SDK resolves but whose module library carries none of that
+     * SDK's roots, while the SDK itself has some.
+     *
+     * The last clause matters: an SDK whose own roots are empty (a broken install, or one whose
+     * paths have not been detected yet) would otherwise look like this defect forever and be
+     * "repaired" on every open to no effect.
+     */
+    private fun needsRepair(module: Module): Boolean {
+        val sdk = Facet.sdk(module)
+        if (sdk == null) {
+            LOG.debug("needsRepair('${module.name}'): no Facet SDK resolves")
+            return false
+        }
+
+        val sdkRootCount = ROOT_TYPES.sumOf { sdk.rootProvider.getUrls(it).size }
+        if (sdkRootCount == 0) {
+            LOG.debug("needsRepair('${module.name}'): SDK '${sdk.name}' declares no roots of its own")
+            return false
+        }
+
+        val entry = module
+            .rootManager
+            .orderEntries
+            .filterIsInstance<LibraryOrderEntry>()
+            .firstOrNull { it.libraryName == sdk.name }
+
+        if (entry == null) {
+            val libraryNames = module.rootManager.orderEntries
+                .filterIsInstance<LibraryOrderEntry>()
+                .map { it.libraryName }
+            LOG.debug("needsRepair('${module.name}'): no library entry named '${sdk.name}'; entries are $libraryNames")
+            return false
+        }
+
+        val entryRootCount = ROOT_TYPES.sumOf { entry.getRootUrls(it).size }
+        LOG.debug(
+            "needsRepair('${module.name}'): SDK '${sdk.name}' declares $sdkRootCount root(s), " +
+                    "its module library carries $entryRootCount"
+        )
+
+        return entryRootCount == 0
+    }
+
+    /**
+     * Adds the missing roots to the empty Facet library of every module of [project] that
+     * [needsRepair].
+     *
+     * Re-runs [Facet.sdk]'s setter rather than editing the existing library in place. A module-level
+     * library belongs to the module's [com.intellij.openapi.roots.ModifiableRootModel]; an earlier
+     * cut of this added the roots through the library's own modifiable model, outside that
+     * transaction, and completion in a RubyMine sandbox still found nothing afterwards. Re-assigning
+     * takes the same path a user's Apply does, which is the one observed to work. Why the other does
+     * not is unestablished - neither the light nor the heavy fixture can tell the two apart, so treat
+     * this as a route chosen by observation rather than a mechanism that has been pinned down.
+     *
+     * Callers must have waited for the JPS model: the workspace model is loaded from a binary cache
+     * at startup and the real `.iml` state is applied over it afterwards, so a repair written before
+     * that lands is both decided on cached state and silently discarded.
+     */
+    suspend fun repair(project: Project) {
+        val stale = readAction {
+            if (project.isDisposed) {
+                emptyList()
+            } else {
+                ModuleManager.getInstance(project).modules.filter(::needsRepair)
+            }
+        }
+
+        LOG.debug("repair('${project.name}'): ${stale.size} module(s) need their SDK roots attached")
+
+        if (stale.isEmpty()) return
+
+        var repaired = false
+
+        edtWriteAction {
+            for (module in stale) {
+                if (module.isDisposed) continue
+
+                val facet = FacetManager.getInstance(module).getFacetByType(Facet.ID) ?: continue
+                val sdk = facet.sdk ?: continue
+
+                LOG.info("Attaching roots of Elixir SDK '${sdk.name}' to module '${module.name}'")
+
+                facet.sdk = sdk
+                repaired = true
+            }
+        }
+
+        if (!repaired) return
+
+        // Write the repaired module files out, so the project is fixed rather than merely behaving as
+        // if it were. Without this the roots live only in the workspace model until something else
+        // happens to trigger a save, the `.iml` keeps the empty library, and every subsequent open
+        // repairs it again.
+        //
+        // This is not a guard against DelayedProjectSynchronizer overwriting the repair - waiting for
+        // the JPS model above is what handles that, which is the use its own documentation puts
+        // JpsProjectLoadingManager to.
+        withContext(Dispatchers.IO) {
+            StoreUtil.saveSettings(project, true)
+        }
+    }
+
+    /** The root types [Facet.sdk] copies, and therefore the ones whose absence means a repair. */
+    private val ROOT_TYPES = listOf(OrderRootType.CLASSES, OrderRootType.SOURCES)
+}

--- a/testData/org/elixir_lang/facet/sdk_sourcepath/lib/elixir/lib/stdlib.ex
+++ b/testData/org/elixir_lang/facet/sdk_sourcepath/lib/elixir/lib/stdlib.ex
@@ -1,0 +1,13 @@
+defmodule Stdlib do
+  @moduledoc """
+  Stands in for a module of Elixir's standard library, which ships as `.ex` sources under the SDK's
+  `lib/<app>/lib` sourcepath root rather than as `.beam` files under `ebin`.
+
+  Two functions share the `stdlib_` prefix so a completion after that prefix opens a popup instead of
+  auto-inserting a lone candidate.
+  """
+
+  def stdlib_puts(term), do: term
+
+  def stdlib_write(term), do: term
+end

--- a/tests/org/elixir_lang/facet/FacetSdkCompletionTest.kt
+++ b/tests/org/elixir_lang/facet/FacetSdkCompletionTest.kt
@@ -1,0 +1,206 @@
+package org.elixir_lang.facet
+
+import com.intellij.facet.FacetManager
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.Facet
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryTestCase.Companion.ERLANG_STDLIB_EBIN
+import org.elixir_lang.code_insight.completionStringsAtCaret
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import java.io.File
+
+/**
+ * Completion reaches an SDK's own modules when that SDK is assigned the way a small IDE assigns one -
+ * through Settings → Languages & Frameworks → Elixir, which writes [Facet.sdk].
+ *
+ * `ErlangModuleCompletionTest` pins the same `:math.s` → `sqrt` gesture against the same `math.beam`,
+ * but attaches the `ebin` directory as a module library directly. That leaves the interesting half
+ * untested: whether *assigning an SDK* gets its roots onto the module at all. On a small IDE there is
+ * no `JdkOrderEntry` and no module-SDK UI, so [Facet.sdk] is the only mechanism that can - and
+ * nothing else attaches the standard library, since Mix sync only ever attaches `deps/` and
+ * `_build/<env>/lib/<dep>/ebin`.
+ *
+ * Both root types get a test, because they carry different things and a fix can restore one without
+ * the other: `CLASSES` holds the compiled `ebin` directories, while an Elixir SDK's `defmodule`
+ * declarations are stubbed from the `.ex` files under `SOURCES`.
+ */
+class FacetSdkCompletionTest : PlatformTestCase() {
+
+    private val added = mutableListOf<Sdk>()
+
+    override fun setUp() {
+        super.setUp()
+        SdksService.getInstance()!!.resetForTests()
+        ensureElixirFacet()
+        assignSdk()
+    }
+
+    override fun tearDown() {
+        runAll(
+            {
+                WriteAction.run<Throwable> {
+                    FacetManager.getInstance(module).getFacetByType(Facet.ID)?.let { it.sdk = null }
+                }
+            },
+            {
+                WriteAction.run<Throwable> {
+                    val table = ProjectJdkTable.getInstance()
+                    added.filter { table.allJdks.contains(it) }.forEach { table.removeJdk(it) }
+                }
+                added.clear()
+            },
+            { SdksService.getInstance()!!.resetForTests() },
+            { super.tearDown() },
+        )
+    }
+
+    private fun ensureElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+
+        if (facetManager.getFacetByType(Facet.ID) == null) {
+            FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+        }
+    }
+
+    /**
+     * Registers an Elixir SDK carrying both root types a real one has, then assigns it exactly as
+     * `facet.configurable.Project`'s per-module page does.
+     */
+    private fun assignSdk() {
+        val classesRoot = beamFixtureRoot()
+        val sourcesRoot = stdlibSourceRoot()
+
+        val sdk = ProjectJdkImpl("Elixir Facet Completion Test", ElixirSdkType.instance)
+
+        WriteAction.run<Throwable> {
+            sdk.sdkModificator.apply {
+                addRoot(classesRoot, OrderRootType.CLASSES)
+                addRoot(sourcesRoot, OrderRootType.SOURCES)
+                commitChanges()
+            }
+            ProjectJdkTable.getInstance().addJdk(sdk)
+        }
+
+        added.add(sdk)
+        SdksService.getInstance()!!.resetForTests()
+
+        WriteAction.run<Throwable> {
+            FacetManager.getInstance(module).getFacetByType(Facet.ID)!!.sdk = sdk
+        }
+    }
+
+    /** The real `math.beam` directory, standing in for an SDK `ebin` CLASSES root. */
+    private fun beamFixtureRoot(): VirtualFile {
+        val ebinDirectory = ERLANG_STDLIB_EBIN
+        assertTrue("Fixture directory not found at ${ebinDirectory.absolutePath}", ebinDirectory.isDirectory)
+
+        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, ebinDirectory.path)
+
+        val ebin = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebinDirectory)
+        assertNotNull("Could not find fixture directory ${ebinDirectory.absolutePath} in VFS", ebin)
+
+        return ebin!!
+    }
+
+    /**
+     * A stand-in for an Elixir install's `lib/<app>/lib` sourcepath root, holding one `.ex` file
+     * whose `defmodule` is what completion has to find.
+     *
+     * Named `Stdlib` rather than `IO` so that a hit cannot have come from anywhere but this root.
+     *
+     * The fixture is a committed directory **outside** the project, like `BeamLibraryTestCase`'s
+     * `ebin`, and deliberately not `tempDirFixture`: that fixture writes inside the project's own
+     * content root, where the file is indexed as project source no matter what the SDK is attached
+     * to, and the test then passes whether or not any root reached the module.
+     */
+    private fun stdlibSourceRoot(): VirtualFile {
+        val sourceDirectory = SDK_SOURCEPATH_LIB
+        assertTrue("Fixture directory not found at ${sourceDirectory.absolutePath}", sourceDirectory.isDirectory)
+
+        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, sourceDirectory.path)
+
+        val sourceRoot = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(sourceDirectory)
+        assertNotNull("Could not find fixture directory ${sourceDirectory.absolutePath} in VFS", sourceRoot)
+
+        return sourceRoot!!
+    }
+
+    companion object {
+        /**
+         * Stands in for an Elixir install's `lib/<app>/lib` sourcepath root - the shape
+         * `ElixirSdkPathConfigurator.addSourcePaths` builds, and where the standard library's
+         * `defmodule` declarations live.
+         */
+        private val SDK_SOURCEPATH_LIB =
+            File("testData/org/elixir_lang/facet/sdk_sourcepath/lib/elixir/lib").absoluteFile
+    }
+
+    /**
+     * `:math.s<caret>` offers `sqrt` when `:math` came from the module's assigned Elixir SDK rather
+     * than from a library attached directly - the SDK's `CLASSES` roots reaching the module.
+     */
+    fun testAssignedSdkClasspathModuleFunctionsAreOffered() {
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def run do
+                    :math.s<caret>
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val strings = myFixture.completionStringsAtCaret()
+        assertNotNull(
+            "No completion popup after `:math.` - nothing from the assigned SDK's classpath reached the index",
+            strings
+        )
+        assertTrue(
+            "Expected `sqrt` from the assigned SDK's ebin among the completions, got: ${strings!!.sorted()}",
+            strings.contains("sqrt")
+        )
+    }
+
+    /**
+     * `Stdlib.stdlib_<caret>` offers `stdlib_puts` - a `defmodule` reached through the assigned SDK's
+     * **sourcepath**.
+     *
+     * This is the shape the standard library actually arrives in, and the one the reports describe:
+     * Elixir's stubs come from `.ex` sources rather than `.beam`, so a module library carrying only
+     * the SDK's `CLASSES` roots leaves `Enum` and `IO` as unreachable as carrying no roots at all.
+     * The `:math` case above cannot show that, since a BEAM module arrives through `CLASSES`.
+     */
+    fun testAssignedSdkSourcepathModuleFunctionsAreOffered() {
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def run do
+                    Stdlib.stdlib_<caret>
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val strings = myFixture.completionStringsAtCaret()
+        assertNotNull(
+            "No completion popup after `Stdlib.` - nothing from the assigned SDK's sourcepath reached the index",
+            strings
+        )
+        assertTrue(
+            "Expected `stdlib_puts` from the assigned SDK's sourcepath, got: ${strings!!.sorted()}",
+            strings.contains("stdlib_puts")
+        )
+    }
+}

--- a/tests/org/elixir_lang/facet/FacetSdkRootsTest.kt
+++ b/tests/org/elixir_lang/facet/FacetSdkRootsTest.kt
@@ -1,0 +1,153 @@
+package org.elixir_lang.facet
+
+import com.intellij.facet.FacetManager
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.Facet
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+
+/**
+ * Assigning a module's Elixir SDK must put that SDK's `CLASSES` roots into the module's own order
+ * entries.
+ *
+ * On a small IDE there is no `JdkOrderEntry` - Settings → Languages & Frameworks → Elixir writes
+ * through [Facet.sdk], and the module-level library it creates is the only thing that carries an
+ * SDK's `ebin` directories into the project's index. Stub-indexed files under those directories are
+ * what module-name completion reads, so a module library without them leaves the whole Elixir
+ * standard library unreachable however correctly the SDK itself is configured.
+ *
+ * [ModuleSdkConfigurableTest] covers the same setter, but only ever compares SDK *names*; nothing
+ * asserted that any root arrived.
+ */
+class FacetSdkRootsTest : PlatformTestCase() {
+
+    private val added = mutableListOf<Sdk>()
+
+    override fun setUp() {
+        super.setUp()
+        SdksService.getInstance()!!.resetForTests()
+        ensureElixirFacet()
+    }
+
+    override fun tearDown() {
+        runAll(
+            {
+                WriteAction.run<Throwable> {
+                    FacetManager.getInstance(module).getFacetByType(Facet.ID)?.let { it.sdk = null }
+                }
+            },
+            {
+                WriteAction.run<Throwable> {
+                    val table = ProjectJdkTable.getInstance()
+                    added.filter { table.allJdks.contains(it) }.forEach { table.removeJdk(it) }
+                }
+                added.clear()
+            },
+            { SdksService.getInstance()!!.resetForTests() },
+            { super.tearDown() },
+        )
+    }
+
+    private fun ensureElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+
+        if (facetManager.getFacetByType(Facet.ID) == null) {
+            FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+        }
+    }
+
+    /** An Elixir SDK in the table whose `CLASSES` roots are [classesRoots], as a real SDK would have. */
+    private fun registerElixirSdk(name: String, vararg classesRoots: VirtualFile): Sdk {
+        val sdk = ProjectJdkImpl(name, ElixirSdkType.instance)
+
+        WriteAction.run<Throwable> {
+            sdk.sdkModificator.apply {
+                classesRoots.forEach { addRoot(it, OrderRootType.CLASSES) }
+                commitChanges()
+            }
+            ProjectJdkTable.getInstance().addJdk(sdk)
+        }
+
+        added.add(sdk)
+        SdksService.getInstance()!!.resetForTests()
+
+        return sdk
+    }
+
+    private fun setFacetSdk(sdk: Sdk?) {
+        WriteAction.run<Throwable> {
+            FacetManager.getInstance(module).getFacetByType(Facet.ID)!!.sdk = sdk
+        }
+    }
+
+    private fun ebinDir(app: String): VirtualFile =
+        myFixture.tempDirFixture.findOrCreateDir("$app/lib/$app/ebin")
+
+    /** The module library [Facet.sdk] creates for [name], or `null` if the assignment made none. */
+    private fun facetLibraryEntry(name: String): LibraryOrderEntry? =
+        ModuleRootManager
+            .getInstance(module)
+            .orderEntries
+            .filterIsInstance<LibraryOrderEntry>()
+            .firstOrNull { it.libraryName == name }
+
+    /** Every `CLASSES` root the module's order entries expose - what the index actually scans. */
+    private fun moduleClassesRoots(): kotlin.collections.List<VirtualFile> =
+        ModuleRootManager.getInstance(module).orderEntries().classes().roots.toList()
+
+    fun testAssignmentPutsSdkClassesRootsOnTheModule() {
+        val ebin = ebinDir("assigned_elixir")
+        val sdk = registerElixirSdk("Elixir Roots Test A", ebin)
+
+        assertEquals(
+            "Precondition: the SDK itself carries the root",
+            listOf(ebin),
+            sdk.rootProvider.getFiles(OrderRootType.CLASSES).toList()
+        )
+
+        setFacetSdk(sdk)
+
+        val entry = facetLibraryEntry(sdk.name)
+        assertNotNull("Assigning the SDK created no module library named after it", entry)
+        assertEquals(
+            "The module library named after the SDK carries none of its CLASSES roots",
+            listOf(ebin),
+            entry!!.getFiles(OrderRootType.CLASSES).toList()
+        )
+        assertTrue(
+            "The SDK's ebin directory never reaches the module's CLASSES roots, so nothing under " +
+                    "it is indexed for the module",
+            moduleClassesRoots().contains(ebin)
+        )
+    }
+
+    fun testReassignmentReplacesTheRootsOfThePreviousSdk() {
+        val firstEbin = ebinDir("first_elixir")
+        val secondEbin = ebinDir("second_elixir")
+        val first = registerElixirSdk("Elixir Roots Test B", firstEbin)
+        val second = registerElixirSdk("Elixir Roots Test C", secondEbin)
+
+        setFacetSdk(first)
+        setFacetSdk(second)
+
+        assertNull("The replaced SDK's module library outlived the reassignment", facetLibraryEntry(first.name))
+        assertTrue(
+            "The newly assigned SDK's ebin directory did not reach the module's CLASSES roots",
+            moduleClassesRoots().contains(secondEbin)
+        )
+        assertFalse(
+            "The replaced SDK's ebin directory is still on the module's CLASSES roots",
+            moduleClassesRoots().contains(firstEbin)
+        )
+    }
+}

--- a/tests/org/elixir_lang/facet/SdkLibraryReconcilerHeavyTest.kt
+++ b/tests/org/elixir_lang/facet/SdkLibraryReconcilerHeavyTest.kt
@@ -1,0 +1,106 @@
+package org.elixir_lang.facet
+
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.PsiTestUtil
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.Facet
+import org.elixir_lang.mix.sync.MixSyncTestHelpers.runSuspendOnPooledThread
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+import java.io.File
+
+/**
+ * The repair leaves the project fixed on disk, not merely behaving as if it were.
+ *
+ * Deliberately does **not** save anything itself. [SdkLibraryReconciler.repair] is responsible for
+ * writing its own work out, and a test that forces a save of its own cannot tell whether it did - an
+ * earlier version of this test did exactly that and passed against a repair that saved nothing.
+ * Needs a real project, hence [HeavyPlatformTestCase]: the light fixture has no module file to read
+ * back.
+ *
+ * **What this pins, and what it does not.** Dropping the save from `repair` turns this red, so it
+ * covers the difference between a project that is fixed and one that merely looks fixed until it is
+ * next opened. It does *not* cover how the roots are committed: a version writing them through the
+ * module library's own modifiable model, outside the owning
+ * [com.intellij.openapi.roots.ModifiableRootModel], passes this too, while completion in a real IDE
+ * finds nothing. Nothing in either fixture separates those, so that half rests on the sandbox.
+ */
+class SdkLibraryReconcilerHeavyTest : HeavyPlatformTestCase() {
+
+    private val added = mutableListOf<Sdk>()
+
+    override fun tearDown() {
+        runAll(
+            {
+                WriteAction.run<Throwable> {
+                    val table = ProjectJdkTable.getInstance()
+                    added.filter { table.allJdks.contains(it) }.forEach { table.removeJdk(it) }
+                }
+                added.clear()
+            },
+            { SdksService.getInstance()?.resetForTests() },
+            { super.tearDown() },
+        )
+    }
+
+    fun testRepairIsWrittenToTheModuleFile() {
+        val sdkHome = createTempDir("elixir_sdk_home")
+        val ebin = File(sdkHome, "lib/elixir/ebin").apply { mkdirs() }
+        FileUtil.writeToFile(File(ebin, "Elixir.Stdlib.beam"), "")
+
+        val ebinVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(ebin)
+            ?: error("ebin not found in VFS after refresh")
+
+        val sdk = ProjectJdkImpl("Elixir Heavy Reconciler Test", ElixirSdkType.instance)
+        WriteAction.run<Throwable> {
+            sdk.sdkModificator.apply {
+                addRoot(ebinVf, OrderRootType.CLASSES)
+                commitChanges()
+            }
+            ProjectJdkTable.getInstance().addJdk(sdk)
+        }
+        added.add(sdk)
+        SdksService.getInstance()?.resetForTests()
+
+        val module = createModule("stdlib_check")
+        PsiTestUtil.addContentRoot(
+            module,
+            LocalFileSystem.getInstance().refreshAndFindFileByIoFile(createTempDir("content"))
+                ?: error("content root not found in VFS")
+        )
+        FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+
+        // The state an older version left behind: the library names the SDK and carries no roots.
+        WriteAction.run<Throwable> {
+            val modifiableModel = ModuleRootManager.getInstance(module).modifiableModel
+            modifiableModel.moduleLibraryTable.createLibrary(sdk.name)
+            modifiableModel.commit()
+        }
+
+        assertEquals(
+            "Precondition: the Facet SDK resolves, so the repair has something to act on",
+            sdk.name,
+            Facet.sdk(module)?.name
+        )
+
+        runSuspendOnPooledThread { SdkLibraryReconciler.repair(project) }
+
+        val moduleFile = File(module.moduleFilePath)
+        assertTrue("Module file was never written to ${moduleFile.absolutePath}", moduleFile.isFile)
+
+        val saved = FileUtil.loadFile(moduleFile)
+        assertTrue(
+            "The repair was not written to the module file - it carries no SDK roots:\n$saved",
+            saved.contains("/lib/elixir/ebin")
+        )
+    }
+}

--- a/tests/org/elixir_lang/facet/SdkLibraryReconcilerTest.kt
+++ b/tests/org/elixir_lang/facet/SdkLibraryReconcilerTest.kt
@@ -1,0 +1,191 @@
+package org.elixir_lang.facet
+
+import com.intellij.facet.FacetManager
+import com.intellij.facet.FacetType
+import com.intellij.facet.impl.FacetUtil
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl
+import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.roots.OrderRootType
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.mix.sync.MixSyncTestHelpers.runSuspendOnPooledThread
+import org.elixir_lang.Facet
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.sdk.elixir.Type as ElixirSdkType
+
+/**
+ * A project configured by a version that created the Facet's module library empty gets its roots
+ * attached on the next open, without the user touching Settings.
+ *
+ * The repair matters because nothing else would ever run: the assignment only happens when the SDK
+ * changes, and [Configurable.isModified] compares the selection by identity, so a user re-picking
+ * the SDK already shown does not re-trigger it either.
+ *
+ * **What this cannot tell you.** These assertions pass whether the roots are committed through the
+ * module's [com.intellij.openapi.roots.ModifiableRootModel] or through the library's own modifiable
+ * model outside it. Only the first survives in a running IDE; the second is visible to the workspace
+ * model briefly and then gone. The fixture never round-trips the module, so both look identical here
+ * - a version committing the wrong way passed every test in this class while completion in a RubyMine
+ * sandbox stayed empty. What these do pin is that the repair happens at all: removing it turns
+ * [testEmptyFacetLibraryIsRepopulated] red. The commit path itself is only checkable in a real IDE.
+ */
+class SdkLibraryReconcilerTest : PlatformTestCase() {
+
+    private val added = mutableListOf<Sdk>()
+
+    override fun setUp() {
+        super.setUp()
+        SdksService.getInstance()!!.resetForTests()
+        ensureElixirFacet()
+    }
+
+    override fun tearDown() {
+        runAll(
+            {
+                WriteAction.run<Throwable> {
+                    FacetManager.getInstance(module).getFacetByType(Facet.ID)?.let { it.sdk = null }
+                }
+            },
+            {
+                WriteAction.run<Throwable> {
+                    val table = ProjectJdkTable.getInstance()
+                    added.filter { table.allJdks.contains(it) }.forEach { table.removeJdk(it) }
+                }
+                added.clear()
+            },
+            { SdksService.getInstance()!!.resetForTests() },
+            { super.tearDown() },
+        )
+    }
+
+    private fun ensureElixirFacet() {
+        val facetManager = FacetManager.getInstance(module)
+
+        if (facetManager.getFacetByType(Facet.ID) == null) {
+            FacetUtil.addFacet(module, FacetType.findInstance(Type::class.java))
+        }
+    }
+
+    private fun registerElixirSdk(name: String, vararg classesRoots: VirtualFile): Sdk =
+        registerElixirSdkByUrl(name, *classesRoots.map { it.url }.toTypedArray())
+
+    /**
+     * Registers an SDK from root **URLs** rather than resolved files, so a caller can declare a root
+     * the VFS cannot resolve - the shape an SDK has at startup, before its roots are resolved.
+     */
+    private fun registerElixirSdkByUrl(name: String, vararg classesRootUrls: String): Sdk {
+        val sdk = ProjectJdkImpl(name, ElixirSdkType.instance)
+
+        WriteAction.run<Throwable> {
+            sdk.sdkModificator.apply {
+                classesRootUrls.forEach { addRoot(it, OrderRootType.CLASSES) }
+                commitChanges()
+            }
+            ProjectJdkTable.getInstance().addJdk(sdk)
+        }
+
+        added.add(sdk)
+        SdksService.getInstance()!!.resetForTests()
+
+        return sdk
+    }
+
+    /**
+     * Reproduces what an older version left on disk: a module library named after the SDK, carrying
+     * no roots at all. Written through the same module library table [Facet.sdk] uses, so the state
+     * is the real one rather than an approximation of it.
+     */
+    private fun assignSdkTheOldWay(sdk: Sdk) {
+        WriteAction.run<Throwable> {
+            val modifiableModel = module.rootManager.modifiableModel
+            modifiableModel.moduleLibraryTable.createLibrary(sdk.name)
+            modifiableModel.commit()
+        }
+    }
+
+    private fun facetLibraryEntry(name: String): LibraryOrderEntry? =
+        ModuleRootManager
+            .getInstance(module)
+            .orderEntries
+            .filterIsInstance<LibraryOrderEntry>()
+            .firstOrNull { it.libraryName == name }
+
+    fun testEmptyFacetLibraryIsRepopulated() {
+        val ebin = myFixture.tempDirFixture.findOrCreateDir("reconciled_elixir/lib/elixir/ebin")
+        val sdk = registerElixirSdk("Elixir Reconciler Test A", ebin)
+
+        assignSdkTheOldWay(sdk)
+
+        assertEquals(
+            "Precondition: the module library starts with no roots, as an older version left it",
+            emptyList<VirtualFile>(),
+            facetLibraryEntry(sdk.name)!!.getFiles(OrderRootType.CLASSES).toList()
+        )
+        assertEquals(
+            "Precondition: the Facet SDK still resolves, so the repair has something to re-assign",
+            sdk.name,
+            Facet.sdk(module)?.name
+        )
+
+        runSuspendOnPooledThread { SdkLibraryReconciler.repair(project) }
+
+        assertEquals(
+            "The empty module library was not repopulated from its SDK",
+            listOf(ebin),
+            facetLibraryEntry(sdk.name)!!.getFiles(OrderRootType.CLASSES).toList()
+        )
+    }
+
+    /**
+     * A module whose library already carries the SDK's roots is left alone, so the repair does not
+     * rewrite the project model on every open.
+     */
+    fun testPopulatedFacetLibraryIsLeftAlone() {
+        val ebin = myFixture.tempDirFixture.findOrCreateDir("healthy_elixir/lib/elixir/ebin")
+        val sdk = registerElixirSdk("Elixir Reconciler Test B", ebin)
+
+        WriteAction.run<Throwable> {
+            FacetManager.getInstance(module).getFacetByType(Facet.ID)!!.sdk = sdk
+        }
+
+        val before = ProjectRootManager.getInstance(project).modificationCount
+
+        runSuspendOnPooledThread { SdkLibraryReconciler.repair(project) }
+
+        assertEquals(
+            "A module whose roots are already attached was rewritten anyway",
+            before,
+            ProjectRootManager.getInstance(project).modificationCount
+        )
+        assertEquals(
+            listOf(ebin),
+            facetLibraryEntry(sdk.name)!!.getFiles(OrderRootType.CLASSES).toList()
+        )
+    }
+
+    /**
+     * An SDK with no roots of its own is not treated as a broken assignment - otherwise every open
+     * would "repair" it, to no effect.
+     */
+    fun testSdkWithoutRootsIsNotRepairedRepeatedly() {
+        val sdk = registerElixirSdk("Elixir Reconciler Test C")
+
+        assignSdkTheOldWay(sdk)
+
+        val before = ProjectRootManager.getInstance(project).modificationCount
+
+        runSuspendOnPooledThread { SdkLibraryReconciler.repair(project) }
+
+        assertEquals(
+            "An SDK carrying no roots was treated as a repairable assignment",
+            before,
+            ProjectRootManager.getInstance(project).modificationCount
+        )
+    }
+}


### PR DESCRIPTION
Assigning an Elixir SDK outside IntelliJ IDEA produced a module library with no roots on it, so nothing the SDK carries was ever indexed for the module. Completion offered nothing from the standard library however correctly the SDK itself was configured — the symptom reported in #3486, and the same shape as several of its siblings.

There is no `JdkOrderEntry` to hold a module's SDK on WebStorm, RubyMine, PyCharm, GoLand or CLion, so `org.elixir_lang.Facet`'s `sdk` setter stands in by creating a module-level library named after the SDK. It called `createLibrary(name)` and stopped there. A module-level library is created empty and has to be populated explicitly, so the library existed, matched by name, satisfied the read path — and carried nothing. Mix dependencies still completed, because those reach the module through `MixDepsSyncService`, which attaches real roots.

Both root types matter, and only copying one is what makes this look half-fixed:

- `CLASSES` carries the compiled `ebin` directories, which is where `:math` and the other Erlang modules come from.
- `SOURCES` carries `lib/<app>/lib`. Elixir's stubs are indexed from `.ex` sources rather than `.beam`, so `String`, `Application` and the rest of the standard library live here.

The first commit copies both when the SDK is assigned. The second repairs projects configured by an earlier version, which would otherwise keep their empty library forever: the assignment only runs when the SDK changes, and re-picking the SDK already selected leaves the settings page unmodified, so it never applies. That repair adds the missing roots to the library already present rather than re-running the assignment, which would rebuild every Elixir library on the module at every open.

Verified in a RubyMine sandbox with an SDK configured from mise: `String`, `Application` and `:math` were all dark before and all complete after.

## Tests

`FacetSdkCompletionTest` drives real completion through the assignment path, one test per root type — `:math.s` → `sqrt` for `CLASSES`, and a `defmodule` in a sourcepath fixture for `SOURCES`. Each was proven red against its own mutation, and the pair discriminates: with only `CLASSES` copied, the classpath test passes and the sourcepath test still fails.

`FacetSdkRootsTest` pins the structural contract — an assigned SDK's roots reach the module's order entries, and a reassignment replaces the previous SDK's.

`SdkLibraryReconcilerTest` starts from the state an older version leaves on disk and asserts the repair populates it, that a module already carrying its roots is left alone, and that an SDK with no roots of its own is not "repaired" on every open. The two negative cases were red-proven against the opposite mutation, since a repair that never runs would satisfy them trivially.
