### PR TITLE
perf(ci): cut per-leg startup cost - Gradle caching, Windows Elixir, disk reclaim

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -174,4 +174,12 @@ runs:
       run: |
         echo "OTP_RELEASE=${{ steps.resolve.outputs.otp-version }}" >> $GITHUB_ENV
         echo "ERLANG_SDK_HOME=$(erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop)" >> $GITHUB_ENV
-
+        # Counterpart of ERLANG_SDK_HOME, and it is the Windows leg that needs it: the resolver's
+        # `elixir` PATH shell-out fails on windows-2025 and the runners have no mise, so it fell
+        # through to downloading Elixir and running `make` - 65 s of the 80 s `Build quoter` step,
+        # into a directory the quoter cache does not cover. Guarded because setup-beam exports
+        # INSTALL_DIR_FOR_ELIXIR but does not declare it as an output; unset or wrong just restores
+        # the old fall-through.
+        if [ -n "${INSTALL_DIR_FOR_ELIXIR:-}" ]; then
+          echo "ELIXIR_SDK_HOME=$INSTALL_DIR_FOR_ELIXIR" >> $GITHUB_ENV
+        fi

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'Skip building searchable options (faster builds, but users cannot search settings). Use false for release builds.'
     required: false
     default: 'true'
+  free-disk-space:
+    description: |
+      Reclaim ~20 GiB of preinstalled toolchains before building. Off because the runner already
+      reports 87 G free of 146 G before the reclaim, against a build that uses roughly 10 G - so it
+      only bought 26-225 s of cost per Linux leg, 269 s on the worst observed. Turn it on for a
+      caller that genuinely needs the space.
+    required: false
+    default: 'false'
   free-docker-images:
     description: 'Remove Docker images during disk space cleanup. Set to false when later steps use Docker container actions.'
     required: false
@@ -74,12 +82,20 @@ runs:
       id: free-disk-space
       ## Windows runners appear to have plenty of free space on D:
       ## and this action doesn't work on Windows.
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && inputs.free-disk-space == 'true'
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       with:
         tool-cache: false
         large-packages: false
         docker-images: ${{ inputs.free-docker-images == 'true' }}
+
+    # Stands in for the before/after `df` the reclaim prints itself, so the leg still reports its
+    # starting headroom with the reclaim off. Linux-only for the same reason the reclaim is.
+    - name: Report disk space
+      id: report-disk-space
+      if: runner.os == 'Linux' && inputs.free-disk-space != 'true'
+      shell: bash
+      run: df -h
 
     # Keyed on the JBR major version so matrix legs on different Java levels (21 vs 25)
     # cannot restore each other's runtime. No prefix restore-keys on purpose: a partial

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -38,6 +38,13 @@ inputs:
     description: 'Remove Docker images during disk space cleanup. Set to false when later steps use Docker container actions.'
     required: false
     default: 'true'
+  gradle-encryption-key:
+    description: |
+      Base64 AES key (`openssl rand -base64 16`, stored as the GRADLE_ENCRYPTION_KEY secret) without
+      which gradle/actions caches no configuration-cache data. A composite action cannot read
+      `secrets`, so callers pass it; empty - as on fork pull requests - skips only that data.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -129,11 +136,22 @@ runs:
         fi
         echo "ORG_GRADLE_PROJECT_skipSearchableOptions=$SKIP_SEARCHABLE_OPTIONS" >> $GITHUB_ENV
 
+    # The excluded dirs are the expensive, worthless half: a build scan measured the whole 1.4 GiB
+    # download at 15 s, and the Gradle-home cache is keyed per job, so caching it across 13 jobs
+    # would exhaust the 10 GB limit on its own. What is left is the build cache - 11.9 MiB, and 0 of
+    # 229 work units hit before this. Excludes filter the Gradle User Home only, so they cannot
+    # affect the configuration-cache data that cache-encryption-key covers. cache-read-only keeps
+    # its default, which writes only from the default branch.
     - name: Setup Gradle
       id: setup-gradle
       uses: gradle/actions/setup-gradle@v6
       with:
-        cache-disabled: true
+        cache-disabled: false
+        # `caches/<gradle-version>/transforms` on Gradle 9, not `caches/transforms-*`.
+        gradle-home-cache-excludes: |
+          caches/modules-2
+          caches/*/transforms
+        cache-encryption-key: ${{ inputs.gradle-encryption-key }}
         # avoid async in shutdown until https://github.com/nodejs/node/pull/61999 lands in the action runner's JS version.
         add-job-summary-as-pr-comment: 'never'
         build-scan-publish: ${{ inputs.build-scan-publish }}
@@ -156,3 +174,4 @@ runs:
       run: |
         echo "OTP_RELEASE=${{ steps.resolve.outputs.otp-version }}" >> $GITHUB_ENV
         echo "ERLANG_SDK_HOME=$(erl -eval 'io:format("~s", [code:root_dir()]).' -noshell -run init stop)" >> $GITHUB_ENV
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           skip-searchable-options: 'false'
 
       - name: Build with Gradle

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -367,6 +367,15 @@ jobs:
           overwrite: true
           if-no-files-found: 'warn'
 
+      # Last step on purpose: the build only grows, so this is the job's low-water mark. It decides
+      # whether setup-env's `Free Disk Space` is worth 26-225 s per Linux leg to reclaim 20 GiB - if
+      # what is left here comfortably exceeds that, the reclaim is pure cost. Nothing today reports
+      # free space at all.
+      - name: Report free disk space
+        id: report-disk-space
+        if: always()
+        run: df -h
+
   build-plugin:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
@@ -437,6 +446,12 @@ jobs:
           # Same 30 days as the zip above, for the same reason: this is the copy a human downloads to
           # install a PR build, and storage costs nothing on a public repository.
           retention-days: 30
+
+      # Same low-water-mark reading as the test legs above, for the other job that runs a build.
+      - name: Report free disk space
+        id: report-disk-space
+        if: always()
+        run: df -h
 
   # Fanned out over one job per product x version by a reusable workflow, verifying the artifact
   # build-plugin uploaded. Kept separate so the verification machinery - and the reasons it runs one

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -135,6 +135,7 @@ jobs:
           idea-version: ${{ matrix.idea-version }}
           java-version: ${{ matrix.java-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           build-scan-publish: 'true'
           skip-searchable-options: 'true'
 
@@ -398,6 +399,7 @@ jobs:
         with:
           setup-elixir: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           skip-searchable-options: 'true'
 
       - name: Build Plugin

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -187,6 +187,7 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           skip-searchable-options: 'false'
 
       - name: Build with Gradle (canary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,11 @@
 
 ### Build / CI
 
+- [#PR](https://github.com/KronicDeth/intellij-elixir/pull/PR) [@sh41](https://github.com/sh41)
+  - **CI now caches Gradle's build and configuration caches, and no longer rebuilds Elixir from
+    source on the Windows leg.** The dependency cache stays off deliberately: it is gigabytes to save
+    seconds.
+
 - [#4003](https://github.com/KronicDeth/intellij-elixir/pull/4003) [@sh41](https://github.com/sh41)
   - **Plugin verification now fails on an internal platform API usage that is not on the approved list.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,10 +279,10 @@
 
 ### Build / CI
 
-- [#PR](https://github.com/KronicDeth/intellij-elixir/pull/PR) [@sh41](https://github.com/sh41)
-  - **CI now caches Gradle's build and configuration caches, and no longer rebuilds Elixir from
-    source on the Windows leg.** The dependency cache stays off deliberately: it is gigabytes to save
-    seconds.
+- [#4006](https://github.com/KronicDeth/intellij-elixir/pull/4006) [@sh41](https://github.com/sh41)
+  - **CI is faster: Gradle's build and configuration caches are kept, Elixir is no longer rebuilt from
+    source on the Windows leg, and the runners no longer reclaim disk space they were not short of.**
+    The dependency cache stays off deliberately - it is gigabytes to save seconds.
 
 - [#4003](https://github.com/KronicDeth/intellij-elixir/pull/4003) [@sh41](https://github.com/sh41)
   - **Plugin verification now fails on an internal platform API usage that is not on the approved list.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,9 @@ already-installed pair. The `resolveElixirErlangSdks` task looks in this order a
 It then exports `ELIXIR_LANG_ELIXIR_PATH`, `ELIXIR_EBIN_DIRECTORY`, `ELIXIR_VERSION`, `ERLANG_SDK_HOME`
 and a `PATH` prefix to every test task, so you never set those by hand.
 
+CI takes row 1 for both, via `setup-env`. Row 2 does not work for Elixir on `windows-2025` and the
+runners have no mise, so otherwise the Windows leg falls to row 4 on every run.
+
 The **expected** versions come from [mise](https://mise.jdx.dev), which this project requires:
 
 ```sh


### PR DESCRIPTION
Three independent cuts to what every test leg pays before it runs a test. Measured from the jobs API, the raw job logs, and a Gradle build scan of run [33845909607](https://github.com/KronicDeth/intellij-elixir/actions/runs/33845909607); each commit stands alone and is separately revertable.

### Gradle caching, but not the expensive half

`cache-disabled: true` meant `org.gradle.caching=true` in `gradle.properties` was inert in CI: the build cache had nothing to restore from, and the scan shows **229 work units requested, 0 hits, 229 misses, storing 11.9 MiB** - among them 219 cacheable transforms costing 26 s.

The dependency cache stays excluded on purpose. The same scan measures the whole build's network at **1.4 GiB in 15 s wall clock**, of which the IDE is a single 6.4 s request at 227 MiB/s. Caching that would spend gigabytes to save seconds, and since the Gradle-home cache is keyed per job, across the 13 Gradle-running jobs it would exceed the repository's 10 GB cache limit on its own. One extracted IDE is 3.7 GB. So `caches/modules-2` and `caches/*/transforms` are excluded and the build cache is kept.

Configuration-cache data is also worth having - the first `Configure project :` costs 67 s per leg (40 s configuration resolution, 19 s task graph calculation) and the entry that replaces it is 131 KiB - but `gradle/actions` stores none without an encryption key, and a composite action cannot read `secrets`. Hence the new `gradle-encryption-key` input, passed at all four call sites from `GRADLE_ENCRYPTION_KEY`.

Two consequences worth knowing, both from GitHub's fork rules rather than anything here:

- Secrets are not passed to runs triggered from a fork, so **configuration-cache data will not be restored on a fork PR** - only on pushes to `main`. Empty key is handled: the rest of the cache still works.
- `cache-read-only` keeps its default, which writes only from the default branch. So this PR's own run will show no cache benefit at all; `release.yml` on `main` seeds the entries and later PRs restore them.

### Windows stopped rebuilding Elixir from source

`resolveElixirErlangSdks` tries `ELIXIR_SDK_HOME` before shelling out to `elixir` on `PATH`. That shell-out does not work on `windows-2025`, and the runners have no mise, so the resolver fell through to its last resort - downloading the Elixir source and running `make`. That is **65 s of the 80 s `Build quoter` step on every Windows run**, into `cache/elixir-<version>`, a sibling of the cached quoter tree that the quoter cache never covered.

`setup-beam` already exports `INSTALL_DIR_FOR_ELIXIR` via `core.exportVariable`, pointing at the tool root whose `bin/` it put on `PATH` - exactly the layout `isValidElixirHome` wants. It is not a declared output of that action, so the export is guarded: unset restores today's behaviour, and set-but-wrong makes the resolver log `ELIXIR_SDK_HOME points to an invalid Elixir SDK` and fall through as before.

Verified locally on Windows: `Resolved SDKs: ... elixir=... (source=env:ELIXIR_SDK_HOME, version=1.13.4)`.

### The disk reclaim was never needed

`jlumbroso/free-disk-space` costs **26-225 s per Linux leg** - 269 s on the `IDEA 2026.2` leg, which is what made it the second-slowest - to reclaim 20 GiB. Its own before/after `df` shows the runner starts with **87 G free of 146 G**, against a build that uses roughly 10 G. It is now an opt-in input defaulting to `false`. Verify legs are unaffected either way: `shared-verify.yml` does not use `setup-env`.

Since the reclaim was also the only thing reporting free space, a plain `df -h` takes its place when it is off, and each build job now ends with one - the last step is the low-water mark, because a build only grows. That number is what decides whether the reclaim ever needs turning back on.

### What this does not touch

`:test` itself, which is 584 s of the 1273 s critical-path leg. `maxParallelForks` was measured and does not work: at 2 forks the suite fails with 128 x `VFS can't be initialized` plus OOM, because `prepareTestSandbox` produces a single sandbox that two IntelliJ test JVMs cannot share. Fixing that needs a per-fork `idea.system.path`, which Gradle cannot template per worker.