### PR TITLE
add(ci): fail verification on an unapproved internal API usage

### DIFF
--- a/.github/internal-api-usages-allowlist.txt
+++ b/.github/internal-api-usages-allowlist.txt
@@ -1,0 +1,36 @@
+# The IntelliJ Platform internal APIs this plugin is allowed to use.
+#
+# A CEILING, not a lint baseline: JetBrains have agreed to ignore exactly these in the plugin's
+# Marketplace verification, and anything else blocks publishing. Adding a line does NOT make a usage
+# publishable - that needs a new agreement with JetBrains first. Removing the usage is the better answer.
+#
+# Enforced per verification leg by .github/scripts/check-internal-api-usages.js.
+#
+# FORMAT: one entry per line, # comments ignored. An entry is a verifier report line minus its trailing
+# "This <kind> is marked with @...Internal ..." sentence and its parameter names - both drift, so both
+# are normalized away on each side. A raw report line can be pasted in verbatim.
+#
+# Entries name the plugin code too, deliberately: a second usage site of an approved API still raises the
+# count and blocks publishing. Moving that code means updating its line, with the ceiling unchanged.
+
+# --- Compiled-PSI mirror for decompiled .beam -----------------------------------------------------
+# BeamFileImpl must override getCachedMirror or the daemon never highlights decompiled .beam; there is
+# no public equivalent. IJPL-252078 asks for @ApiStatus.OverrideOnly instead.
+Internal method com.intellij.psi.PsiCompiledElement.getCachedMirror() : com.intellij.psi.PsiElement is overridden in class org.elixir_lang.beam.psi.BeamFileImpl
+
+# --- Code-insight context propagation onto that mirror --------------------------------------------
+# Only the setter needs the impl; everything else goes through the public CodeInsightContextManager,
+# which is what holds this to two entries. See the KDoc on propagateCodeInsightContextTo.
+Internal class com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl is referenced in org.elixir_lang.beam.psi.BeamFileImpl.propagateCodeInsightContextTo(PsiFile) : void
+Internal method com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl.setCodeInsightContext(com.intellij.psi.FileViewProvider, com.intellij.codeInsight.multiverse.CodeInsightContext) : void is invoked in org.elixir_lang.beam.psi.BeamFileImpl.propagateCodeInsightContextTo(PsiFile) : void
+
+# --- Awaiting the JPS project model before changing module or SDK configuration --------------------
+# The replacement is itself internal and absent from build 253, so migrating would relocate the finding,
+# not remove it. Five entries for one call site: a Kotlin Companion access compiles to a field read, an
+# interface reference and the call. Watch IJPL-249625 and IJPL-241069; see the KDoc on
+# awaitJpsProjectLoaded, the single place to change.
+Internal interface com.intellij.workspaceModel.ide.JpsProjectLoadingManager is referenced in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object
+Internal class com.intellij.workspaceModel.ide.JpsProjectLoadingManager.Companion is referenced in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object
+Internal field com.intellij.workspaceModel.ide.JpsProjectLoadingManager.Companion : com.intellij.workspaceModel.ide.JpsProjectLoadingManager.Companion is accessed in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object
+Internal method com.intellij.workspaceModel.ide.JpsProjectLoadingManager.Companion.getInstance(com.intellij.openapi.project.Project) : com.intellij.workspaceModel.ide.JpsProjectLoadingManager is invoked in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object
+Internal method com.intellij.workspaceModel.ide.JpsProjectLoadingManager.jpsProjectLoaded(java.lang.Runnable) : void is invoked in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object

