### PR TITLE
fix(editor): indent a heredoc's auto-inserted closing """

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 
 ### Bug Fixes
 
+- [#4007](https://github.com/KronicDeth/intellij-elixir/pull/4007) [@sh41](https://github.com/sh41)
+  - **Typing a heredoc's opening `"""` now closes it at the same indentation.** Fixes [#806](https://github.com/KronicDeth/intellij-elixir/issues/806).
+
 - [#4005](https://github.com/KronicDeth/intellij-elixir/pull/4005) [@sh41](https://github.com/sh41)
   - **The IDE no longer freezes while a terminal produces output.** Fixes [#4004](https://github.com/KronicDeth/intellij-elixir/issues/4004).
   - **A Windows path printed with its drive letter now links from the drive letter.**

--- a/src/org/elixir_lang/QuoteHandler.java
+++ b/src/org/elixir_lang/QuoteHandler.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.editor.highlighter.HighlighterIterator;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
+import com.intellij.util.DocumentUtil;
 import org.elixir_lang.lexer.StackFrame;
 import org.elixir_lang.psi.ElixirTypes;
 import org.jetbrains.annotations.Nullable;
@@ -50,7 +51,11 @@ public class QuoteHandler implements MultiCharQuoteHandler {
 
                         if (terminator != null) {
                             if (terminator.length() >= 3) {
-                                closingQuote = "\n" + terminator;
+                                /* A heredoc terminator's column is the dedent applied to the body, and the platform
+                                   inserts this text verbatim without reformatting, so indent it here. */
+                                closingQuote = "\n" +
+                                        DocumentUtil.getIndent(document, highlighterIterator.getStart()) +
+                                        terminator;
                             } else {
                                 closingQuote = terminator;
                             }

--- a/tests/org/elixir_lang/QuoteHandlerTest.kt
+++ b/tests/org/elixir_lang/QuoteHandlerTest.kt
@@ -1,0 +1,54 @@
+package org.elixir_lang
+
+/**
+ * Typing a heredoc promoter auto-closes it on the next line. The terminator's column is the dedent applied to the body,
+ * and the expected columns are the ones `mix format` produces - the indent of the promoter's own line, which is not
+ * always the enclosing statement's.
+ *
+ * The insert never reaches the formatter, so [org.elixir_lang.FormattingTest]'s reformat fixtures cannot cover it.
+ */
+class QuoteHandlerTest : PlatformTestCase() {
+    private fun assertTextAfterTyping(code: String, typed: String, expected: String) {
+        myFixture.configureByText("a.ex", code)
+
+        myFixture.type(typed)
+
+        assertEquals(expected, myFixture.editor.document.text)
+    }
+
+    fun testHeredocPromoterAtColumnZero() =
+        assertTextAfterTyping("_x = <caret>\n", "\"\"\"", "_x = \"\"\"\n\"\"\"\n")
+
+    fun testHeredocPromoterInFunctionBody() =
+        assertTextAfterTyping(
+            "defmodule M do\n  def run do\n    _x = <caret>\n  end\nend\n",
+            "\"\"\"",
+            "defmodule M do\n  def run do\n    _x = \"\"\"\n    \"\"\"\n  end\nend\n"
+        )
+
+    fun testHeredocPromoterInNestedBlock() =
+        assertTextAfterTyping(
+            "defmodule M do\n  def run do\n    if one do\n      _x = <caret>\n    end\n  end\nend\n",
+            "\"\"\"",
+            "defmodule M do\n  def run do\n    if one do\n      _x = \"\"\"\n      \"\"\"\n    end\n  end\nend\n"
+        )
+
+    /** The promoter's line is indented deeper than the statement it belongs to, and `mix format` follows the promoter. */
+    fun testHeredocPromoterOnKeywordLine() =
+        assertTextAfterTyping(
+            "defmodule M do\n  def run do\n    _x = [\n      k: <caret>\n    ]\n  end\nend\n",
+            "\"\"\"",
+            "defmodule M do\n  def run do\n    _x = [\n      k: \"\"\"\n      \"\"\"\n    ]\n  end\nend\n"
+        )
+
+    fun testCharListHeredocPromoter() =
+        assertTextAfterTyping("  _x = <caret>\n", "'''", "  _x = '''\n  '''\n")
+
+    fun testSigilHeredocPromoter() =
+        assertTextAfterTyping("  _x = ~s<caret>\n", "\"\"\"", "  _x = ~s\"\"\"\n  \"\"\"\n")
+
+    fun testTabIndentedHeredocPromoter() =
+        assertTextAfterTyping("\t_x = <caret>\n", "\"\"\"", "\t_x = \"\"\"\n\t\"\"\"\n")
+
+    fun testLinePromoterIsUnaffected() = assertTextAfterTyping("  _x = <caret>\n", "\"", "  _x = \"\"\n")
+}


### PR DESCRIPTION
Typing a heredoc's opening `"""` inserted the terminator at column 0, through a raw `Document.insertString` that never reaches the formatter. A heredoc terminator's column is the dedent applied to the body, so this changed the string's value rather than just looking wrong. `QuoteHandler#getClosingQuote` now prefixes it with the promoter line's own indent.

Fixes #806.

- Expected columns come from `mix format`, which aligns the terminator to the promoter's line, not to the enclosing statement. `testHeredocPromoterOnKeywordLine` is the case that tells the two apart.
- The Reformat action already handled heredocs correctly (`FormattingTest.testHeredocAlignment`); only the on-type path was wrong, and there is no `EnterHandlerDelegate` to fix it up afterwards.
- `QuoteHandlerTest` is the first typing-simulation coverage here. 6 of its 8 cases fail without the fix; the column-0 and single-quote cases pass throughout as no-regression pins.