### PR TITLE
fix(console): keep the file-reference filter linear, and link a Windows path from its drive letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 
 ### Bug Fixes
 
+- [#4005](https://github.com/KronicDeth/intellij-elixir/pull/4005) [@sh41](https://github.com/sh41)
+  - **The IDE no longer freezes for seconds at a time while a terminal produces output.** Fixes [#4004](https://github.com/KronicDeth/intellij-elixir/issues/4004).
+
 - [#4001](https://github.com/KronicDeth/intellij-elixir/pull/4001) [@sh41](https://github.com/sh41)
   - **A Mix project opened in a small IDE is configured as an Elixir project again.** Fixes [#3999](https://github.com/KronicDeth/intellij-elixir/issues/3999).
   - **A Mix app below the opened directory is attached to the project again**, in RubyMine, GoLand and other small IDEs that support attaching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@
 ### Bug Fixes
 
 - [#4005](https://github.com/KronicDeth/intellij-elixir/pull/4005) [@sh41](https://github.com/sh41)
-  - **The IDE no longer freezes for seconds at a time while a terminal produces output.** Fixes [#4004](https://github.com/KronicDeth/intellij-elixir/issues/4004).
+  - **The IDE no longer freezes while a terminal produces output.** Fixes [#4004](https://github.com/KronicDeth/intellij-elixir/issues/4004).
+  - **A Windows path printed with its drive letter now links from the drive letter.**
 
 - [#4001](https://github.com/KronicDeth/intellij-elixir/pull/4001) [@sh41](https://github.com/sh41)
   - **A Mix project opened in a small IDE is configured as an Elixir project again.** Fixes [#3999](https://github.com/KronicDeth/intellij-elixir/issues/3999).

--- a/src/org/elixir_lang/console/AboveGenericFileLinks.java
+++ b/src/org/elixir_lang/console/AboveGenericFileLinks.java
@@ -1,0 +1,26 @@
+package org.elixir_lang.console;
+
+import com.intellij.execution.filters.Filter.ResultItem;
+import com.intellij.execution.filters.HyperlinkInfo;
+import com.intellij.openapi.editor.markup.HighlighterLayer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A link that outranks the terminal's own bare-path link over the same text.
+ *
+ * <p>{@code TerminalGenericFileFilter} is registered ahead of every plugin's and marks up the same
+ * path, invisibly and opening at line 1. Both default to {@link HighlighterLayer#HYPERLINK} and a
+ * tie goes to whichever was added first, which is the terminal's, so one layer up is enough.
+ */
+final class AboveGenericFileLinks extends ResultItem {
+    AboveGenericFileLinks(int highlightStartOffset,
+                          int highlightEndOffset,
+                          @NotNull HyperlinkInfo hyperlinkInfo) {
+        super(highlightStartOffset, highlightEndOffset, hyperlinkInfo);
+    }
+
+    @Override
+    public int getHighlighterLayer() {
+        return HighlighterLayer.HYPERLINK + 1;
+    }
+}

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -6,6 +6,7 @@ import com.intellij.execution.filters.OpenFileHyperlinkInfo;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.patterns.StringPattern;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,7 +24,17 @@ public final class FileReferenceFilter implements Filter {
     /** The expression a formatted frame's {@code path:line} is read with. */
     static final String COMPILATION_ERROR_PATH = PATH_MACROS + ":" + LINE_MACROS;
     private static final String COLUMN_MACROS = "$COLUMN$";
-    private static final String FILE_PATH_REGEXP = "\\s*([0-9 a-z_A-Z\\-\\\\./]+)";
+    /**
+     * The lookbehind and possessive {@code *} keep this linear, and a console hands it every line it
+     * prints. The path class is closed over ordinary text, so without the lookbehind every offset on
+     * an unmatchable line starts an attempt that rescans the rest of it; no match is lost, because
+     * one found inside a run is always found at that run's start too. The possessive stops the
+     * leading whitespace being re-split against the class, which also accepts a space.
+     *
+     * <p>Assumes {@link #PATH_MACROS} opens the expression, as {@link #COMPILATION_ERROR_PATH} does.
+     */
+    private static final String FILE_PATH_REGEXP =
+            "(?<![\\s0-9 a-z_A-Z\\-\\\\./])\\s*+([0-9 a-z_A-Z\\-\\\\./]+)";
     private static final String NUMBER_REGEXP = "([0-9]+)";
 
     private final int myColumnMatchGroup;
@@ -97,7 +108,10 @@ public final class FileReferenceFilter implements Filter {
     @Nullable
     @Override
     public Result applyFilter(@NotNull String line, int entireLength) {
-        Matcher matcher = myPattern.matcher(line);
+        // A write waiting behind this read action holds up the EDT until the match ends, and Matcher
+        // polls nothing itself, so the sequence it reads does - as RegexpFilter's does. Letting the
+        // cancellation out lets the non-blocking read action retry, so the line still gets linked.
+        Matcher matcher = myPattern.matcher(StringPattern.newBombedCharSequence(line));
         Result result = null;
 
         if (matcher.find()) {

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -25,16 +25,18 @@ public final class FileReferenceFilter implements Filter {
     static final String COMPILATION_ERROR_PATH = PATH_MACROS + ":" + LINE_MACROS;
     private static final String COLUMN_MACROS = "$COLUMN$";
     /**
-     * The lookbehind and possessive {@code *} keep this linear, and a console hands it every line it
-     * prints. The path class is closed over ordinary text, so without the lookbehind every offset on
-     * an unmatchable line starts an attempt that rescans the rest of it; no match is lost, because
-     * one found inside a run is always found at that run's start too. The possessive stops the
-     * leading whitespace being re-split against the class, which also accepts a space.
+     * Keeps the match linear on a line that cannot match: the lookbehind drops start offsets that
+     * would only rescan the same run, and the possessive stops leading whitespace being re-split
+     * against a class that also accepts a space.
+     *
+     * <p>The drive-letter prefix and lookahead exist because {@code :} is not in the path class, so
+     * {@code C:} could otherwise be neither captured nor started from.
      *
      * <p>Assumes {@link #PATH_MACROS} opens the expression, as {@link #COMPILATION_ERROR_PATH} does.
      */
     private static final String FILE_PATH_REGEXP =
-            "(?<![\\s0-9 a-z_A-Z\\-\\\\./])\\s*+([0-9 a-z_A-Z\\-\\\\./]+)";
+            "(?:(?<![\\s0-9 a-z_A-Z\\-\\\\./])|(?=[A-Za-z]:[\\\\/]))"
+                    + "\\s*+((?:[A-Za-z]:)?[0-9 a-z_A-Z\\-\\\\./]+)";
     private static final String NUMBER_REGEXP = "([0-9]+)";
 
     private final int myColumnMatchGroup;
@@ -108,9 +110,8 @@ public final class FileReferenceFilter implements Filter {
     @Nullable
     @Override
     public Result applyFilter(@NotNull String line, int entireLength) {
-        // A write waiting behind this read action holds up the EDT until the match ends, and Matcher
-        // polls nothing itself, so the sequence it reads does - as RegexpFilter's does. Letting the
-        // cancellation out lets the non-blocking read action retry, so the line still gets linked.
+        // Matcher polls nothing itself, so the sequence it reads does, as RegexpFilter's does. The
+        // cancellation is left to propagate so the non-blocking read action retries.
         Matcher matcher = myPattern.matcher(StringPattern.newBombedCharSequence(line));
         Result result = null;
 
@@ -127,7 +128,7 @@ public final class FileReferenceFilter implements Filter {
 
                 for (VirtualFile virtualFile : virtualFileCollection) {
                     resultItemList.add(
-                            new ResultItem(
+                            new AboveGenericFileLinks(
                                     highlightStartOffset,
                                     highlightEndOffset,
                                     new OpenFileHyperlinkInfo(myProject, virtualFile, fileLine, fileColumn)

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -16,14 +16,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/console/FileReferenceFilter.java
+ * <a href="https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/console/FileReferenceFilter.java">...</a>
  */
 public final class FileReferenceFilter implements Filter {
     static final String LINE_MACROS = "$LINE$";
     static final String PATH_MACROS = "$FILE_PATH$";
     /** The expression a formatted frame's {@code path:line} is read with. */
     static final String COMPILATION_ERROR_PATH = PATH_MACROS + ":" + LINE_MACROS;
-    private static final String COLUMN_MACROS = "$COLUMN$";
     /**
      * Keeps the match linear on a line that cannot match: the lookbehind drops start offsets that
      * would only rescan the same run, and the possessive stops leading whitespace being re-split
@@ -39,7 +38,6 @@ public final class FileReferenceFilter implements Filter {
                     + "\\s*+((?:[A-Za-z]:)?[0-9 a-z_A-Z\\-\\\\./]+)";
     private static final String NUMBER_REGEXP = "([0-9]+)";
 
-    private final int myColumnMatchGroup;
     private final int myFileMatchGroup;
     private final int myLineMatchGroup;
     private final Pattern myPattern;
@@ -54,24 +52,21 @@ public final class FileReferenceFilter implements Filter {
 
         int filePathIndex = expression.indexOf(PATH_MACROS);
         int lineIndex = expression.indexOf(LINE_MACROS);
-        int columnIndex = expression.indexOf(COLUMN_MACROS);
 
         if (filePathIndex == -1) {
             throw new InvalidExpressionException("Expression must contain " + PATH_MACROS + " marcos.");
         }
+
+        // Both are required because the highlight runs from the path's group to the line's.
+        if (lineIndex == -1) {
+            throw new InvalidExpressionException("Expression must contain " + LINE_MACROS + " marcos.");
+        }
+
         TreeMap<Integer, String> map = new TreeMap<>();
         map.put(filePathIndex, PATH_MACROS);
+        map.put(lineIndex, LINE_MACROS);
         String regex = StringUtil.replace(expression, PATH_MACROS, FILE_PATH_REGEXP);
-
-        if (lineIndex != -1) {
-            regex = StringUtil.replace(regex, LINE_MACROS, NUMBER_REGEXP);
-            map.put(lineIndex, LINE_MACROS);
-        }
-
-        if (columnIndex != -1) {
-            regex = StringUtil.replace(regex, COLUMN_MACROS, NUMBER_REGEXP);
-            map.put(columnIndex, COLUMN_MACROS);
-        }
+        regex = StringUtil.replace(regex, LINE_MACROS, NUMBER_REGEXP);
 
         // The block below determines the registers based on the sorted map.
         int count = 0;
@@ -83,14 +78,11 @@ public final class FileReferenceFilter implements Filter {
                 filePathIndex = count;
             } else if (LINE_MACROS.equals(s)) {
                 lineIndex = count;
-            } else if (COLUMN_MACROS.equals(s)) {
-                columnIndex = count;
             }
         }
 
         myFileMatchGroup = filePathIndex;
         myLineMatchGroup = lineIndex;
-        myColumnMatchGroup = columnIndex;
         myPattern = Pattern.compile(regex, Pattern.MULTILINE);
     }
 
@@ -119,19 +111,19 @@ public final class FileReferenceFilter implements Filter {
             String filePath = matcher.group(myFileMatchGroup);
             Collection<VirtualFile> virtualFileCollection = SourceFileResolver.resolve(myProject, filePath);
 
-            if (virtualFileCollection.size() > 0) {
+            if (!virtualFileCollection.isEmpty()) {
                 List<ResultItem> resultItemList = new ArrayList<>(virtualFileCollection.size());
-                int highlightStartOffset = entireLength - line.length() + matcher.start(1);
-                int highlightEndOffset = highlightStartOffset + matcher.end(matcher.groupCount()) - matcher.start(1);
+                int lineStartOffset = entireLength - line.length();
+                int highlightStartOffset = lineStartOffset + matcher.start(myFileMatchGroup);
+                int highlightEndOffset = lineStartOffset + matcher.end(myLineMatchGroup);
                 int fileLine = matchGroupToNumber(matcher, myLineMatchGroup);
-                int fileColumn = matchGroupToNumber(matcher, myColumnMatchGroup);
 
                 for (VirtualFile virtualFile : virtualFileCollection) {
                     resultItemList.add(
                             new AboveGenericFileLinks(
                                     highlightStartOffset,
                                     highlightEndOffset,
-                                    new OpenFileHyperlinkInfo(myProject, virtualFile, fileLine, fileColumn)
+                                    new OpenFileHyperlinkInfo(myProject, virtualFile, fileLine)
                             )
                     );
                 }

--- a/src/org/elixir_lang/console/FileReferenceFilter.java
+++ b/src/org/elixir_lang/console/FileReferenceFilter.java
@@ -3,6 +3,7 @@ package org.elixir_lang.console;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.InvalidExpressionException;
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -18,7 +19,7 @@ import java.util.regex.Pattern;
 /**
  * <a href="https://github.com/ignatov/intellij-erlang/blob/master/src/org/intellij/erlang/console/FileReferenceFilter.java">...</a>
  */
-public final class FileReferenceFilter implements Filter {
+public final class FileReferenceFilter implements Filter, DumbAware {
     static final String LINE_MACROS = "$LINE$";
     static final String PATH_MACROS = "$FILE_PATH$";
     /** The expression a formatted frame's {@code path:line} is read with. */

--- a/src/org/elixir_lang/console/LiteralStackTraceFilter.java
+++ b/src/org/elixir_lang/console/LiteralStackTraceFilter.java
@@ -4,6 +4,7 @@ import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.HyperlinkInfoFactory;
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -58,7 +59,7 @@ import java.util.regex.Pattern;
  * - it is zero in the terminal by construction, and a console added later that behaves like the
  * terminal gets the safe branch without anyone having to notice it exists.
  */
-final class LiteralStackTraceFilter implements Filter {
+final class LiteralStackTraceFilter implements Filter, DumbAware {
     /**
      * The path and its number, together on one line. A stack trace's {@code file:} is a charlist, so
      * Elixir 1.14 and earlier inspect it as {@code 'lib/x.ex'} and 1.15 and later as the sigil

--- a/src/org/elixir_lang/console/LiteralStackTraceFilter.java
+++ b/src/org/elixir_lang/console/LiteralStackTraceFilter.java
@@ -4,7 +4,6 @@ import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.HyperlinkInfoFactory;
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
-import com.intellij.openapi.editor.markup.HighlighterLayer;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
@@ -242,37 +241,6 @@ final class LiteralStackTraceFilter implements Filter {
         );
 
         return resultItems;
-    }
-
-    /**
-     * A link that outranks the terminal's own bare-path link over the same text.
-     *
-     * <p>The reworked terminal registers {@code TerminalGenericFileFilter} ahead of every plugin's
-     * filters and builds the composite with {@code setForceUseAllFilters(true)}, so both run and both
-     * mark up the same path. Its link is an invisible one - Ctrl to follow - and opens the file at
-     * line 1, because all it sees is a path with no {@code :line} after it. Ours knows the number
-     * from the keyword list beside it.
-     *
-     * <p>Both default to {@link HighlighterLayer#HYPERLINK}, and an exact-range tie goes to whichever
-     * was added first, which is the terminal's. {@link FileReferenceFilter} never notices because its
-     * match covers {@code path:line} and so is a wider range than the bare path. One layer up is
-     * enough.
-     *
-     * <p>It applies to every link this filter makes, including a wrapped path linked to the top of
-     * the file, where the terminal's own link would have gone to the same place. Distinguishing the
-     * two would buy nothing and would make the layer depend on which branch produced the link.
-     */
-    private static final class AboveGenericFileLinks extends ResultItem {
-        private AboveGenericFileLinks(int highlightStartOffset,
-                                      int highlightEndOffset,
-                                      @NotNull HyperlinkInfo hyperlinkInfo) {
-            super(highlightStartOffset, highlightEndOffset, hyperlinkInfo);
-        }
-
-        @Override
-        public int getHighlighterLayer() {
-            return HighlighterLayer.HYPERLINK + 1;
-        }
     }
 
     /**

--- a/src/org/elixir_lang/console/SourceFileResolver.java
+++ b/src/org/elixir_lang/console/SourceFileResolver.java
@@ -54,10 +54,10 @@ final class SourceFileResolver {
      * <p>Empty when nothing matches - a path naming a file nothing indexed can be found for, or one
      * whose extension {@link #PATTERN_FILENAME} does not accept.
      *
-     * <p>Requires a read action for the {@link FilenameIndex} lookup, and indexes to be built. Both
-     * are the platform's to provide: it runs console filters inside
-     * {@code ReadAction.nonBlocking}, and skips a filter that is not {@code DumbAware} while
-     * indexing.
+     * <p>Requires a read action, which the platform provides by running console filters inside
+     * {@code ReadAction.nonBlocking}. It does not require indexes to be built: the
+     * {@link FilenameIndex} lookup answers during dumb mode rather than throwing, returning whatever
+     * has been indexed so far, which is why both filters are {@code DumbAware}.
      */
     @NotNull
     @RequiresReadLock

--- a/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
+++ b/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
@@ -2,9 +2,14 @@ package org.elixir_lang.console
 
 import com.intellij.execution.filters.FileHyperlinkInfo
 import com.intellij.execution.filters.Filter
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
 import org.elixir_lang.PlatformTestCase
 import java.util.concurrent.Callable
+import java.util.concurrent.TimeUnit
 
 /**
  * Characterises the console filter that has linked compiler errors and formatted stack frames since
@@ -79,6 +84,72 @@ class FileReferenceFilterTest : PlatformTestCase() {
         assertEmpty(applyFilter("{Gald.Phase, :init, 1, [file: 'lib/gald/phase.ex', line: 54]}"))
     }
 
+    /**
+     * The path class accepts spaces. Pinned because dropping the space is the cheapest-looking cure
+     * for the backtracking below, and it would stop linking every path like this one.
+     */
+    fun testLinksAPathContainingSpaces() {
+        val file = myFixture.addFileToProject("my app/lib/some file.ex", "defmodule Some.File do\nend\n")
+
+        val items = applyFilter("  my app/lib/some file.ex:3: anonymous fn/2")
+
+        assertEquals("Expected the spaced path to link, got: $items", 1, items.size)
+        assertEquals(file.virtualFile, (items.single().hyperlinkInfo as FileHyperlinkInfo).descriptor!!.file)
+    }
+
+    /**
+     * A line the expression cannot match still has to be cheap. The three shapes fail for different
+     * reasons - retrying at every offset makes any long line quadratic, and `\s*` competing with the
+     * path class for the same space makes an indented one cubic - so a cure for one can leave the
+     * others hanging. Each ends in a bare colon, so it fails late rather than early.
+     */
+    fun testDoesNotBacktrackOnAnIndentedLine() {
+        assertRejectsWithinBudget(" ".repeat(1000) + "a".repeat(1000) + ":")
+    }
+
+    fun testDoesNotBacktrackOnAWhitespaceOnlyLine() {
+        assertRejectsWithinBudget(" ".repeat(2000) + ":")
+    }
+
+    fun testDoesNotBacktrackOnALineWithoutSpaces() {
+        assertRejectsWithinBudget("a".repeat(32000) + ":")
+    }
+
+    /**
+     * A write waiting behind the filter's read action stalls the EDT until the match ends, and
+     * `Matcher` polls nothing itself. The indicator is started before being cancelled because
+     * `runProcess` starts one that is not running and `EmptyProgressIndicator.start` clears the
+     * cancellation. The line clears 1024 characters, which is how often the bombed sequence checks.
+     */
+    fun testAbortsWhenTheProgressIndicatorIsCancelled() {
+        val line = " ".repeat(2000) + ":"
+        val indicator = EmptyProgressIndicator().apply { start(); cancel() }
+        val filter = FileReferenceFilter(project, FileReferenceFilter.COMPILATION_ERROR_PATH)
+
+        val thrown = ApplicationManager.getApplication().executeOnPooledThread<Throwable?> {
+            try {
+                ProgressManager.getInstance().runProcess({ filter.applyFilter(line, line.length) }, indicator)
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        }.get(30, TimeUnit.SECONDS)
+
+        assertInstanceOf(thrown, ProcessCanceledException::class.java)
+    }
+
+    private fun assertRejectsWithinBudget(line: String) {
+        val start = System.nanoTime()
+        val items = applyFilter(line)
+        val elapsedMillis = (System.nanoTime() - start) / 1_000_000
+
+        assertEmpty("Expected a line ending in a bare colon not to link, got: $items", items)
+        assertTrue(
+            "Matching ${line.length} characters took ${elapsedMillis}ms, budget is ${BUDGET_MILLIS}ms",
+            elapsedMillis < BUDGET_MILLIS
+        )
+    }
+
     private fun applyFilter(line: String): List<Filter.ResultItem> =
         ReadAction.nonBlocking(
             Callable {
@@ -86,4 +157,9 @@ class FileReferenceFilterTest : PlatformTestCase() {
                     .applyFilter(line, line.length)
             }
         ).executeSynchronously()?.resultItems.orEmpty()
+
+    companion object {
+        /** Wide on purpose: a working expression takes about a millisecond, a backtracking one seconds. */
+        private const val BUDGET_MILLIS = 1_000L
+    }
 }

--- a/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
+++ b/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.testFramework.DumbModeTestUtils
 import org.elixir_lang.PlatformTestCase
 import java.io.File
 import java.util.concurrent.Callable
@@ -114,6 +115,38 @@ class FileReferenceFilterTest : PlatformTestCase() {
         val item = items.single()
         assertEquals("The whole path must be highlighted, drive letter included", 0, item.highlightStartOffset)
         assertEquals(virtualFile, (item.hyperlinkInfo as FileHyperlinkInfo).descriptor!!.file)
+    }
+
+    /**
+     * The suffix search reads [com.intellij.psi.search.FilenameIndex] through a lookup that tolerates
+     * dumb mode, so it answers rather than throwing. Pinned because the filter is
+     * [com.intellij.openapi.project.DumbAware] on the strength of it.
+     */
+    fun testResolvesASuffixPathWhileIndexing() {
+        val file = myFixture.addFileToProject("lib/gald/turn.ex", "defmodule Gald.Turn do\nend\n")
+
+        val items = DumbModeTestUtils.computeInDumbModeSynchronously<List<Filter.ResultItem>>(project) {
+            applyFilter("gald/turn.ex:1: whatever")
+        }
+
+        assertEquals("Expected the suffix match to resolve while indexing, got: $items", 1, items.size)
+        assertEquals(file.virtualFile, (items.single().hyperlinkInfo as FileHyperlinkInfo).descriptor!!.file)
+    }
+
+    /** The path-as-written branch is pure VFS, so it still links while an index is being built. */
+    fun testLinksAnAbsolutePathWhileIndexing() {
+        val file = File(project.basePath!!, "dumb_mode.ex")
+        file.parentFile.mkdirs()
+        file.writeText("defmodule DumbMode do\nend\n")
+        val virtualFile = requireNotNull(LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file))
+        val line = "${file.absolutePath}:3: DumbMode.boom/0"
+
+        val items = DumbModeTestUtils.computeInDumbModeSynchronously<List<Filter.ResultItem>>(project) {
+            applyFilter(line)
+        }
+
+        assertEquals("Expected the absolute path to link while indexing, got: $items", 1, items.size)
+        assertEquals(virtualFile, (items.single().hyperlinkInfo as FileHyperlinkInfo).descriptor!!.file)
     }
 
     /** Pins the offsets, which are computed from the match groups rather than from the path text. */

--- a/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
+++ b/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
@@ -116,6 +116,16 @@ class FileReferenceFilterTest : PlatformTestCase() {
         assertEquals(virtualFile, (item.hyperlinkInfo as FileHyperlinkInfo).descriptor!!.file)
     }
 
+    /** Pins the offsets, which are computed from the match groups rather than from the path text. */
+    fun testHighlightsExactlyThePathAndItsLine() {
+        myFixture.addFileToProject("lib/gald/turn.ex", "defmodule Gald.Turn do\nend\n")
+        val line = "    (gald) lib/gald/turn.ex:38: Gald.Turn.handle_cast/2"
+
+        val item = applyFilter(line).single()
+
+        assertEquals("lib/gald/turn.ex:38", line.substring(item.highlightStartOffset, item.highlightEndOffset))
+    }
+
     /** The terminal's own bare-path link is registered first and wins a tie; ours knows the line. */
     fun testOutranksTheTerminalsOwnGenericFileLink() {
         myFixture.addFileToProject("lib/gald/turn.ex", "defmodule Gald.Turn do\nend\n")

--- a/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
+++ b/tests/org/elixir_lang/console/FileReferenceFilterTest.kt
@@ -6,8 +6,11 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.vfs.LocalFileSystem
 import org.elixir_lang.PlatformTestCase
+import java.io.File
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 
@@ -84,10 +87,7 @@ class FileReferenceFilterTest : PlatformTestCase() {
         assertEmpty(applyFilter("{Gald.Phase, :init, 1, [file: 'lib/gald/phase.ex', line: 54]}"))
     }
 
-    /**
-     * The path class accepts spaces. Pinned because dropping the space is the cheapest-looking cure
-     * for the backtracking below, and it would stop linking every path like this one.
-     */
+    /** Pinned because dropping the space from the path class would be a tempting cure below. */
     fun testLinksAPathContainingSpaces() {
         val file = myFixture.addFileToProject("my app/lib/some file.ex", "defmodule Some.File do\nend\n")
 
@@ -98,10 +98,39 @@ class FileReferenceFilterTest : PlatformTestCase() {
     }
 
     /**
-     * A line the expression cannot match still has to be cheap. The three shapes fail for different
-     * reasons - retrying at every offset makes any long line quadratic, and `\s*` competing with the
-     * path class for the same space makes an indented one cubic - so a cure for one can leave the
-     * others hanging. Each ends in a bare colon, so it fails late rather than early.
+     * On Windows the drive letter's colon is not in the path class, so the match used to start after
+     * it and resolve nothing. Written to disk because only a real file is found by an absolute path.
+     */
+    fun testLinksAnAbsolutePathIncludingAnyDriveLetter() {
+        val file = File(project.basePath!!, "drive_letter.ex")
+        file.parentFile.mkdirs()
+        file.writeText("defmodule DriveLetter do\nend\n")
+        val virtualFile = requireNotNull(LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file))
+        val line = "${file.absolutePath}:7: DriveLetter.boom/0"
+
+        val items = applyFilter(line)
+
+        assertEquals("Expected the absolute path to link, got: $items", 1, items.size)
+        val item = items.single()
+        assertEquals("The whole path must be highlighted, drive letter included", 0, item.highlightStartOffset)
+        assertEquals(virtualFile, (item.hyperlinkInfo as FileHyperlinkInfo).descriptor!!.file)
+    }
+
+    /** The terminal's own bare-path link is registered first and wins a tie; ours knows the line. */
+    fun testOutranksTheTerminalsOwnGenericFileLink() {
+        myFixture.addFileToProject("lib/gald/turn.ex", "defmodule Gald.Turn do\nend\n")
+
+        val item = applyFilter("lib/gald/turn.ex:38: Gald.Turn.handle_cast/2").single()
+
+        assertTrue(
+            "Layer ${item.highlighterLayer} must beat the terminal's ${HighlighterLayer.HYPERLINK}",
+            item.highlighterLayer > HighlighterLayer.HYPERLINK
+        )
+    }
+
+    /**
+     * The three shapes fail differently - retrying at every offset is quadratic, `\s*` competing
+     * with the path class for a space is cubic - so a cure for one can leave the others hanging.
      */
     fun testDoesNotBacktrackOnAnIndentedLine() {
         assertRejectsWithinBudget(" ".repeat(1000) + "a".repeat(1000) + ":")
@@ -116,10 +145,9 @@ class FileReferenceFilterTest : PlatformTestCase() {
     }
 
     /**
-     * A write waiting behind the filter's read action stalls the EDT until the match ends, and
-     * `Matcher` polls nothing itself. The indicator is started before being cancelled because
-     * `runProcess` starts one that is not running and `EmptyProgressIndicator.start` clears the
-     * cancellation. The line clears 1024 characters, which is how often the bombed sequence checks.
+     * Started before being cancelled because `runProcess` starts an indicator that is not running
+     * and `EmptyProgressIndicator.start` clears the cancellation. The line clears 1024 characters,
+     * which is how often the bombed sequence checks.
      */
     fun testAbortsWhenTheProgressIndicatorIsCancelled() {
         val line = " ".repeat(2000) + ":"


### PR DESCRIPTION
Fixes #4004.

## The freeze

`FileReferenceFilter`'s path expression had no anchor, and its character class is closed over everything ordinary console text is made of — letters, digits, space, `.`, `/`, `-`, `\`. So on a line that cannot match, `find()` restarted at every offset and each attempt rescanned the rest of the line. `\s*` and the class also competed for the same space character, which let every whitespace run be split between them every possible way, making an indented line cubic rather than quadratic.

That had been true for years, but until #3925 the filter only saw output from this plugin's own run configurations. Installing it on every console put it in front of every line of every terminal, and a long line then pinned the read lock while a queued write held the EDT behind it — 5–7 second freezes, and one of 36.9 s.

A negative lookbehind drops the redundant start offsets and a possessive `\s*+` stops the leading whitespace being re-split. Both are needed and neither is sufficient: measured on one `find()` over a 64 000-character non-matching line (ms, JBR 21.0.8):

| variant | no spaces | all spaces | half-indented |
| --- | --- | --- | --- |
| before | 21 352 | blown at 2 000 | blown at 2 000 |
| space removed from the class | 19 333 | 25 243 | 20 863 |
| possessive `\s*+` only | 19 605 | 7 702 | 16 384 |
| lookbehind only | 1.8 | 18 875 | 14 552 |
| **both (this change)** | **1.8** | **1.4** | **1.6** |

Dropping the space from the character class was the obvious-looking cure and is in the table because it does not work — it only shortens class runs in inputs that happen to contain spaces, and it stops `my app/lib/some file.ex` linking at all. `testLinksAPathContainingSpaces` pins that.

No match is lost by the lookbehind: from a run's start the greedy class reaches the same terminator it would from any later offset inside the run, and backtracking tests `:` at every position between, so a match reachable from inside a run is reachable from its start — which is the one `find()` returns anyway. Checked against a corpus of realistic frames: 0 differences.

The line is now read through a bombed `CharSequence`, which is what the platform's own `RegexpFilter` does with the line it is handed and what this fork dropped. `Matcher` polls nothing itself, so a cancelled read action previously ran to completion regardless.

## Both terminal engines were affected

The filter is reached through `com.intellij.consoleFilterProvider`, which both engines and every run-configuration console share. Thread dumps confirmed each independently:

- classic — `JediTermHyperlinkFilterAdapter.runFilters` (25 of 35 dumps over two days)
- reworked — `BackendTerminalHyperlinkHighlighter.HyperlinkProcessor.processBatch`

## The drive letter

Found while verifying the above. A drive letter's colon is not in the path class, so the expression could neither capture `C:` nor begin a match at it and started after it instead. The resolver was handed a path with no drive, which matches nothing, leaving only the terminal's own link on the line — undecorated, Ctrl to follow, and opening at line 1 rather than the line number printed beside the path.

The path group now takes an optional drive-letter prefix, and a lookahead lets one begin a match even where the guard against redundant start offsets would otherwise block it, so a path embedded mid-line is linked whole too. Neither construct captures, so the group registers are unchanged and the expression stays linear.

`FileReferenceFilter` also now builds the `AboveGenericFileLinks` result item `LiteralStackTraceFilter` already used, moved out to be shared. Its note said this filter never needed the extra layer because its match covers `path:line` and so is always wider than the terminal's bare-path link; a drive letter is exactly the case where it is narrower.

## Tests

Written and proven red before either fix, each failing on its own assertion:

- three budget tests over the shapes that fail for different reasons — indented, whitespace-only, and space-free — so a cure for one cannot pass for the others
- a cancellation test with a pre-cancelled indicator on a pooled thread
- an absolute-path test asserting the highlight starts at offset 0
- a layer test asserting the result outranks the terminal's own link

43 console tests green, including the existing `ConsoleFiltersTest`, which drives a real `ConsoleViewImpl` through the extension point. `verifyPlugin` is `Compatible` across all 15 IDE/version combinations with internal API usage unchanged at 8.

The absolute-path test discriminates only on Windows; on Linux legs it still runs and asserts, but a `/tmp/...` path was already captured whole.