--- a/.github/scripts/check-internal-api-usages.js
+++ b/.github/scripts/check-internal-api-usages.js
@@ -1,0 +1,273 @@
+'use strict';
+
+// Fails a verification leg when the plugin uses an internal platform API absent from
+// .github/internal-api-usages-allowlist.txt. Anything not on that list blocks publishing, so this is a
+// release ceiling, not a lint - hence a hard failure.
+//
+// The verifier cannot do it: INTERNAL_API_USAGES is all-or-nothing and it has no per-usage allowlist, so
+// the gate diffs the verifier's own report. Deliberately thin - whether that report is complete is the
+// verifier's business, not this script's.
+
+const fs = require('fs');
+const path = require('path');
+const { addSummary, fail, warn } = require('./actions');
+
+// A literal, not path.join: it is printed back in error messages, and path.join backslashes it on Windows.
+const DEFAULT_ALLOWLIST = '.github/internal-api-usages-allowlist.txt';
+const USAGES_FILE = 'internal-api-usages.txt';
+
+// Split on this rather than the whole sentence: verifier-version is LATEST, so only its opening is stable.
+const BOILERPLATE = '. This ';
+
+// The platform symbol alone. Anchored on the connector verb so the field form keeps its `X : T`.
+const SYMBOL = /^(Internal (?:class|interface|method|field) .+?) is (?:referenced|invoked|accessed|overridden) in /;
+
+const SKIP_DIRS = new Set(['.git', '.gradle', 'node_modules', '.idea']);
+const MAX_DEPTH = 8;
+
+// A report line reduced to a key. Both sides go through this, so a raw line can be pasted in verbatim.
+function normalize(line) {
+  const marker = line.lastIndexOf(BOILERPLATE);
+  if (marker === -1) return null;
+
+  return (
+    line
+      .slice(0, marker)
+      // Parameter names come from debug info and drift between builds; types do not.
+      .replace(/\(([^()]*)\)/g, (_match, args) => {
+        const types = args
+          .split(',')
+          .map((arg) => arg.trim().split(/\s+/)[0])
+          .filter(Boolean);
+        return `(${types.join(', ')})`;
+      })
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+function platformSymbol(key) {
+  const match = SYMBOL.exec(key);
+  return match ? match[1] : null;
+}
+
+function readAllowlist(file) {
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (error) {
+    fail(
+      `could not read the internal API allowlist at ${file}: ${error.message}. It is the record of which ` +
+        'internal platform APIs JetBrains have agreed to ignore in the plugin\'s Marketplace verification, ' +
+        'so verification cannot be gated without it.',
+      'Internal API allowlist missing'
+    );
+  }
+
+  const allowed = new Map();
+  const symbols = new Set();
+
+  text.split('\n').forEach((raw, index) => {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) return;
+
+    const key = normalize(line) || line.replace(/\s+/g, ' ');
+    allowed.set(key, index + 1);
+    const symbol = platformSymbol(key);
+    if (symbol) symbols.add(symbol);
+  });
+
+  if (allowed.size === 0) {
+    warn(
+      `${file} lists no approved usages, so every internal API usage the verifier reports will fail.`,
+      'Internal API allowlist is empty'
+    );
+  }
+
+  return { allowed, symbols };
+}
+
+function isDirectory(candidate) {
+  try {
+    return fs.statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function findReports(root, depth = 0) {
+  if (depth > MAX_DEPTH) return [];
+
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const found = [];
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) found.push(...findReports(full, depth + 1));
+    } else if (entry.name === USAGES_FILE) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function main() {
+  const allowlistFile = process.env.ALLOWLIST || DEFAULT_ALLOWLIST;
+  const { allowed, symbols } = readAllowlist(allowlistFile);
+  const leg = process.env.LEG || 'this leg';
+  // `=== 'success'`, not `!== 'failure'`: a skipped or cancelled verify wrote no reports to demand.
+  const verified = process.env.VERIFY_OUTCOME === 'success';
+
+  // The action sed's this out of the verifier's console log, so it can be empty or container-absolute.
+  // No fallback to searching the workspace on purpose: one that finds nothing would pass the leg having
+  // checked nothing.
+  const root = process.env.REPORTS_DIR;
+  if (!root || !isDirectory(root)) {
+    const where = root ? `"${root}", which is not a directory here` : 'nothing';
+    if (verified) {
+      fail(
+        `the verifier action reported its reports directory as ${where}, so no internal API usage could be ` +
+          'checked. Verification succeeded, so those reports exist and this gate is broken - passing the leg ' +
+          'would mean nothing. Upload Verify Reports is uploading nothing either; both read the same output.',
+        'Internal API usages not checked'
+      );
+    }
+    warn(
+      `the verifier action reported its reports directory as ${where}, so no internal API usage was checked. ` +
+        'Verification did not succeed, so the reports may legitimately be absent.',
+      'Internal API usages not checked'
+    );
+    return;
+  }
+
+  const reports = findReports(root);
+  if (reports.length === 0) {
+    // The verifier writes this file lazily on its first line, so no file means no usages.
+    addSummary(`### Internal API usages\n\nNo internal API usages reported for ${leg}.\n\n`);
+    reportStale(allowed, new Set(), allowlistFile);
+    return;
+  }
+
+  // The verifier reports a SET, and that is what JetBrains counted. Do not "fix" this into a multiset.
+  const observed = new Map();
+  const malformed = [];
+
+  for (const report of reports) {
+    for (const raw of fs.readFileSync(report, 'utf8').split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+
+      const key = normalize(line);
+      if (key === null) malformed.push({ report, line });
+      else if (!observed.has(key)) observed.set(key, line);
+    }
+  }
+
+  if (malformed.length > 0) {
+    fail(
+      `${malformed.length} line(s) in the verifier's ${USAGES_FILE} do not carry the "${BOILERPLATE.trim()} ` +
+        '<kind> is marked with ..." sentence this check splits on, so no usage could be compared. The report ' +
+        'format has changed - update normalize() in .github/scripts/check-internal-api-usages.js. ' +
+        `First line: ${malformed[0].line}`,
+      'Verifier report format changed'
+    );
+  }
+
+  const summary = [
+    '### Internal API usages',
+    '',
+    `${observed.size} reported for ${leg}, across ${reports.length} report file(s).`,
+    '',
+  ];
+
+  const unexpected = [...observed.keys()].filter((key) => !allowed.has(key));
+  if (unexpected.length > 0) {
+    const newSymbols = [];
+    const movedUsages = [];
+    unexpected.forEach((key) => {
+      const symbol = platformSymbol(key);
+      // An unfamiliar line shape counts as new - the cautious side.
+      if (symbol && symbols.has(symbol)) movedUsages.push(key);
+      else newSymbols.push(key);
+    });
+
+    summary.push('| verdict | usage |', '|---|---|');
+    newSymbols.forEach((key) => summary.push(`| **new internal API** | \`${key}\` |`));
+    movedUsages.forEach((key) => summary.push(`| moved usage | \`${key}\` |`));
+    summary.push('');
+    addSummary(`${summary.join('\n')}\n`);
+
+    // Detail to the log, not the annotation: GitHub ends an annotation at the first newline. These keys
+    // are the exact form the allowlist stores, so they can be pasted straight in.
+    if (newSymbols.length > 0) {
+      console.log('Internal platform APIs used without a JetBrains agreement:');
+      newSymbols.forEach((key) => console.log(`  ${key}`));
+    }
+    if (movedUsages.length > 0) {
+      console.log('Approved APIs used from plugin code the allowlist does not record:');
+      movedUsages.forEach((key) => console.log(`  ${key}`));
+    }
+
+    // One fail() for both: it exits, so a second would never print - but the remedies differ.
+    const remedies = [];
+    if (newSymbols.length > 0) {
+      remedies.push(
+        `${newSymbols.length} use(s) an internal platform API JetBrains have not agreed to ignore, which BLOCKS ` +
+          `publishing - adding a line to ${allowlistFile} does not make it publishable, the ceiling has to be ` +
+          'renegotiated with JetBrains first, and removing the usage is the better answer'
+      );
+    }
+    if (movedUsages.length > 0) {
+      remedies.push(
+        `${movedUsages.length} use(s) an already-approved API from plugin code the allowlist does not record - the ` +
+          'ceiling is unchanged, so replace the stale allowlist line with the reported one and say in the pull ' +
+          'request that the count is unchanged'
+      );
+    }
+
+    fail(
+      `${unexpected.length} internal API usage(s) are not on the approved list; see the log above for each. ` +
+        `${remedies.join('. ')}. The allowlist is shared by every verification leg, so this is not specific to ` +
+        'this product or platform version.',
+      newSymbols.length > 0 ? 'New internal API usage' : 'Internal API usage moved'
+    );
+  }
+
+  summary.push('All reported usages are on the approved list.', '');
+  addSummary(`${summary.join('\n')}\n`);
+  reportStale(allowed, new Set(observed.keys()), allowlistFile);
+}
+
+// A warning, not a failure: one allowlist covers every leg, and a version may stop annotating an API in
+// one product only.
+function reportStale(allowed, observedKeys, allowlistFile) {
+  const stale = [...allowed.entries()].filter(([key]) => !observedKeys.has(key));
+  if (stale.length === 0) return;
+
+  console.log('Allowlist entries no longer reported:');
+  stale.forEach(([key, lineNumber]) => console.log(`  ${allowlistFile}:${lineNumber} ${key}`));
+
+  warn(
+    `${stale.length} allowlist entr(ies) are no longer reported; see the log above for each. If the usage is gone ` +
+      `for good, remove the line from ${allowlistFile} - a shrinking ceiling is good news, but a stale entry hides ` +
+      'the next usage that reuses that API.',
+    'Stale internal API allowlist entry'
+  );
+}
+
+// The opposite of record-leg-status.js, which swallows exceptions so reporting cannot redden a leg. A
+// gate that hides its own bug and exits 0 is the green check that lies.
+try {
+  main();
+} catch (error) {
+  fail(
+    `the internal API allowlist check itself failed: ${error.stack || error.message}`,
+    'Internal API check failed'
+  );
+}

--- a/.github/workflows/shared-verify.yml
+++ b/.github/workflows/shared-verify.yml
@@ -64,7 +64,9 @@ on:
       # see what it would cost - do not add them to the default until it is zero:
       #   MISSING_DEPENDENCIES - RubyMine fails it, because the verifier does not understand "optional"
       #     dependencies.
-      #   INTERNAL_API_USAGES - the plugin still has some; they have to be resolved first.
+      #   INTERNAL_API_USAGES - all-or-nothing, and the verifier has no per-usage allowlist, so it would
+      #     fail on the usages JetBrains have agreed to ignore. Enforced instead by the
+      #     `Check internal API usages against the allowlist` step.
       failure-levels:
         description: 'Passed to the verifier action. The list of failure levels you want to set. Any set and found will cause this action to fail. One of COMPATIBILITY_WARNINGS, COMPATIBILITY_PROBLEMS, DEPRECATED_API_USAGES, EXPERIMENTAL_API_USAGES, INTERNAL_API_USAGES, OVERRIDE_ONLY_API_USAGES, NON_EXTENDABLE_API_USAGES, PLUGIN_STRUCTURE_WARNINGS, MISSING_DEPENDENCIES, INVALID_PLUGIN, NOT_DYNAMIC, whitespace-separated.'
         required: false
@@ -184,6 +186,22 @@ jobs:
             || fromJson(format('{{"include":[{{"product":"{0}","version":"{1}"}}]}}', inputs.product, inputs.version)) }}
 
     steps:
