### PR TITLE
Make scope processors positive filters and every infix operation a Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@
 
 ### Bug Fixes
 
+- [#4014](https://github.com/KronicDeth/intellij-elixir/pull/4014) [@sh41](https://github.com/sh41)
+  - **Resolving a variable or type no longer reports an error for code shapes the resolver does not
+    declare from**, such as a `do` block met on the walk or a `@type` head with a literal argument.
+    Refs [#3985](https://github.com/KronicDeth/intellij-elixir/issues/3985).
+
 - [#4007](https://github.com/KronicDeth/intellij-elixir/pull/4007) [@sh41](https://github.com/sh41)
   - **Typing a heredoc's opening `"""` now closes it at the same indentation.** Fixes [#806](https://github.com/KronicDeth/intellij-elixir/issues/806).
 

--- a/gen/org/elixir_lang/psi/ElixirHeredoc.java
+++ b/gen/org/elixir_lang/psi/ElixirHeredoc.java
@@ -30,10 +30,6 @@ public interface ElixirHeredoc extends HeredocLiteral, Quote {
 
   @NotNull LiteralTextEscaper<? extends PsiLanguageInjectionHost> createLiteralTextEscaper();
 
-  //WARNING: getHeredocLineList(...) is skipped
-  //matching getHeredocLineList(ElixirHeredoc, ...)
-  //methods are not found in ElixirPsiImplUtil
-
   boolean isCharList();
 
   boolean isValidHost();

--- a/gen/org/elixir_lang/psi/ElixirKeywordPair.java
+++ b/gen/org/elixir_lang/psi/ElixirKeywordPair.java
@@ -17,10 +17,6 @@ public interface ElixirKeywordPair extends QuotableKeywordPair {
   @Nullable
   ElixirUnmatchedExpression getUnmatchedExpression();
 
-  //WARNING: getKeywordKey(...) is skipped
-  //matching getKeywordKey(ElixirKeywordPair, ...)
-  //methods are not found in ElixirPsiImplUtil
-
   @NotNull Quotable getKeywordValue();
 
   @NotNull OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirMatchedNotInOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirMatchedNotInOperation.java
@@ -29,14 +29,6 @@ public interface ElixirMatchedNotInOperation extends ElixirMatchedExpression, Ca
 
   @Nullable ElixirDoBlock getDoBlock();
 
-  //WARNING: getName(...) is skipped
-  //matching getName(ElixirMatchedNotInOperation, ...)
-  //methods are not found in ElixirPsiImplUtil
-
-  //WARNING: getNameIdentifier(...) is skipped
-  //matching getNameIdentifier(ElixirMatchedNotInOperation, ...)
-  //methods are not found in ElixirPsiImplUtil
-
   @RequiresReadLock
   boolean hasDoBlockOrKeyword();
 
@@ -55,10 +47,6 @@ public interface ElixirMatchedNotInOperation extends ElixirMatchedExpression, Ca
   @Nullable Quotable leftOperand();
 
   @Nullable String moduleName();
-
-  //WARNING: operator(...) is skipped
-  //matching operator(ElixirMatchedNotInOperation, ...)
-  //methods are not found in ElixirPsiImplUtil
 
   @RequiresReadLock
   @NotNull PsiElement[] primaryArguments();

--- a/gen/org/elixir_lang/psi/ElixirNoParenthesesKeywordPair.java
+++ b/gen/org/elixir_lang/psi/ElixirNoParenthesesKeywordPair.java
@@ -20,10 +20,6 @@ public interface ElixirNoParenthesesKeywordPair extends QuotableKeywordPair {
   @Nullable
   ElixirNoParenthesesManyStrictNoParenthesesExpression getNoParenthesesManyStrictNoParenthesesExpression();
 
-  //WARNING: getKeywordKey(...) is skipped
-  //matching getKeywordKey(ElixirNoParenthesesKeywordPair, ...)
-  //methods are not found in ElixirPsiImplUtil
-
   @NotNull Quotable getKeywordValue();
 
   @NotNull OtpErlangObject quote();

--- a/gen/org/elixir_lang/psi/ElixirNoParenthesesOneArgument.java
+++ b/gen/org/elixir_lang/psi/ElixirNoParenthesesOneArgument.java
@@ -30,10 +30,6 @@ public interface ElixirNoParenthesesOneArgument extends Arguments, MaybeModuleNa
 
   boolean isModuleName();
 
-  //WARNING: processDeclarations(...) is skipped
-  //matching processDeclarations(ElixirNoParenthesesOneArgument, ...)
-  //methods are not found in ElixirPsiImplUtil
-
   @NotNull OtpErlangObject[] quoteArguments();
 
 }

--- a/gen/org/elixir_lang/psi/ElixirStabParenthesesSignature.java
+++ b/gen/org/elixir_lang/psi/ElixirStabParenthesesSignature.java
@@ -4,10 +4,9 @@ package org.elixir_lang.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
-import org.elixir_lang.psi.operation.When;
 import com.ericsson.otp.erlang.OtpErlangObject;
 
-public interface ElixirStabParenthesesSignature extends Quotable, When {
+public interface ElixirStabParenthesesSignature extends Quotable {
 
   @Nullable
   ElixirEmptyParentheses getEmptyParentheses();
@@ -24,16 +23,6 @@ public interface ElixirStabParenthesesSignature extends Quotable, When {
   @Nullable
   ElixirWhenInfixOperator getWhenInfixOperator();
 
-  //WARNING: getNameIdentifier(...) is skipped
-  //matching getNameIdentifier(ElixirStabParenthesesSignature, ...)
-  //methods are not found in ElixirPsiImplUtil
-
-  @Nullable Quotable leftOperand();
-
-  @NotNull Operator operator();
-
   @NotNull OtpErlangObject quote();
-
-  @Nullable Quotable rightOperand();
 
 }

--- a/gen/org/elixir_lang/psi/ElixirUnmatchedNotInOperation.java
+++ b/gen/org/elixir_lang/psi/ElixirUnmatchedNotInOperation.java
@@ -29,14 +29,6 @@ public interface ElixirUnmatchedNotInOperation extends ElixirUnmatchedExpression
 
   @Nullable ElixirDoBlock getDoBlock();
 
-  //WARNING: getName(...) is skipped
-  //matching getName(ElixirUnmatchedNotInOperation, ...)
-  //methods are not found in ElixirPsiImplUtil
-
-  //WARNING: getNameIdentifier(...) is skipped
-  //matching getNameIdentifier(ElixirUnmatchedNotInOperation, ...)
-  //methods are not found in ElixirPsiImplUtil
-
   @RequiresReadLock
   boolean hasDoBlockOrKeyword();
 
@@ -55,10 +47,6 @@ public interface ElixirUnmatchedNotInOperation extends ElixirUnmatchedExpression
   @Nullable Quotable leftOperand();
 
   @Nullable String moduleName();
-
-  //WARNING: operator(...) is skipped
-  //matching operator(ElixirUnmatchedNotInOperation, ...)
-  //methods are not found in ElixirPsiImplUtil
 
   @RequiresReadLock
   @NotNull PsiElement[] primaryArguments();

--- a/gen/org/elixir_lang/psi/ElixirVisitor.java
+++ b/gen/org/elixir_lang/psi/ElixirVisitor.java
@@ -700,7 +700,6 @@ public class ElixirVisitor extends PsiElementVisitor {
 
   public void visitStabParenthesesSignature(@NotNull ElixirStabParenthesesSignature o) {
     visitQuotable(o);
-    // visitWhen(o);
   }
 
   public void visitStructOperation(@NotNull ElixirStructOperation o) {

--- a/gen/org/elixir_lang/psi/impl/ElixirStabParenthesesSignatureImpl.java
+++ b/gen/org/elixir_lang/psi/impl/ElixirStabParenthesesSignatureImpl.java
@@ -59,23 +59,8 @@ public class ElixirStabParenthesesSignatureImpl extends ASTWrapperPsiElement imp
   }
 
   @Override
-  public @Nullable Quotable leftOperand() {
-    return ElixirPsiImplUtil.leftOperand(this);
-  }
-
-  @Override
-  public @NotNull Operator operator() {
-    return ElixirPsiImplUtil.operator(this);
-  }
-
-  @Override
   public @NotNull OtpErlangObject quote() {
     return ElixirPsiImplUtil.quote(this);
-  }
-
-  @Override
-  public @Nullable Quotable rightOperand() {
-    return ElixirPsiImplUtil.rightOperand(this);
   }
 
 }

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -90,14 +90,11 @@
     functionName
     functionNameElement
     getDoBlock
-    getName
-    getNameIdentifier
     hasDoBlockOrKeyword
     isCalling
     isCallingMacro
     leftOperand
     moduleName
-    operator
     primaryArguments
     primaryArity
     processDeclarations
@@ -655,7 +652,6 @@ noParenthesesKeywordPair ::= keywordKeyColon noParenthesesExpression
                              {
                                implements = "org.elixir_lang.psi.QuotableKeywordPair"
                                methods = [
-                                 getKeywordKey
                                  getKeywordValue
                                  quote
                                ]
@@ -711,7 +707,6 @@ heredoc ::= HEREDOC_PROMOTER EOL
                   addFragmentCodePoints
                   addHexadecimalEscapeSequenceCodePoints
                   createLiteralTextEscaper
-                  getHeredocLineList
                   isCharList
                   isValidHost
                   quote
@@ -1456,7 +1451,6 @@ noParenthesesOneArgument ::= noParenthesesKeywords | // @see https://github.com/
                                methods = [
                                  arguments
                                  isModuleName
-                                 processDeclarations
                                  quoteArguments
                                ]
                              }
@@ -2859,7 +2853,6 @@ keywordPair ::=  keywordKeyColon containerExpression
                  {
                    implements = "org.elixir_lang.psi.QuotableKeywordPair"
                    methods = [
-                     getKeywordKey
                      getKeywordValue
                      quote
                    ]

--- a/src/org/elixir_lang/Elixir.bnf
+++ b/src/org/elixir_lang/Elixir.bnf
@@ -1902,19 +1902,7 @@ stabNoParenthesesSignature ::= noParenthesesArguments
  * @see https://github.com/elixir-lang/elixir/blob/de39bbaca277002797e52ffbde617ace06233a2b/lib/elixir/src/elixir_parser.yrl#L430-L432
  */
 stabParenthesesSignature ::= parenthesesArguments (whenInfixOperator expression)?
-                             {
-                               implements = [
-                                 "org.elixir_lang.psi.Quotable"
-                                 "org.elixir_lang.psi.operation.When"
-                               ]
-                               methods = [
-                                 getNameIdentifier
-                                 leftOperand
-                                 operator
-                                 quote
-                                 rightOperand
-                               ]
-                             }
+                             { implements = "org.elixir_lang.psi.Quotable" methods = [quote] }
 
 stabInfixOperator ::= STAB_OPERATOR
                       {

--- a/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
+++ b/src/org/elixir_lang/psi/impl/ElixirPsiImplUtil.java
@@ -620,17 +620,39 @@ public class ElixirPsiImplUtil {
     }
 
     @RequiresReadLock
+    public static boolean processDeclarations(@NotNull final And and,
+                                              @NotNull PsiScopeProcessor processor,
+                                              @NotNull ResolveState state,
+                                              PsiElement lastParent,
+                                              @NotNull PsiElement place) {
+        return ProcessDeclarationsImpl.processDeclarations(and, processor, state, lastParent, place);
+    }
+
+    @RequiresReadLock
     public static boolean processDeclarations(@NotNull final Call call,
                                               @NotNull PsiScopeProcessor processor,
                                               @NotNull ResolveState state,
                                               PsiElement lastParent,
                                               @NotNull PsiElement place) {
-        return switch (call) {
-            case And and -> ProcessDeclarationsImpl.processDeclarations(and, processor, state, lastParent, place);
-            case Match match -> ProcessDeclarationsImpl.processDeclarations(match, processor, state, lastParent, place);
-            case Type type -> ProcessDeclarationsImpl.processDeclarations(type, processor, state);
-            default -> ProcessDeclarationsImpl.processDeclarations(call, processor, state, lastParent, place);
-        };
+        return ProcessDeclarationsImpl.processDeclarations(call, processor, state, lastParent, place);
+    }
+
+    @RequiresReadLock
+    public static boolean processDeclarations(@NotNull final Match match,
+                                              @NotNull PsiScopeProcessor processor,
+                                              @NotNull ResolveState state,
+                                              PsiElement lastParent,
+                                              @NotNull PsiElement place) {
+        return ProcessDeclarationsImpl.processDeclarations(match, processor, state, lastParent, place);
+    }
+
+    @RequiresReadLock
+    public static boolean processDeclarations(@NotNull final Type type,
+                                              @NotNull PsiScopeProcessor processor,
+                                              @NotNull ResolveState state,
+                                              PsiElement lastParent,
+                                              @NotNull PsiElement place) {
+        return ProcessDeclarationsImpl.processDeclarations(type, processor, state);
     }
 
     public static boolean processDeclarations(@NotNull final ElixirAlias alias,

--- a/src/org/elixir_lang/psi/operation/Infix.java
+++ b/src/org/elixir_lang/psi/operation/Infix.java
@@ -1,14 +1,18 @@
 package org.elixir_lang.psi.operation;
 
 import org.elixir_lang.psi.Quotable;
+import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A binary operator with a left operand, operator, and right operand
+ * A binary operator with a left operand, operator, and right operand.
+ *
+ * Every infix operation is also a {@link Call} of its operator, so a static overload keyed on an
+ * {@code Infix} subtype is more specific than one keyed on {@code Call} and javac can pick it.
  *
  * Created by kadie.enheduanna.inanna on 3/18/15.
  */
-public interface Infix extends Operation {
+public interface Infix extends Operation, Call {
   /**
    * @return {@code null} if there was an error in element (such as when user is till typing it) and so the Pratt Parser
    *   error handling matches {@code partialLeft PsiElementError operand rightOperand}.  {@code partialLeft} is not

--- a/src/org/elixir_lang/psi/scope/Type.kt
+++ b/src/org/elixir_lang/psi/scope/Type.kt
@@ -10,7 +10,6 @@ import com.intellij.psi.util.isAncestor
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.Module
 import org.elixir_lang.psi.ModuleAttribute.isTypeSpecName
@@ -48,11 +47,8 @@ abstract class Type : PsiScopeProcessor {
             is ModuleImpl<*> -> execute(element, state)
             is TypeDefinitionImpl<*> -> execute(element, state)
             is CallDefinitionImpl<*> -> true
-            else -> {
-                error("Don't know how process element as type", element)
-
-                true
-            }
+            // Anything else declares no type; keep walking.
+            else -> true
         }
 
 
@@ -163,7 +159,8 @@ abstract class Type : PsiScopeProcessor {
                     }
                 }
 
-                else -> TODO()
+                // A single-target reference cannot name a `defprotocol` to walk; keep walking.
+                else -> true
             }
         } ?: true
 
@@ -212,12 +209,6 @@ abstract class Type : PsiScopeProcessor {
                 true
             }
         } ?: true
-
-    companion object {
-        fun error(title: String, element: PsiElement) {
-            Logger.error(Type::class.java, title, element)
-        }
-    }
 }
 
 internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
@@ -281,11 +272,8 @@ internal fun PsiElement.ancestorTypeSpec(): AtUnqualifiedNoParenthesesCall<*>? =
         is QualifiableAlias,
         -> null
 
-        else -> {
-            Logger.error(PsiElement::class.java, "Don't know how to find ancestorTypeSpec", this)
-
-            null
-        }
+        // Anything else is not a shape a type specification is written in.
+        else -> null
     }
 
 val OPTIONALITIES = arrayOf("optional", "required")

--- a/src/org/elixir_lang/psi/scope/Variable.kt
+++ b/src/org/elixir_lang/psi/scope/Variable.kt
@@ -1,12 +1,9 @@
 package org.elixir_lang.psi.scope
 
-import com.intellij.lang.parser.GeneratedParserUtilBase
 import com.intellij.openapi.util.Key
 import com.intellij.psi.*
-import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.scope.PsiScopeProcessor
 import com.intellij.psi.util.PsiTreeUtil
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.CallDefinitionClause.head
@@ -25,7 +22,6 @@ import org.elixir_lang.psi.operation.Normalized.operatorIndex
 import org.elixir_lang.psi.operation.Type
 import org.elixir_lang.psi.operation.infix.Normalized
 import org.elixir_lang.psi.scope.WhileIn.whileIn
-import org.elixir_lang.reference.Callable
 import org.elixir_lang.resolvesToMacro
 import org.elixir_lang.structure_view.element.CallDefinitionHead.Companion.strip
 import org.elixir_lang.structure_view.element.Delegation
@@ -74,36 +70,8 @@ abstract class Variable : PsiScopeProcessor {
                 /* KeywordLists happen in map, struct and {@code do: <body>} matches, while KeywordKey happens only in
                    bindQuoted */
                 is QuotableKeywordList -> execute(element, state)
-                else -> {
-                    if (!(element is AtOperation ||  // a module attribute reference
-                                    element is AtUnqualifiedBracketOperation ||  // a module attribute reference with access
-                                    element is HeredocLiteral ||
-                                    element is BracketOperation ||  /* an anonymous function is a new scope, so it can't be used to declare a variable.  This won't ever
-                           be hit if the element is declared in the {@code fn} signature because that upward resolution
-                           from resolveVariable stops before this level */
-                                    element is ElixirAnonymousFunction ||
-                                    element is ElixirAtom ||
-                                    element is ElixirAtomKeyword ||
-                                    element is ElixirCharToken ||
-                                    element is ElixirDecimalFloat ||
-                                    element is ElixirEmptyParentheses ||
-                                    element is ElixirEndOfExpression ||
-                                    // type variable in a type restriction guard
-                                    element is ElixirKeywordKey ||
-                                    // noParenthesesManyStrictNoParenthesesExpression exists only to be marked as an error
-                                    element is ElixirNoParenthesesManyStrictNoParenthesesExpression ||
-                                    element is LeafPsiElement ||
-                                    element is Line ||
-                                    element is PsiErrorElement ||
-                                    element is PsiWhiteSpace ||
-                                    element is QualifiableAlias ||
-                                    element is WholeNumber ||
-                                element.node?.elementType == GeneratedParserUtilBase.DUMMY_BLOCK)) {
-                        Logger.error(Callable::class.java, "Don't know how to resolve variable in match", element)
-                    }
-
-                    true
-                }
+                // Anything else declares no variable; keep walking.
+                else -> true
             }
 
     override fun <T> getHint(hintKey: Key<T>): T? = null

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.kt
@@ -5,7 +5,6 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.NameArityInterval
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
 import org.elixir_lang.psi.call.Call
@@ -92,11 +91,8 @@ private constructor(
                                             modularResultResult.isValidResult,
                                             state
                                         )
-                                        else -> {
-                                            Logger.error(javaClass,
-                                                         "Don't know how to add resolve results for delegation",
-                                                         modularResultResultElement)
-                                        }
+                                        // Anything else is not a definition a delegation can target.
+                                        else -> Unit
                                     }
                                 }
 

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -151,14 +151,14 @@ class Variants : CallDefinitionClause() {
         element.finalArguments()?.first()?.stripAccessExpression()?.let { it as? ElixirAtom }?.node?.lastChildNode?.text?.let { prefix ->
             val suffix = element.functionName()!!.removePrefix("embed_")
             val name = "${prefix}_${suffix}"
+            // `Generator.isEmbed` admits only these two names.
+            val renderer = when (suffix) {
+                "template" -> org.elixir_lang.code_insight.lookup.element_renderer.mix.generator.EmbedTemplate(name)
+                "text" -> org.elixir_lang.code_insight.lookup.element_renderer.mix.generator.EmbedText(name)
+                else -> null
+            } ?: return true
 
             lookupElementByPsiElementName.computeIfAbsent(element to name) { (element, name) ->
-                val renderer = when (suffix) {
-                    "template" ->  org.elixir_lang.code_insight.lookup.element_renderer.mix.generator.EmbedTemplate(name)
-                    "text" -> org.elixir_lang.code_insight.lookup.element_renderer.mix.generator.EmbedText(name)
-                    else -> TODO()
-                }
-
                 LookupElementBuilder
                         .createWithSmartPointer(name, element)
                         .withRenderer(renderer)

--- a/src/org/elixir_lang/psi/scope/type/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/type/MultiResolve.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.beam.psi.impl.ModuleImpl
 import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.qualification.Qualified
@@ -163,11 +162,8 @@ private constructor(private val name: String,
                     }
                 }
                 is ElixirVariable -> executeOnParameter(parameter, parameter.name, state)
-                else -> {
-                    Logger.error(MultiResolve::class.java, "Don't know how to get name of parameter", parameter)
-
-                    true
-                }
+                // Anything else names no type variable; keep walking.
+                else -> true
             }
     }
 

--- a/tests/org/elixir_lang/psi/impl/declarations/OperationDispatchTest.kt
+++ b/tests/org/elixir_lang/psi/impl/declarations/OperationDispatchTest.kt
@@ -1,0 +1,75 @@
+package org.elixir_lang.psi.impl.declarations
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.impl.ProcessDeclarationsImpl.DECLARING_SCOPE
+import org.elixir_lang.psi.operation.And
+import org.elixir_lang.psi.operation.Infix
+import org.elixir_lang.psi.operation.Match
+import org.elixir_lang.psi.operation.Type
+
+/**
+ * `&&`, `=` and `::` each declare differently from an ordinary call, so their generated
+ * `processDeclarations` must reach the operation-specific implementation rather than the one for
+ * any call. Each case asserts on what only that implementation does with the processor: the call
+ * fallback hands a `&&`, `=` or `::` to no processor at all.
+ */
+class OperationDispatchTest : PlatformTestCase() {
+    /** Walking up from the right operand, `&&` offers its left operand as a non-declaring scope. */
+    fun testAndOffersLeftOperandFromRightOperand() {
+        val and = operationIn<And>("{:ok, value} = func() && value == 1")
+        val place = and.rightOperand()!!
+        val recorder = Recorder()
+
+        and.processDeclarations(recorder, ResolveState.initial(), place, place)
+
+        assertEquals(listOf(and.leftOperand()), recorder.elements)
+        assertEquals(listOf(false), recorder.declaringScopes)
+    }
+
+    /** Walking up from the right operand, `=` offers only the right operand. */
+    fun testMatchOffersRightOperandFromRightOperand() {
+        val match = operationIn<Match>("value = compute()")
+        val place = match.rightOperand()!!
+        val recorder = Recorder()
+
+        match.processDeclarations(recorder, ResolveState.initial(), place, place)
+
+        assertEquals(listOf(place), recorder.elements)
+    }
+
+    /** `::` offers its left operand, the type head, whichever side the walk comes from. */
+    fun testTypeOffersLeftOperand() {
+        val type = operationIn<Type>("@type t :: term")
+        val place = type.rightOperand()!!
+        val recorder = Recorder()
+
+        type.processDeclarations(recorder, ResolveState.initial(), place, place)
+
+        assertEquals(listOf(type.leftOperand()), recorder.elements)
+    }
+
+    private inline fun <reified T : Infix> operationIn(text: String): T {
+        val file = myFixture.configureByText("dispatch.ex", text) as ElixirFile
+        val operation = PsiTreeUtil.findChildOfType(file, T::class.java)
+        assertNotNull("fixture did not parse to ${T::class.simpleName}", operation)
+
+        return operation!!
+    }
+
+    private class Recorder : PsiScopeProcessor {
+        val elements = mutableListOf<PsiElement>()
+        val declaringScopes = mutableListOf<Boolean?>()
+
+        override fun execute(element: PsiElement, state: ResolveState): Boolean {
+            elements.add(element)
+            declaringScopes.add(state.get(DECLARING_SCOPE))
+
+            return true
+        }
+    }
+}

--- a/tests/org/elixir_lang/psi/operation/StabParenthesesSignatureTest.kt
+++ b/tests/org/elixir_lang/psi/operation/StabParenthesesSignatureTest.kt
@@ -1,0 +1,35 @@
+package org.elixir_lang.psi.operation
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.ElixirStabParenthesesSignature
+
+/**
+ * `(a, b)` and `(a, b) when guard` in front of `->` are the same node. A node whose operator is
+ * optional cannot honour [Operation.operator], which promises one, so the signature is not an
+ * operation: it is an argument list that may carry a guard.
+ */
+class StabParenthesesSignatureTest : PlatformTestCase() {
+    fun testSignatureWithoutGuardIsNotAnOperation() {
+        val signature = signatureIn("fn (a) -> a end")
+
+        assertNull(signature.whenInfixOperator)
+        assertFalse("a signature without a guard has no operator to offer", signature is Operation)
+    }
+
+    fun testSignatureWithGuardIsNotAnOperation() {
+        val signature = signatureIn("fn (a) when is_atom(a) -> a end")
+
+        assertNotNull(signature.whenInfixOperator)
+        assertFalse("the guard does not make the signature an operation", signature is Operation)
+    }
+
+    private fun signatureIn(text: String): ElixirStabParenthesesSignature {
+        val file = myFixture.configureByText("signature.ex", text) as ElixirFile
+        val signature = PsiTreeUtil.findChildOfType(file, ElixirStabParenthesesSignature::class.java)
+        assertNotNull("fixture did not parse to a parentheses signature", signature)
+
+        return signature!!
+    }
+}

--- a/tests/org/elixir_lang/psi/scope/UnhandledElementTest.kt
+++ b/tests/org/elixir_lang/psi/scope/UnhandledElementTest.kt
@@ -1,0 +1,53 @@
+package org.elixir_lang.psi.scope
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
+import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
+import org.elixir_lang.psi.ElixirDoBlock
+import org.elixir_lang.psi.ElixirFile
+
+/**
+ * A scope processor is a positive filter: it names the elements it declares from and answers "keep
+ * walking" for everything else. An element outside that set is the common case, not a defect, so
+ * meeting one must neither stop the walk nor be reported.
+ *
+ * A `do` block is used as the unhandled element because no processor declares anything from one
+ * directly; the block's body is reached through the call that owns it.
+ */
+class UnhandledElementTest : PlatformTestCase() {
+    fun testVariableProcessorKeepsWalkingPastAnElementItDoesNotHandle() {
+        val processor = object : Variable() {
+            override fun executeOnVariable(match: PsiNamedElement, state: ResolveState): Boolean = true
+        }
+
+        assertKeepsWalkingSilently(processor)
+    }
+
+    fun testTypeProcessorKeepsWalkingPastAnElementItDoesNotHandle() {
+        val processor = object : Type() {
+            override fun executeOnType(definition: AtUnqualifiedNoParenthesesCall<*>, state: ResolveState) = true
+            override fun executeOnParameter(parameter: PsiElement, state: ResolveState) = true
+            override fun keepProcessing() = true
+            override fun execute(typeDefinitionImpl: TypeDefinitionImpl<*>, state: ResolveState) = true
+        }
+
+        assertKeepsWalkingSilently(processor)
+    }
+
+    private fun assertKeepsWalkingSilently(processor: com.intellij.psi.scope.PsiScopeProcessor) {
+        val file = myFixture.configureByText("unhandled.ex", "foo do\n  :ok\nend\n") as ElixirFile
+        val doBlock = PsiTreeUtil.findChildOfType(file, ElixirDoBlock::class.java)
+        assertNotNull("fixture did not parse to a do block", doBlock)
+
+        val (keepProcessing, errors) = captureLoggedErrors {
+            processor.execute(doBlock!!, ResolveState.initial())
+        }
+
+        assertEmpty("an unhandled element is not an error", errors)
+        assertTrue("an unhandled element must not stop the walk", keepProcessing)
+    }
+}

--- a/tests/org/elixir_lang/psi/scope/type/UnhandledTypeHeadArgumentTest.kt
+++ b/tests/org/elixir_lang/psi/scope/type/UnhandledTypeHeadArgumentTest.kt
@@ -1,0 +1,37 @@
+package org.elixir_lang.psi.scope.type
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.UnqualifiedParenthesesCall
+
+/**
+ * A `@type` head argument the type resolver cannot name is not a type variable, and saying nothing
+ * about it is the right answer. A string literal is one such argument: it is a syntax the user can
+ * type part-way through an edit, and it must not turn resolving every other type in the module into
+ * an error report.
+ */
+class UnhandledTypeHeadArgumentTest : PlatformTestCase() {
+    fun testUnnameableTypeHeadArgumentDoesNotReportAnError() {
+        myFixture.configureByText(
+            "unnameable.ex",
+            """
+            defmodule Unnameable do
+              @type t("x") :: term
+              @spec f() :: t<caret>()
+              def f, do: nil
+            end
+            """.trimIndent()
+        )
+        val usage = PsiTreeUtil.getParentOfType(
+            myFixture.file.findElementAt(myFixture.caretOffset),
+            UnqualifiedParenthesesCall::class.java
+        )
+        assertNotNull("caret is not on a type usage", usage)
+
+        val (_, errors) = captureLoggedErrors {
+            MultiResolve.resolveResults("t", 0, false, usage!!)
+        }
+
+        assertEmpty("an unnameable head argument is not an error", errors)
+    }
+}


### PR DESCRIPTION
## Summary

Resolving a variable or type no longer reports an error for code shapes the resolver does not declare from. The scope processors under `psi/scope/` carried "don't know how to ..." error defaults, so any element outside a hand-kept list became a crash report; each fall-through now answers "keep walking" silently, which is the contract the platform's own `PsiScopeProcessor` implementations use. Refs #3985, which is the cause behind the individual unmodelled-shape reports.

The same audit found one PSI contract that could not be honoured: `stabParenthesesSignature` (`(a, b)` or `(a, b) when guard` before `->`) was declared a `When` operation while its guard is optional, so the `@NotNull operator()` it inherited indexed `children[-1]` without a guard. No caller reached it, because every consumer tested for the signature before any `Infix` branch, but the contract was false. It now implements only `Quotable`.

With that gone, every rule that is `Infix` is also declared `Call`, so `Infix` now extends `Call`. That lets javac pick `processDeclarations` overloads keyed on `And`, `Match` and `Type` over the one keyed on `Call`, which replaces the runtime type switch in `ElixirPsiImplUtil`. The overloads carry identical parameter lists and annotations on purpose: GrammarKit copies both from the overload it binds at generation time, and a mismatch shows up as churn across every generated call interface.

Also removed: `methods=` entries GrammarKit flagged with `//WARNING ... not found in ElixirPsiImplUtil` because nothing backed them.

## Tests

Four new classes, eight methods. Five were run red before the production change: the two signature tests (it was an `Operation`), the two unhandled-element processor tests and the type-head test (each logged an error). The three dispatch tests assert on what only the `And`, `Match` and `Type` implementations do with the processor, and guard the switch removal.

Full suite: 7,306 tests, 0 skipped, 2 failures in `MixDepsSyncServiceSiblingAppHeavyTest` (10 s pooled-thread timeout). The same class fails the same way on `main` on this machine, so it is pre-existing and unrelated.
