### PR TITLE
fix(mix): wait for the OTP app scan before configuring a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@
 
 ### Bug Fixes
 
+- [#4001](https://github.com/KronicDeth/intellij-elixir/pull/4001) [@sh41](https://github.com/sh41)
+  - **A Mix project opened in a small IDE is configured as an Elixir project again.** Fixes [#3999](https://github.com/KronicDeth/intellij-elixir/issues/3999).
+  - **A Mix app below the opened directory is attached to the project again**, in RubyMine and other small IDEs that support attaching.
+
 - [#3998](https://github.com/KronicDeth/intellij-elixir/pull/3998) [@sh41](https://github.com/sh41)
   - **Completion offers the Elixir and Erlang standard libraries again in WebStorm, RubyMine,
     PyCharm, GoLand and CLion.** `String`, `Application`, `:math` and everything else that ships

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 - [#4001](https://github.com/KronicDeth/intellij-elixir/pull/4001) [@sh41](https://github.com/sh41)
   - **A Mix project opened in a small IDE is configured as an Elixir project again.** Fixes [#3999](https://github.com/KronicDeth/intellij-elixir/issues/3999).
-  - **A Mix app below the opened directory is attached to the project again**, in RubyMine and other small IDEs that support attaching.
+  - **A Mix app below the opened directory is attached to the project again**, in RubyMine, GoLand and other small IDEs that support attaching.
 
 - [#3998](https://github.com/KronicDeth/intellij-elixir/pull/3998) [@sh41](https://github.com/sh41)
   - **Completion offers the Elixir and Erlang standard libraries again in WebStorm, RubyMine,

--- a/src/org/elixir_lang/create_module/ElementCreator.kt
+++ b/src/org/elixir_lang/create_module/ElementCreator.kt
@@ -22,7 +22,9 @@ class ElementCreator(project: Project, private val directory: PsiDirectory, priv
     override fun getActionName(newName: String): String = NEW_ELIXIR_MODULE
 }
 
-private val LOGGER = Logger.getInstance(ElementCreator::class.java);
+// Qualified because an explicit import outranks a declaration in the same file: the bare name
+// resolves to the imported com.intellij.ide.actions.ElementCreator.
+private val LOGGER = Logger.getInstance(org.elixir_lang.create_module.ElementCreator::class.java);
 
 /**
  * @link com.intellij.ide.actions.CreateTemplateInPackageAction#checkOrCreate

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -27,7 +27,9 @@ import java.io.File
 
 object Project {
     const val MIX_EXS = "mix.exs"
-    private val LOG = Logger.getInstance(Project::class.java)
+    // Qualified because an explicit import outranks a declaration in the same file: the bare name
+    // resolves to the imported com.intellij.openapi.project.Project.
+    private val LOG = Logger.getInstance(org.elixir_lang.mix.Project::class.java)
 
     fun addSourceDirToContent(
         content: ContentEntry,

--- a/src/org/elixir_lang/mix/Project.kt
+++ b/src/org/elixir_lang/mix/Project.kt
@@ -201,11 +201,14 @@ object Project {
      * through: the New Project wizard and the New Module wizard via
      * [org.elixir_lang.module.ElixirModuleBuilder], and the import wizard and project-open
      * processor via [createModulesForOtpApps].
+     *
+     * `CompilerModuleExtension` ships with the Java plugin, so it is absent in a small IDE such as
+     * RubyMine - where there is no `<exclude-output/>` to suppress in the first place.
      */
     private fun clearExcludeOutput(modifiableRootModel: ModifiableRootModel) {
         modifiableRootModel
             .getModuleExtension(CompilerModuleExtension::class.java)
-            .setExcludeOutput(false)
+            ?.setExcludeOutput(false)
     }
 
     /**

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -1,63 +1,63 @@
 package org.elixir_lang.mix.project
 
-import com.intellij.configurationStore.StoreUtil
 import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetType
 import com.intellij.facet.impl.FacetUtil
-import com.intellij.ide.impl.OpenProjectTask
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.progress.Task
+import com.intellij.openapi.progress.coroutineToIndicator
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ex.ProjectManagerEx
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.util.Ref
-import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.DirectoryProjectConfigurator
-import com.intellij.platform.PlatformProjectOpenProcessor.Companion.runDirectoryProjectConfigurators
 import com.intellij.projectImport.ProjectAttachProcessor
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.elixir_lang.Facet
 import org.elixir_lang.mix.Project.addFolders
 import org.elixir_lang.mix.sync.MixDepsSyncService
 import org.elixir_lang.mix.sync.SyncRequest
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.io.path.exists
 
 /**
  * Used in Small IDEs like Rubymine/Webstorm that don't support [OpenProcessor].
+ *
+ * Extends [DirectoryProjectConfigurator.AsyncDirectoryProjectConfigurator] because the scan for OTP
+ * apps is too slow for the EDT and its result decides everything below it: only [configure] is
+ * awaited by `PlatformProjectOpenProcessor.runDirectoryProjectConfigurators`.
  */
-class DirectoryConfigurator : DirectoryProjectConfigurator {
+class DirectoryConfigurator : DirectoryProjectConfigurator.AsyncDirectoryProjectConfigurator() {
     companion object {
         private val LOG = Logger.getInstance(DirectoryConfigurator::class.java)
     }
 
-    override fun configureProject(
+    override suspend fun configure(
         project: Project,
         baseDir: VirtualFile,
         moduleRef: Ref<Module>,
         isProjectCreatedWithWizard: Boolean
     ) {
-        var foundOtpApps: List<OtpApp> = emptyList()
         LOG.debug("configuring $baseDir for project $project, created with wizard: $isProjectCreatedWithWizard")
 
-        ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Scanning Mix projects", true) {
-            override fun run(indicator: ProgressIndicator) {
-                foundOtpApps = org.elixir_lang.mix.Project.findOtpApps(baseDir, indicator)
+        // The indicator coroutineToIndicator installs is backed by this coroutine's Job, so
+        // cancelling the project open cancels the scan.
+        val foundOtpApps = withContext(Dispatchers.IO) {
+            coroutineToIndicator { indicator ->
+                org.elixir_lang.mix.Project.findOtpApps(baseDir, indicator)
             }
-        })
+        }
 
         // If this is an umbrella app, RubyMine currently freezes.
         // Instead, let's just show a notification that the user needs to use the Wizard.
-        if (!isProjectCreatedWithWizard && foundOtpApps.isNotEmpty() && foundOtpApps.size > 1) {
+        if (!isProjectCreatedWithWizard && foundOtpApps.size > 1) {
             LOG.info("not configuring project $project because it is an umbrella app")
             NotificationGroupManager.getInstance()
                 .getNotificationGroup("Elixir")
@@ -83,81 +83,61 @@ class DirectoryConfigurator : DirectoryProjectConfigurator {
         }
     }
 
-    private fun configureRootOtpApp(project: Project, otpApp: OtpApp) {
-        val module = ModuleManager.getInstance(project).modules[0]
+    private suspend fun configureRootOtpApp(project: Project, otpApp: OtpApp) {
+        val module = readAction { ModuleManager.getInstance(project).modules.firstOrNull() }
 
-        if (FacetManager.getInstance(module).findFacet(Facet.ID, "Elixir") == null) {
-            FacetUtil.addFacet(module, FacetType.findInstance(org.elixir_lang.facet.Type::class.java))
+        if (module == null) {
+            LOG.debug("no module to attach the Elixir facet to in project $project")
+            return
+        }
 
-            ModuleRootModificationUtil.updateModel(module) { modifiableRootModel ->
-                addFolders(modifiableRootModel, otpApp.root)
+        // The facet check shares the write action with the mutations it guards, so a second
+        // configurator pass cannot add the facet twice.
+        val configured = edtWriteAction {
+            if (FacetManager.getInstance(module).findFacet(Facet.ID, "Elixir") != null) {
+                false
+            } else {
+                FacetUtil.addFacet(module, FacetType.findInstance(org.elixir_lang.facet.Type::class.java))
+
+                ModuleRootModificationUtil.updateModel(module) { modifiableRootModel ->
+                    addFolders(modifiableRootModel, otpApp.root)
+                }
+
+                true
             }
+        }
 
+        if (configured) {
             project.service<MixDepsSyncService>().enqueue(SyncRequest.All)
         }
     }
 
-    private fun configureDescendantOtpApp(rootProject: Project, otpApp: OtpApp) {
-        if (System.getProperty("idea.platform.prefix") != "GoLand" && ProjectAttachProcessor.canAttachToProject()) {
-            newProject(otpApp)?.let { otpAppProject ->
-                LOG.debug("attaching $otpAppProject to $rootProject")
-                attachToProject(rootProject, Paths.get(otpApp.root.path))
+    private suspend fun configureDescendantOtpApp(rootProject: Project, otpApp: OtpApp) {
+        if (System.getProperty("idea.platform.prefix") == "GoLand" || !ProjectAttachProcessor.canAttachToProject()) {
+            return
+        }
 
-                LOG.debug("scanning libraries for newly attached project for OTP app ${otpApp.name}")
-                otpAppProject.service<MixDepsSyncService>().enqueue(SyncRequest.All)
-            }
+        LOG.debug("attaching ${otpApp.name} to $rootProject")
+
+        if (attachToProject(rootProject, Paths.get(otpApp.root.path))) {
+            LOG.debug("scanning libraries for newly attached OTP app ${otpApp.name}")
+            rootProject.service<MixDepsSyncService>().enqueue(SyncRequest.All)
+        } else {
+            LOG.info("no ProjectAttachProcessor attached ${otpApp.name} to $rootProject")
         }
     }
 
     /**
-     * @return Only returns a project if it is new.
+     * `attachToProjectAsync` is the only entry point `ModuleAttachProcessor` - the platform's sole
+     * [ProjectAttachProcessor] - still implements; the non-suspend `attachToProject` it replaced is
+     * left as a base-class stub returning `false`, so calling that attaches nothing.
+     *
+     * It also creates, configures, saves and disposes the attached app's own project itself, which
+     * is why nothing here does that.
      */
-    private fun newProject(otpApp: OtpApp): Project? {
-        val projectDir = Paths.get(FileUtil.toSystemDependentName(otpApp.root.path), Project.DIRECTORY_STORE_FOLDER)
-        LOG.debug("Checking if $projectDir exists")
-
-        return if (projectDir.exists()) {
-            LOG.debug("$projectDir already exists")
-            null
-        } else {
-            val path = otpApp.root.path.let { Paths.get(it) }
-            val openProjectTask = OpenProjectTask
-                .build()
-                .asNewProject()
-                .withProjectName(otpApp.name)
-
-            LOG.debug("Creating new project at $path with isNewProject: ${openProjectTask.isNewProject} and useDefaultProjectAsTemplate: ${openProjectTask.useDefaultProjectAsTemplate} and projectName: ${openProjectTask.projectName}")
-
-            ProjectManagerEx
-                .getInstanceEx()
-                .newProject(
-                    path,
-                    openProjectTask
-                )
-                ?.let { project ->
-                    LOG.debug("runDirectoryProjectConfigurators for project: $project at $path")
-                    // runDirectoryProjectConfigurators is a suspend function in 2025.3
-                    // Use runBlocking here specifically for this single call, not blocking the entire loop
-                    runBlocking {
-                        runDirectoryProjectConfigurators(projectFile = path, project = project, newProject = false, createModule = false)
-                    }
-                    LOG.debug("runDirectoryProjectConfigurators complete for project: $project at $path")
-
-                    LOG.debug("Saving settings for project: $project at $path")
-
-                    StoreUtil.saveSettings(project, true)
-                    LOG.debug("Saved settings for project: $project at $path")
-
-                    project
-                }
+    @Suppress("UnstableApiUsage")
+    private suspend fun attachToProject(project: Project, baseDir: Path): Boolean =
+        ProjectAttachProcessor.EP_NAME.extensionList.any { processor ->
+            processor.attachToProjectAsync(project, baseDir, null)
         }
-    }
-
-    private fun attachToProject(project: Project, baseDir: Path) {
-        for (processor in ProjectAttachProcessor.EP_NAME.extensionList) {
-            if (processor.attachToProject(project, baseDir, null)) {
-                break
-            }
-        }
-    }
 }

--- a/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
+++ b/src/org/elixir_lang/mix/project/DirectoryConfigurator.kt
@@ -113,7 +113,7 @@ class DirectoryConfigurator : DirectoryProjectConfigurator.AsyncDirectoryProject
     }
 
     private suspend fun configureDescendantOtpApp(rootProject: Project, otpApp: OtpApp) {
-        if (System.getProperty("idea.platform.prefix") == "GoLand" || !ProjectAttachProcessor.canAttachToProject()) {
+        if (!ProjectAttachProcessor.canAttachToProject()) {
             return
         }
 

--- a/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.kt
+++ b/src/org/elixir_lang/sdk/erlang_dependent/AdditionalDataConfigurable.kt
@@ -492,6 +492,8 @@ class AdditionalDataConfigurable(
     }
 
     companion object {
-        private val LOG = Logger.getInstance(AdditionalDataConfigurable::class.java)
+        // Qualified because an explicit import outranks a declaration in the same file: the bare
+        // name resolves to the imported com.intellij.openapi.projectRoots.AdditionalDataConfigurable.
+        private val LOG = Logger.getInstance(org.elixir_lang.sdk.erlang_dependent.AdditionalDataConfigurable::class.java)
     }
 }

--- a/tests/org/elixir_lang/mix/project/DirectoryConfiguratorHeavyTest.kt
+++ b/tests/org/elixir_lang/mix/project/DirectoryConfiguratorHeavyTest.kt
@@ -1,0 +1,154 @@
+package org.elixir_lang.mix.project
+
+import com.intellij.facet.FacetManager
+import com.intellij.notification.Notification
+import com.intellij.notification.Notifications
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.platform.PlatformProjectOpenProcessor.Companion.runDirectoryProjectConfigurators
+import com.intellij.testFramework.HeavyPlatformTestCase
+import com.intellij.testFramework.LoggedErrorProcessor
+import com.intellij.testFramework.PlatformTestUtil
+import kotlinx.coroutines.runBlocking
+import org.elixir_lang.Facet
+import java.io.File
+
+/**
+ * Drives [DirectoryConfigurator] the way a small IDE does - through the platform's own
+ * [runDirectoryProjectConfigurators] - so the test asserts the outcome a user sees and does not
+ * depend on which branch of the dispatch loop the configurator takes.
+ *
+ * Needs [HeavyPlatformTestCase]: [runDirectoryProjectConfigurators] resolves its argument with
+ * `refreshAndFindFileByNioFile`, and the facet lands on `ModuleManager.modules[0]`.
+ */
+class DirectoryConfiguratorHeavyTest : HeavyPlatformTestCase() {
+    /** [runDirectoryProjectConfigurators] dispatches to `Dispatchers.EDT`, which a [runBlocking] on the EDT would never reach. */
+    override fun runInDispatchThread(): Boolean = false
+
+    fun testConfiguresTheRootModule() {
+        val appDir = createTempDir("mix_app")
+        FileUtil.writeToFile(File(appDir, "mix.exs"), MIX_EXS)
+        val appVirtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(appDir)
+            ?: error("$appDir not found in VFS after refresh")
+
+        configureDirectory(appDir)
+
+        val module = ModuleManager.getInstance(project).modules.first()
+
+        assertNotNull(
+            "Opening a directory holding a mix.exs must leave the module with an Elixir facet - " +
+                    "without one Module.isElixirModule() is false in an IDE that has no ELIXIR_MODULE type",
+            FacetManager.getInstance(module).findFacet(Facet.ID, "Elixir")
+        )
+
+        // The facet commits separately from the roots, so asserting only the facet would pass on a
+        // half-configured module.
+        val contentEntries = ModuleRootManager.getInstance(module).contentEntries
+        val contentEntry = contentEntries.singleOrNull { it.file == appVirtualFile }
+
+        assertNotNull(
+            "the configured directory must be a content root, got: ${contentEntries.map { it.url }}",
+            contentEntry
+        )
+
+        val sourceUrls = contentEntry!!.sourceFolders.associate { it.url to it.isTestSource }
+
+        assertTrue(
+            "lib should be Sources, got: ${sourceUrls.keys}",
+            sourceUrls["${appVirtualFile.url}/lib"] == false
+        )
+        assertTrue(
+            "test should be Test Sources, got: ${sourceUrls.keys}",
+            sourceUrls["${appVirtualFile.url}/test"] == true
+        )
+        assertContainsElements(
+            contentEntry.excludeFolderUrls,
+            "${appVirtualFile.url}/deps",
+            "${appVirtualFile.url}/cover"
+        )
+    }
+
+    fun testNotifiesInsteadOfConfiguringAnUmbrella() {
+        val umbrellaDir = createTempDir("mix_umbrella")
+        FileUtil.writeToFile(File(umbrellaDir, "mix.exs"), MIX_EXS)
+        FileUtil.writeToFile(File(umbrellaDir, "apps/first/mix.exs"), MIX_EXS)
+        FileUtil.writeToFile(File(umbrellaDir, "apps/second/mix.exs"), MIX_EXS)
+        LocalFileSystem.getInstance().refreshAndFindFileByIoFile(umbrellaDir)
+            ?: error("$umbrellaDir not found in VFS after refresh")
+
+        val titles = mutableListOf<String>()
+        project.messageBus.connect(testRootDisposable).subscribe(
+            Notifications.TOPIC,
+            object : Notifications {
+                override fun notify(notification: Notification) {
+                    titles.add(notification.title)
+                }
+            }
+        )
+
+        configureDirectory(umbrellaDir)
+
+        assertContainsElements(titles, "Umbrella App detected")
+
+        val module = ModuleManager.getInstance(project).modules.first()
+
+        assertNull(
+            "An umbrella is left for the Project Wizard, so no facet is added to the root module",
+            FacetManager.getInstance(module).findFacet(Facet.ID, "Elixir")
+        )
+    }
+
+    /**
+     * `runDirectoryProjectConfigurators` catches every [Throwable] a configurator raises and only
+     * logs it, so the errors are collected and asserted on rather than left to reach the test
+     * thread - they never would.
+     *
+     * Without `intellij.progress.task.ignoreHeadless`, `CoreProgressManager.run(Task)` takes its
+     * `isSynchronousHeadless` branch and runs a `Task.Backgroundable` to completion on the calling
+     * thread - the one arrangement under which reading its result on the next line works.
+     */
+    private fun configureDirectory(dir: File) {
+        val logged = mutableListOf<String>()
+        val processor = object : LoggedErrorProcessor() {
+            override fun processError(
+                category: String,
+                message: String,
+                details: Array<out String>,
+                t: Throwable?
+            ): Set<Action> {
+                logged.add("$category: $message")
+
+                return Action.NONE
+            }
+        }
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            PlatformTestUtil.withSystemProperty<Throwable>("intellij.progress.task.ignoreHeadless", "true") {
+                runBlocking {
+                    runDirectoryProjectConfigurators(
+                        projectFile = dir.toPath(),
+                        project = project,
+                        newProject = false,
+                        createModule = false
+                    )
+                }
+            }
+        }
+
+        assertEmpty("configuring $dir logged errors", logged)
+    }
+
+    private companion object {
+        private val MIX_EXS = """
+            defmodule TestApp.MixProject do
+              use Mix.Project
+
+              def project do
+                [app: :test_app, version: "0.1.0"]
+              end
+            end
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
Fixes #3999.

`DirectoryConfigurator` launched a `Task.Backgroundable` to scan for OTP apps and read its result on the next line. `ProgressManager.run` does not block for a non-modal backgroundable task, so the loop iterated an empty list and `configureRootOtpApp` — the only code that adds the Elixir facet — was never reached. A small IDE has no `ELIXIR_MODULE` type to fall back on, so `Module.isElixirModule()` stayed false and everything keyed on it went quiet.

## What changed

- **`DirectoryConfigurator` extends `DirectoryProjectConfigurator.AsyncDirectoryProjectConfigurator`.** `PlatformProjectOpenProcessor.runDirectoryProjectConfigurators` checks for that subclass first and awaits `configure`, so the scan completes before the loop moves on. The `Task.Backgroundable` is gone; `findOtpApps` keeps its `ProgressIndicator` and is bridged with `coroutineToIndicator` on `Dispatchers.IO`, the same shape `OpenProcessor.openProjectAsync` already uses — which also means cancelling the project open now cancels the scan.
- **Threading, now that none of this is on the EDT.** `FacetUtil.addFacet` runs a write action on its calling thread, so it and the `ModuleRootModificationUtil.updateModel` beside it moved into one `edtWriteAction`, which also makes the "does the facet exist?" check atomic with the mutations it guards. Module reads are in `readAction`. `ProjectManagerEx.newProject` and `StoreUtil.saveSettings` are blocking and run on `Dispatchers.IO`; `newProjectAsync` is `@ApiStatus.Internal`. The attach loop is wrapped in `Dispatchers.EDT`, matching `attachToProjectAsync`'s default implementation. The nested `runBlocking` around `runDirectoryProjectConfigurators` is a plain suspend call now.
- **The umbrella guard was dead too**, reading the same empty list, so "Umbrella App detected" could never fire. It is live again — still an early return, so it cannot reach the code the comment above it says freezes RubyMine.
- **Three shadowed logger categories.** A file that declares a type whose simple name it also imports gets the import, so `Logger.getInstance(X::class.java)` picked up the platform class. `org.elixir_lang.mix.Project` is why the scan looked as though it never ran; `create_module.ElementCreator` and `sdk.erlang_dependent.AdditionalDataConfigurable` do the same. All three arguments are qualified.

## Tests

`DirectoryConfiguratorHeavyTest` drives the platform's own `runDirectoryProjectConfigurators`, so its shape is identical either side of the fix and it never encodes the dispatch rule as an assumption. Two cases: a plain `mix new` layout ends with an Elixir facet, and an umbrella produces the notification and no facet.

It sets `intellij.progress.task.ignoreHeadless` around the call. Without it `CoreProgressManager.run(Task)` takes its `isSynchronousHeadless` branch — `Task.isHeadless()` is true under `isUnitTestMode()` — and runs a `Task.Backgroundable` to completion on the calling thread, which is the one arrangement under which the old code worked. Removing the property turns both cases green against the unfixed code, which is what proves the harness reaches the configurator and that the dispatch is the only thing being measured.

## The descendant-app path attached nothing, and had not since 2023.1

`configureDescendantOtpApp` called `ProjectAttachProcessor.attachToProject`. `ModuleAttachProcessor` is the platform's only implementation of that class and overrides `attachToProjectAsync` instead — the platform renamed the method in 2023.1 and left the old name as a base-class stub returning `false`. RubyMine registers `ModuleAttachProcessor` (`RubyPlugin.xml`, `rubymine-customization.xml`), so `canAttachToProject()` was true, the loop ran, and nothing attached. Nothing logged it either: the "attaching …" line is emitted before the call and the return value was discarded.

This is not newly-dead code. Attaching worked until the 2023.1 platform; from then until `Task.Backgroundable` landed it ran and silently failed, writing a `.idea` into the sub-app and adding nothing to the user's window.

The fix deletes the plugin's private `newProject()` rather than only renaming the call, because `attachToProjectAsync` is a strict superset of it — same `newProjectAsync`, `runDirectoryProjectConfigurators` and `runInAutoSaveDisabledMode { saveSettings(…) }`, plus `Disposer.dispose()` in a `finally` and the attach itself. The 2019 copy is what rotted when the original moved. That also removes an undisposed `Project` per descendant app, and a `createModule = false` that produced a project with no module for `configureRootOtpApp` to find. `attachToProjectAsync` is `@ApiStatus.Experimental`; it has been the only working entry point since 2023.1 and the stable alternative provably does nothing.

The `!isGoIde()` guard is removed, in its own commit. Its stated evidence — the Test Report on #1443 — covers RubyMine, WebStorm and PHPStorm and never mentions GoLand, and the commit that added the exclusion deleted the comment citing that report, so no rationale for it survived. Checking GoLand 2026.1.4 directly: it registers `GoProjectAttachProcessor`, which delegates to `ModuleAttachProcessor` unless the `go.attach.content.root` registry key is set — and `go-ide`'s own `plugin.xml` gives that key `defaultValue="false"` and calls it "a fallback option, it will be removed in the future". So GoLand attaches through the same processor RubyMine does, and `canAttachToProject()` already answers whether attaching is supported. Worth noting the old call was broken there too, by the same mechanism: `MyModuleAttachProcessor` implements only `attachToProjectAsync`.

## Not covered by a test

`canAttachToProject()` is `EP_NAME.hasAnyExtensions()`, and no `ProjectAttachProcessor` is registered in the `IU` test fixture, so a harness test returns at the guard before reaching the attach. The facet and root assertions are covered; the attach needs a sandbox with a mix app in a subdirectory.