+      # Only the internal API gate needs the repository. MUST be first: checkout clears the workspace
+      # unless it is already a clone of this repo, so later it would delete the staged plugin zip.
+      - name: Checkout the internal API allowlist
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The head commit, as `build-plugin` uses: the allowlist must come from the same commit as the
+          # zip. `github.ref` on a pull request is the synthesised merge ref, whose base may have removed
+          # an entry the head-built zip still needs.
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github/internal-api-usages-allowlist.txt
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
       # Every source lands a zip in build/distributions, which is the verifier action's default
       # plugin-location (resolved relative to the workspace), so nothing downstream varies.
       - name: Download plugin distribution (this run)
@@ -297,6 +315,21 @@ jobs:
           if [ -n "$log_file" ] && [ -f "$log_file" ]; then
             cat "$log_file"
           fi
+
+      # Runs on every path, dispatch included: a one-off run is asking whether that zip passes TODAY's
+      # approved list. Placed BEFORE Upload Verify Reports so that step's `failure()` still uploads the
+      # report naming the usage - on `pull_request` its `inputs` are empty, so `failure()` is the only
+      # thing that uploads.
+      - name: Check internal API usages against the allowlist
+        id: internal-api-usages
+        if: ${{ !cancelled() }}
+        env:
+          REPORTS_DIR: ${{ steps.verify.outputs.verification-reports-dir }}
+          # `outcome`, not `failure()`: a leg that never downloaded its plugin is `skipped` and a timed-out
+          # one is `cancelled`; the script only demands reports when verification actually succeeded.
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          LEG: ${{ matrix.product }} ${{ matrix.version }}
+        run: node .github/scripts/check-internal-api-usages.js
 
       # One invocation per job, so the action's fixed verification_result.log name needs no
       # per-product copy - the artifact name carries the product and version instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,9 @@
 
 ### Build / CI
 
+- [#4003](https://github.com/KronicDeth/intellij-elixir/pull/4003) [@sh41](https://github.com/sh41)
+  - **Plugin verification now fails on an internal platform API usage that is not on the approved list.**
+
 - [#3994](https://github.com/KronicDeth/intellij-elixir/pull/3994) [@sh41](https://github.com/sh41)
   - **A pull request build's plugin artifact is now stamped with a commit that exists.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@
       - [Which versions CI tests against](#which-versions-ci-tests-against)
         - [Widening Elixir support](#widening-elixir-support)
         - [Reading a leg in the checks list](#reading-a-leg-in-the-checks-list)
+      - [Internal API usages](#internal-api-usages)
       - [Working with a different Elixir/OTP version](#working-with-a-different-elixirotp-version)
     - [From IntelliJ IDEA](#from-intellij-idea)
       - [Running the plugin in a specific IDE](#running-the-plugin-in-a-specific-ide)
@@ -459,6 +460,25 @@ The status text names the reason: `tests failed` with a count beside it, versus
 `failed at compile` where the counts cover only what ran. For *which* tests failed, follow a row
 to its `Test Results (...)` check or read the **Failed tests** summary on the leg's own job - the
 comment deals in counts only.
+
+#### Internal API usages
+
+JetBrains have agreed to ignore the internal platform APIs listed in
+`.github/internal-api-usages-allowlist.txt`. **Any other internal API usage blocks the plugin from being
+published**, so `.github/scripts/check-internal-api-usages.js` fails any verification leg that reports
+one.
+
+**The allowlist records that agreement; it does not suppress a warning.** Adding a line does not make a
+usage publishable - that needs a new agreement with JetBrains, and removing the usage is the better
+answer. A **moved usage** (an approved API called from code the allowlist does not name) is the exception:
+the ceiling is unchanged, so just replace the line with the reported one, which pastes in verbatim.
+
+To check a local run - `verifyPlugin` covers more IDEs than CI, so it may report more:
+
+```sh
+REPORTS_DIR=build/reports/pluginVerifier VERIFY_OUTCOME=success \
+  node .github/scripts/check-internal-api-usages.js
+```
 
 #### Working with a different Elixir/OTP version
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -526,8 +526,12 @@ intellijPlatform {
 
     pluginVerification {
         // Match CI failure levels: only fail on compatibility problems and invalid plugin.
-        // INTERNAL_API_USAGES is excluded because the verifier flags ComponentManager methods
-        // referenced indirectly via service/extension registration bytecode, not our source code.
+        // INTERNAL_API_USAGES is excluded because it is all-or-nothing: it would fail on the usages
+        // JetBrains have agreed to ignore. Those are capped by .github/internal-api-usages-allowlist.txt,
+        // which CI enforces; to check a local run against it (broader IDE set than CI, so it can report
+        // more):
+        //   REPORTS_DIR=build/reports/pluginVerifier VERIFY_OUTCOME=success \
+        //     node .github/scripts/check-internal-api-usages.js
         // See https://platform.jetbrains.com/t/stricter-plugin-verification-in-intellij-platform-gradle-plugin-2-15-0/4169
         failureLevel.set(
             listOf(


### PR DESCRIPTION
JetBrains have agreed to ignore the plugin's current internal platform API usages in its Marketplace verification, and any additional one blocks publishing. Nothing enforced that, so a new usage could merge and only surface at publish time.

`INTERNAL_API_USAGES` can't do it — all-or-nothing, and the verifier has no per-usage allowlist — so each verify leg diffs the verifier's own `internal-api-usages.txt` against `.github/internal-api-usages-allowlist.txt`. That file is a **ceiling, not a suppression list**: a new usage needs a new agreement with JetBrains, not a new line.

**Proven red in CI.** Temporarily reverting [1b9d13fe9](https://github.com/KronicDeth/intellij-elixir/commit/1b9d13fe91ce394cbc8a8a4ae330612d906cddc4) (#4002), which had removed a use of internal `createPsiDocumentationTarget`, failed all six verify legs — [run 33845042617](https://github.com/KronicDeth/intellij-elixir/actions/runs/33845042617), [ideaIU 2025.3.6](https://github.com/KronicDeth/intellij-elixir/actions/runs/33845042617/job/100936579237?pr=4003). `Verify Plugin` itself passed, so the gate is what caught it, and every leg still uploaded its report. The revert has been dropped.

Review notes:

- The `verify` job gains its first `actions/checkout`. It must run first, or it clears the staged plugin zip.
- One call site can be several reported usages: that revert added two (internal class + method), which is why `CodeInsightContextManagerImpl` takes two allowlist lines and a Kotlin `Companion` access takes five.
- Two `INTERNAL_API_USAGES` comments that were factually wrong are corrected, in `build.gradle.kts` and `shared-verify.yml`.
