### PR TITLE
Stop reporting code shapes the resolvers, annotator and navigation do not model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@
 
 ### Bug Fixes
 
+- [#4015](https://github.com/KronicDeth/intellij-elixir/pull/4015) [@sh41](https://github.com/sh41)
+  - **Resolving, highlighting, documentation and Go to Symbol no longer report an error for code
+    shapes they do not model**, such as an unlisted `@doc` metadata key, a pinned Ecto query option,
+    a `def` outside a module or a capture in a `@type`. Refs [#3985](https://github.com/KronicDeth/intellij-elixir/issues/3985).
+  - **A dep named by a quoted atom, `{:"my-dep", "~> 1.0"}`, is no longer dropped.**
+  - **Renaming an operator now says it cannot be renamed** instead of silently doing nothing.
+
 - [#4014](https://github.com/KronicDeth/intellij-elixir/pull/4014) [@sh41](https://github.com/sh41)
   - **Resolving a variable or type no longer reports an error for code shapes the resolver does not
     declare from**, such as a `do` block met on the walk or a `@type` head with a literal argument.

--- a/src/org/elixir_lang/annotator/ModuleAttribute.kt
+++ b/src/org/elixir_lang/annotator/ModuleAttribute.kt
@@ -125,10 +125,6 @@ internal class ModuleAttribute : Annotator, DumbAware {
     /*
      * Private Instance Methods
      */
-    private fun cannotHighlightTypes(element: PsiElement) {
-        error("Cannot highlight types", element)
-    }
-
     private fun error(userMessage: String, element: PsiElement) {
         Logger.error(this.javaClass, userMessage, element)
     }
@@ -219,13 +215,9 @@ internal class ModuleAttribute : Annotator, DumbAware {
                                 leftOperand,
                                 annotationHolder
                             )
-                        } else if (leftOperand !is ElixirMatchedUnqualifiedNoArgumentsCall) {
-                            cannotHighlightTypes(leftOperand)
                         }
                     } else if (leftOperand is ElixirAtomKeyword) {
                         highlightTypeName(leftOperand, annotationHolder)
-                    } else if (leftOperand != null) {
-                        cannotHighlightTypes(leftOperand)
                     }
 
                     val rightOperand: PsiElement? = grandChild.rightOperand()
@@ -329,9 +321,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                     // typing the parentheses before the relative name and before name like `@type String.()`
                 is DotCall<*> -> Unit
 
-                else -> {
-                    cannotHighlightTypes(grandChild)
-                }
+                // Anything else is not a type the annotator colours
+                else -> Unit
             }
         }
     }
@@ -486,11 +477,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 )
             }
 
-            else -> {
-                if (psiElement !is ElixirAtomKeyword) {
-                    error("Cannot highlight types and type parameter declarations", psiElement)
-                }
-            }
+            // Anything else declares no type parameter
+            else -> Unit
         }
     }
 
@@ -594,8 +582,6 @@ internal class ModuleAttribute : Annotator, DumbAware {
                                     leftMostFunctionNameTextAttributesKey,
                                     typeParameterNameSet
                                 )
-                            } else {
-                                cannotHighlightTypes(strippedTypeOperationLeftOperand)
                             }
                         }
 
@@ -619,11 +605,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                         )
                     }
 
-                    else -> {
-                        if (leftOperand != null) {
-                            cannotHighlightTypes(leftOperand)
-                        }
-                    }
+                    // Anything else is not a specification head the annotator colours
+                    else -> Unit
                 }
 
                 if (rightOperand != null) {
@@ -777,15 +760,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 )
             }
 
-            is UnqualifiedNoParenthesesCall<*> -> {
-                highlightTypesAndSpecificationTypeParameterDeclarations(
-                    psiElement
-                )
-            }
-
-            else -> {
-                error("Cannot highlight types and specification type parameter declarations", psiElement)
-            }
+            // Anything else declares no specification type parameter
+            else -> Unit
         }
     }
 
@@ -816,17 +792,6 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 annotationHolder,
                 functionNameElement.textRange,
                 ElixirSyntaxHighlighter.TYPE_PARAMETER
-            )
-        }
-    }
-
-    private fun highlightTypesAndSpecificationTypeParameterDeclarations(
-        unqualifiedNoParenthesesCall: UnqualifiedNoParenthesesCall<*>,
-    ) {
-        if (!`is`(unqualifiedNoParenthesesCall)) {
-            error(
-                "Cannot highlight types and specification type parameter declarations in UnqualifiedNoParenthesesCall that is not a call definition clause",
-                unqualifiedNoParenthesesCall
             )
         }
     }
@@ -863,8 +828,6 @@ internal class ModuleAttribute : Annotator, DumbAware {
                     }
                 }
             }
-        } else {
-            cannotHighlightTypes(decimalFloat)
         }
 
         if (message == null) {
@@ -957,8 +920,6 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 annotationHolder,
                 typeTextAttributesKey
             )
-        } else if (children.size != 3) {
-            error("Cannot highlight types and type parameter usages", stabParenthesesSignature)
         }
     }
 
@@ -1105,7 +1066,7 @@ internal class ModuleAttribute : Annotator, DumbAware {
             is ElixirBitString,
             is ElixirCharToken,
             // Every base highlights as an ordinary number, so match the supertype rather than
-            // enumerating them; enumerating left hexadecimal and octal reaching cannotHighlightTypes.
+            // enumerating them; enumerating left hexadecimal and octal uncoloured.
             is WholeNumber,
                 // Fixes #2583
             is ElixirEmptyParentheses,
@@ -1179,7 +1140,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 typeTextAttributesKey
             )
 
-            else -> cannotHighlightTypes(psiElement)
+            // Anything else is not a type the annotator colours
+            else -> Unit
         }
     }
 
@@ -1438,10 +1400,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                 specificationTypeParameterNameSet(psiElement)
             }
 
-            else -> {
-                error("Cannot extract specification type parameter name set", psiElement)
-                emptySet<String>()
-            }
+            // Anything else names no specification type parameter
+            else -> emptySet()
         }
 
     private fun specificationTypeParameterNameSet(psiElements: Array<PsiElement>): Set<String?> =
@@ -1458,18 +1418,10 @@ internal class ModuleAttribute : Annotator, DumbAware {
             setOf(it)
         } ?: emptySet<String>()
 
+    // A definition clause head names its type parameters through `when`, not here
     private fun specificationTypeParameterNameSet(
-        unqualifiedNoParenthesesCall: UnqualifiedNoParenthesesCall<*>,
-    ): Set<String?> {
-        if (!`is`(unqualifiedNoParenthesesCall)) {
-            error(
-                "Cannot extract specification type parameter name set from " +
-                        "unqualifiedNoParenthesesCall that is a not a call definition clause",
-                unqualifiedNoParenthesesCall
-            )
-        }
-        return emptySet<String>()
-    }
+        @Suppress("UNUSED_PARAMETER") unqualifiedNoParenthesesCall: UnqualifiedNoParenthesesCall<*>,
+    ): Set<String?> = emptySet()
 
     /**
      * Assume bare aliases are incorrectly capitalized type parameters, say from someone's that's used to generics
@@ -1496,8 +1448,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
             }
         }
 
+        // Any other tuple names no type parameter
         if (typeParameterNameSet == null) {
-            error("Cannot extract type type parameter name set", tuple)
             typeParameterNameSet = emptySet()
         }
 
@@ -1532,10 +1484,8 @@ internal class ModuleAttribute : Annotator, DumbAware {
                See https://github.com/KronicDeth/intellij-elixir/issues/1835 */
             is QualifiedNoArgumentsCall<*> -> emptySet()
 
-            else -> {
-                error("Cannot extract type type parameter name set", psiElement)
-                emptySet<String>()
-            }
+            // Anything else names no type parameter
+            else -> emptySet()
         }
 
     private fun typeTypeParameterNameSet(psiElements: Array<PsiElement>): Set<String> =

--- a/src/org/elixir_lang/annotator/Parameter.java
+++ b/src/org/elixir_lang/annotator/Parameter.java
@@ -4,7 +4,6 @@ import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
-import org.elixir_lang.errorreport.Logger;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.psi.operation.InMatch;
@@ -58,10 +57,6 @@ public class Parameter {
         }
 
         return notNull;
-    }
-
-    private static void error(@NotNull String message, @NotNull PsiElement element) {
-        Logger.error(Parameter.class, message + " (when element class is " + element.getClass().getName() + ")", element);
     }
 
     @Contract(pure = true)
@@ -188,7 +183,7 @@ public class Parameter {
                 parent instanceof QualifiedMultipleAliases) {
             parameterizedParameter = new Parameter(parameter.entrance);
         } else {
-            error("Don't know how to check if parameter", parent);
+            // Anything else cannot hold a parameter either
             parameterizedParameter = new Parameter(parameter.entrance);
         }
 

--- a/src/org/elixir_lang/documentation/BeamDocsHelper.kt
+++ b/src/org/elixir_lang/documentation/BeamDocsHelper.kt
@@ -8,8 +8,6 @@ import com.intellij.psi.ResolveState
 import org.elixir_lang.beam.Beam
 import org.elixir_lang.beam.psi.Module
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.errorreport.Logger
-import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 import org.elixir_lang.psi.Definition
 import org.elixir_lang.psi.call.MaybeExported
 import org.elixir_lang.beam.chunk.debug_info.v1.erl_abstract_code.abstract_code_compiler_options.abstract_code.Attribute
@@ -68,13 +66,8 @@ object BeamDocsHelper {
                             }
                         }
                     }
-                    // types are only generated for builtins, so no docs
-                    is AtUnqualifiedNoParenthesesCall<*> -> null
-                    else -> {
-                        Logger.error(BeamDocsHelper.javaClass, "Don't know how to fetch docs", element)
-
-                        null
-                    }
+                    // Only modules and exported definitions carry docs; a type or anything else has none
+                    else -> null
                 }
             }
         }

--- a/src/org/elixir_lang/documentation/Comment.kt
+++ b/src/org/elixir_lang/documentation/Comment.kt
@@ -5,7 +5,6 @@ import com.intellij.psi.PsiDocCommentBase
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.FakePsiElement
 import com.intellij.psi.tree.IElementType
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.ElixirTypes
@@ -35,11 +34,8 @@ class Comment(val moduleAttribute: AtUnqualifiedNoParenthesesCall<*>) : FakePsiE
                             isTypeName(expression.atIdentifier.identifierName())
                 }
             }
-            else -> {
-                Logger.error(javaClass, "Don't know how to calculate owner", moduleAttribute)
-
-                null
-            }
+            // Any other attribute documents nothing, and `findDocComment` wraps every attribute
+            else -> null
         }
 
     override fun getTextRange(): TextRange = moduleAttribute.textRange

--- a/src/org/elixir_lang/ecto/Query.kt
+++ b/src/org/elixir_lang/ecto/Query.kt
@@ -136,6 +136,8 @@ private object From : NameArityRangeWalker("from", 1..2) {
                     "limit", "lock", "offset", "prefix", "preload", "union", "union_all", "update",
                     "windows" -> true
 
+                    // Ecto's `from/2` keywords are a finite, documented set and a new one may declare
+                    // bindings, so an unlisted key is reported rather than passed over.
                     else -> {
                         // https://github.com/KronicDeth/intellij-elixir/issues/3171
                         // Missing list around preload arguments
@@ -155,15 +157,8 @@ private object From : NameArityRangeWalker("from", 1..2) {
             }
             // middle of typing like in Issue #2915
             is UnqualifiedNoArgumentsCall<*> -> true
-            else -> {
-                Logger.error(
-                    logger,
-                    "Don't kow how to find reference variables in keyword arguments of from/2",
-                    fromKeywords
-                )
-
-                true
-            }
+            // Pinned or unquoted options, or an argument still being typed, declare no binding
+            else -> true
         }
 }
 
@@ -264,11 +259,8 @@ private object WithCTE : NameArityRangeWalker("with_cte", 3..3) {
                 else -> true
             }
 
-            else -> {
-                Logger.error(logger, "Don't know how to walk with_cte list", list)
-
-                true
-            }
+            // A bracketed or pinned option list declares no binding
+            else -> true
         }
 }
 
@@ -325,11 +317,8 @@ object Query : ModuleWalker(
             is UnqualifiedNoArgumentsCall<*> ->
                 inReference.resolvedFinalArity() != 0 || keepProcessing(inReference, state)
 
-            else -> {
-                Logger.error(logger, "Don't know how to find reference variables in Ecto query", inReference)
-
-                true
-            }
+            // A pinned source or a left operand still being typed declares no binding
+            else -> true
         }
 
     internal fun executeOnBinding(
@@ -386,31 +375,16 @@ object Query : ModuleWalker(
                             // `a` in `{^assoc, a}`
                             && executeOnBinding(elements[1], state, keepProcessing)
                 } else {
-                    Logger.error(
-                        logger,
-                        "Don't know how to find reference variables in binding tuple when arity is not 2",
-                        element
-                    )
-
+                    // Ecto rejects any other tuple, and one is typed part-way through; it binds nothing
                     true
                 }
             }
 
             is UnqualifiedNoArgumentsCall<*> -> element.resolvedFinalArity() != 0 || keepProcessing(element, state)
-            is ElixirUnmatchedUnaryOperation -> {
-                // pinned variable, not a reference binding
-                if (element.unaryPrefixOperator.text != "^") {
-                    Logger.error(logger, "Don't know how to find reference variables in binding", element)
-                }
-
-                true
-            }
-
-            else -> {
-                Logger.error(logger, "Don't know how to find reference variables in binding", element)
-
-                true
-            }
+            // A pinned variable is a use, not a binding, and no other prefix operator binds either
+            is ElixirUnmatchedUnaryOperation -> true
+            // Anything else in a binding position binds nothing
+            else -> true
         }
 
 

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -58,23 +58,13 @@ class Injector : MultiHostInjector {
             is ElixirAtomKeyword -> Unit
 
             is ElixirLine -> injectMarkdownInQuote(registrar, documentation)
-            is QuotableKeywordPair -> {
-                when (val key = documentation.keywordKey.text) {
-                    "deprecated" -> getLanguagesToInjectInQuote(registrar, documentation.keywordValue)
-                    "authors", "delegate_to", "group", "guard", "request_body", "responses", "since", "type" -> Unit
-                    else -> {
-                        Logger.error(
-                            javaClass,
-                            "Do not know whether to inject Markdown in documentation key $key",
-                            documentation
-                        )
-                    }
-                }
+            // `deprecated:` is the one metadata key whose value is prose; any other key is data
+            is QuotableKeywordPair -> if (documentation.keywordKey.text == "deprecated") {
+                getLanguagesToInjectInQuote(registrar, documentation.keywordValue)
             }
 
-            else -> {
-                Logger.error(javaClass, "Do not know whether to inject Markdown in documentation", documentation)
-            }
+            // Any other value shape is not prose to inject into
+            else -> Unit
         }
     }
 

--- a/src/org/elixir_lang/leex/reference/resolver/Assign.kt
+++ b/src/org/elixir_lang/leex/reference/resolver/Assign.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.stubs.StubIndex
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.leex.reference.Assign
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.Modular.callDefinitionClauseCallFoldWhile
@@ -312,11 +311,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
                 }
             }
 
-            else -> {
-                error("Cannot resolve assign in call definition clause expression", expression)
-
-                AccumulatorContinue(initial, true)
-            }
+            // Anything else assigns nothing; keep looking
+            else -> AccumulatorContinue(initial, true)
         }
 
     private fun resolveInAssign2Argument(
@@ -371,11 +367,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
 
             is QuotableKeywordPair -> resolveInAssign2Argument(assign, incompleteCode, expression.keywordKey, initial)
             is ElixirUnmatchedUnqualifiedNoArgumentsCall -> initial
-            else -> {
-                error("Cannot resolve assign in assign/2 argument", expression)
-
-                initial
-            }
+            // Anything else names no assign
+            else -> initial
         }
 
     private fun resolveInAtomArgument(
@@ -406,11 +399,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
                 null
             } ?: initial
 
-            else -> {
-                error("Cannot resolve assign in atom argument", expression)
-
-                initial
-            }
+            // A key that is not an atom names no assign
+            else -> initial
         }
 
     private fun resolveInLiveComponentCalls(
@@ -528,11 +518,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
             }
             // function calls are the source of the socket, don't resolve through the function call
             is Call -> resolveSocketAsOtherNamedElement(assign, incompleteCode, expression, initial)
-            else -> {
-                error("Cannot resolve assign in @myself expression", expression)
-
-                AccumulatorContinue(initial, true)
-            }
+            // Anything else is not a socket; keep looking
+            else -> AccumulatorContinue(initial, true)
         }
 
     private fun resolveSocketAsOtherNamedElement(
@@ -686,11 +673,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
             }
 
             is ElixirEndOfExpression -> AccumulatorContinue(initial, true)
-            else -> {
-                error("Cannot resolve assign in to_rendered expression", expression)
-
-                AccumulatorContinue(initial, true)
-            }
+            // Anything else assigns nothing; keep looking
+            else -> AccumulatorContinue(initial, true)
         }
 
     private fun resolveLiveAction(assign: Assign, incompleteCode: Boolean): AccumulatorContinue<List<ResolveResult>> {
@@ -779,12 +763,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
                 }
             }
 
-            is Arrow, is AtOperation, is ElixirAtomKeyword, is Pipe, is Two -> AccumulatorContinue(initial, true)
-            is Operation -> {
-                error("Cannot resolve assign in operation for @myself", expression)
-
-                AccumulatorContinue(initial, true)
-            }
+            // No operation assigns
+            is Operation -> AccumulatorContinue(initial, true)
 
             is Call -> {
                 val arguments = expression.finalArguments()
@@ -874,11 +854,8 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
                 } ?: AccumulatorContinue(initial, true)
             }
 
-            else -> {
-                error("Cannot resolve assign for  @myself", expression)
-
-                AccumulatorContinue(initial, true)
-            }
+            // Anything else assigns nothing; keep looking
+            else -> AccumulatorContinue(initial, true)
         }
 
     private fun resolveInCallDefinitionClause(
@@ -907,9 +884,5 @@ object Assign : ResolveCache.PolyVariantResolver<ReferenceAssign> {
         return element.containingFile.originalFile.virtualFile?.let { elementVirtualFile ->
             LibraryScopeCache.getInstance(project).getLibraryScope(elementVirtualFile)
         } ?: GlobalSearchScope.allScope(project)
-    }
-
-    fun error(title: String, element: PsiElement) {
-        Logger.error(Assign::class.java, title, element)
     }
 }

--- a/src/org/elixir_lang/mix/Dep.kt
+++ b/src/org/elixir_lang/mix/Dep.kt
@@ -203,11 +203,8 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
             atom.line?.let { name(it) }
                 ?: atom.node.lastChildNode.text
 
-        private fun name(line: ElixirLine): String? {
-            Logger.error(logger, "Don't know how to convert ${line.text} to dep name", line.parent)
-
-            return null
-        }
+        // A quoted atom, `:"my-dep"`, names the dep by its string body
+        private fun name(line: ElixirLine): String? = line.body?.text
 
         private fun putPath(dep: Dep, keywordValue: Quotable): Dep {
             val strippedKeywordValue = keywordValue.stripAccessExpression()
@@ -215,11 +212,8 @@ data class Dep(val application: String, val path: String, val type: Type = Type.
             return when (strippedKeywordValue) {
                 is ElixirLine -> putPath(dep, strippedKeywordValue)
                 is Call -> putPath(dep, strippedKeywordValue)
-                else -> {
-                    Logger.error(logger, "Don't know how to convert ${keywordValue.text} to path", keywordValue.parent)
-
-                    dep
-                }
+                // Anything else cannot be read as a path either, and leaves the dep where it was
+                else -> dep
             }
         }
 

--- a/src/org/elixir_lang/navigation/ChooseByNameContributor.kt
+++ b/src/org/elixir_lang/navigation/ChooseByNameContributor.kt
@@ -124,9 +124,8 @@ open class ChooseByNameContributor(private val stubIndexKey: StubIndexKey<String
         enclosingModularByCall: EnclosingModularByCall,
         call: Call
     ) {
-        enclosingModularByCall.putNew(call)?.let { Callback(it, call) }?.run {
-            items.add(this)
-        } ?: error("Cannot find enclosing Modular for Callback", call)
+        // A callback outside any module has nowhere to be listed
+        enclosingModularByCall.putNew(call)?.let { items.add(Callback(it, call)) }
     }
 
     private fun getItemsFromCallDefinitionClause(
@@ -140,12 +139,8 @@ open class ChooseByNameContributor(private val stubIndexKey: StubIndexKey<String
                 val time = CallDefinitionClause.time(call)
                 val modular = enclosingModularByCall.putNew(call)
 
-                if (modular == null) {
-                    // don't throw an error if really EEX, but has wrong extension
-                    if (!call.text.contains("<%=")) {
-                        error("Cannot find enclosing Modular", call)
-                    }
-                } else {
+                // A definition outside any module has nowhere to be listed
+                if (modular != null) {
                     for (arity in arityInterval.closed()) {
                         val tuple = CallDefinition.Tuple(modular, time, name, arity)
                         callDefinitionByTuple.computeIfAbsent(tuple) { (modular, time, name, arity) ->
@@ -196,11 +191,7 @@ open class ChooseByNameContributor(private val stubIndexKey: StubIndexKey<String
 
                     val callDefinitionHead = CallDefinitionHead(callDefinition, visibility, call)
                     items.add(callDefinitionHead)
-                } else {
-                    error("Call for CallDefinitionHead does not have function name", call)
                 }
-            } else {
-                error("Cannot find enclosing Modular for Delegation call", delegationCall)
             }
         } else {
             error("Cannot find enclosing delegation call for CallDefinitionHead", call)
@@ -212,16 +203,12 @@ open class ChooseByNameContributor(private val stubIndexKey: StubIndexKey<String
         enclosingModularByCall: EnclosingModularByCall,
         call: Call
     ) {
+        // A specification outside any module has nowhere to be listed
         enclosingModularByCall.putNew(call)?.let { modular ->
-            CallDefinitionSpecification(
-                modular,
-                call as AtUnqualifiedNoParenthesesCall<*>,
-                false,
-                Timed.Time.RUN
-            ).run {
-                items.add(this)
-            }
-        } ?: error("Cannot find enclosing Modular for CallDefinitionSpecification", call)
+            items.add(
+                CallDefinitionSpecification(modular, call as AtUnqualifiedNoParenthesesCall<*>, false, Timed.Time.RUN)
+            )
+        }
     }
 
     private fun getItemsFromImplementation(

--- a/src/org/elixir_lang/psi/Unquote.kt
+++ b/src/org/elixir_lang/psi/Unquote.kt
@@ -5,7 +5,6 @@ import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.ResolveState
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.UNQUOTE
 import org.elixir_lang.psi.call.name.Module.KERNEL
@@ -83,30 +82,13 @@ object Unquote {
                             treeWalkUpValue(value, resolveState, keepProcessing)
                         } ?: true
                     }
-                    // ... = variable
+                    // ... = variable: a use, which binds nothing further up
                     else {
-                        Logger.error(
-                                Unquote::class.java,
-                                "Don't know how to walk unquoted variable parent",
-                                parent
-                        )
-
                         true
                     }
                 }
-                // ...: variable
-                is ElixirKeywordPair -> if (parent.keywordKey.name == "do") {
-                    // `do: variable`, such as `do: block` in macro parameters
-                    true
-                } else {
-                    Logger.error(
-                            Unquote::class.java,
-                            "Don't know how to walk unquoted variable parent",
-                            parent
-                    )
-
-                    true
-                }
+                // ...: variable, such as `do: block` in macro parameters
+                is ElixirKeywordPair -> true
                 // (..., parameter)
                 is ElixirParenthesesArguments -> true
                 // Transparent wrappers: keep walking upward
@@ -117,17 +99,8 @@ object Unquote {
                 is QuotableArguments,
                 is QuotableKeywordList,
                 is Call -> treeWalkUpUnquotedVariable(parent, resolveState, keepProcessing)
-                // Stop quietly at file boundary
-                is com.intellij.psi.PsiFile -> true
-                else -> {
-                    Logger.error(
-                            Unquote::class.java,
-                            "Don't know how to walk unquoted variable parent",
-                            parent
-                    )
-
-                    true
-                }
+                // Anything else, the file included, binds nothing the unquote could see
+                else -> true
             }
 
     private fun treeWalkUpValue(value: PsiElement,
@@ -135,15 +108,8 @@ object Unquote {
                                 keepProcessing: (PsiElement, ResolveState) -> Boolean): Boolean =
             when (value) {
                 is Call -> treeWalkUpValue(value, resolveState, keepProcessing)
-                else -> {
-                    Logger.error(
-                            Unquote::class.java,
-                            "Don't know how to walk unquoted variable value",
-                            value
-                    )
-
-                    true
-                }
+                // A literal, container or operation has no definitions to walk into
+                else -> true
             }
 
     private fun treeWalkUpValue(value: Call,

--- a/src/org/elixir_lang/psi/__module__/AliasPresentation.kt
+++ b/src/org/elixir_lang/psi/__module__/AliasPresentation.kt
@@ -17,6 +17,6 @@ class AliasPresentation(private val __MODULE__Call: Call) : ItemPresentation {
     }
 
     private val _presentableText by lazy {
-        "alias ${UnaliasedName.unaliasedName(__MODULE__Call as PsiNamedElement)}"
+        UnaliasedName.unaliasedName(__MODULE__Call as PsiNamedElement)?.let { "alias $it" } ?: __MODULE__Call.text
     }
 }

--- a/src/org/elixir_lang/psi/impl/ProcessDeclarationsImpl.kt
+++ b/src/org/elixir_lang/psi/impl/ProcessDeclarationsImpl.kt
@@ -119,15 +119,8 @@ object ProcessDeclarationsImpl {
             is Call,
                 // Fixes #2577
             is ElixirTuple -> true
-            else -> {
-                Logger.error(
-                    restrictions::class.java,
-                    "Don't know how find type variable restrictions",
-                    restrictions
-                )
-
-                true
-            }
+            // Anything else restricts no type variable; keep walking
+            else -> true
         }
 
     /**

--- a/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
+++ b/src/org/elixir_lang/psi/impl/PsiNamedElementImpl.kt
@@ -5,7 +5,6 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.IncorrectOperationException
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.Name
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.module.PutAttribute
 import org.elixir_lang.module.RegisterAttribute
 import org.elixir_lang.psi.*
@@ -139,25 +138,20 @@ object PsiNamedElementImpl {
                     newFunctionNameElementCall.functionNameElement()!!.node
                 }
 
-                else -> {
-                    Logger.error(javaClass, "Don't know how to replace function name", named)
-
-                    nameNode
-                }
+                else -> throw IncorrectOperationException(
+                    "Cannot rename a call named by ${functionNameElement.node.elementType}"
+                )
             }
 
             val newNameElementType = newNameNode.elementType
 
-            if (nameElementType == newNameElementType) {
-                val node = nameNode.treeParent
-                node.replaceChild(nameNode, newNameNode)
-            } else {
-                Logger.error(
-                    javaClass,
-                    "New name node elementType (${newNameElementType}) does not match old name node elementType (${nameElementType})",
-                    named
+            if (nameElementType != newNameElementType) {
+                throw IncorrectOperationException(
+                    "New name node elementType ($newNameElementType) does not match old name node elementType ($nameElementType)"
                 )
             }
+
+            nameNode.treeParent.replaceChild(nameNode, newNameNode)
         }
 
         return named

--- a/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
@@ -5,7 +5,6 @@ import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.isAncestor
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Module.KERNEL
@@ -182,39 +181,12 @@ object QualifiableAliasImpl {
             is Call -> {
                 val modularSet = strippedQualifier.maybeModularNameToModulars()
 
-                when (modularSet.size) {
-                    0 -> {
-                        Logger.error(
-                            QualifiableAlias::class.java,
-                            "Don't know how to prepend qualifier when call resolves to no modulars",
-                            context
-                        )
-
-                        "?"
-                    }
-
-                    1 -> modularSet.single().name ?: "?"
-                    else -> {
-                        Logger.error(
-                            QualifiableAlias::class.java,
-                            "Don't know how to prepend qualifier when call resolves to more than one modular",
-                            context
-                        )
-
-                        "?"
-                    }
-                }
+                // A qualifier that resolves to no module, or to more than one, is a placeholder segment
+                modularSet.singleOrNull()?.name ?: "?"
             }
 
-            else -> {
-                Logger.error(
-                    QualifiableAlias::class.java,
-                    "Don't know how to prepend qualifier",
-                    context
-                )
-
-                "?"
-            }
+            // Anything else names no module either
+            else -> "?"
         }
 
     private fun prependQualifiers(ancestor: PsiElement, previousAncestor: PsiElement, accumulator: String): String =
@@ -263,16 +235,12 @@ object QualifiableAliasImpl {
                         "${qualifierName(qualifier, ancestor)}.${accumulator}"
                     }
                 } else {
-                    Logger.error(QualifiableAlias::class.java, "Don't know how to prepend qualifier", ancestor)
-
+                    // A qualified alias still missing its qualifier while being typed
                     "?.${accumulator}"
                 }
             }
 
-            else -> {
-                Logger.error(QualifiableAlias::class.java, "Don't know how to prepend qualifier", ancestor)
-
-                "?.${accumulator}"
-            }
+            // Any other container ends qualification, as every container named above does
+            else -> accumulator
         }
 }

--- a/src/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentation.kt
+++ b/src/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentation.kt
@@ -35,7 +35,7 @@ class ItemPresentation(private val qualifiableAlias: QualifiableAlias) : ItemPre
             when (ancestor) {
                 is Call ->
                         if (ancestor.isCalling(KERNEL, ALIAS)) {
-                            "alias ${UnaliasedName.unaliasedName(qualifiableAlias)}"
+                            UnaliasedName.unaliasedName(qualifiableAlias)?.let { "alias $it" } ?: qualifiableAlias.name
                         } else {
                             qualifiableAlias.fullyQualifiedName()
                         }
@@ -47,9 +47,10 @@ class ItemPresentation(private val qualifiableAlias: QualifiableAlias) : ItemPre
                     getPresentableText(ancestor.parent)
                 is QuotableKeywordPair -> {
                     if (ancestor.hasKeywordKey("as")) {
-                        aliasFirstArgument(ancestor)?.let { aliasFirstArgument ->
-                            "alias ${UnaliasedName.unaliasedName(aliasFirstArgument)}, as: ${qualifiableAlias.name}"
-                        } ?: qualifiableAlias.name
+                        aliasFirstArgument(ancestor)
+                            ?.let { UnaliasedName.unaliasedName(it) }
+                            ?.let { "alias $it, as: ${qualifiableAlias.name}" }
+                            ?: qualifiableAlias.name
                     } else {
                         null
                     }

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
@@ -99,7 +99,8 @@ class MultiResolve internal constructor(private val name: String, private val in
     private fun addUnaliasedNamedElementsToResolveResultList(match: PsiNamedElement,
                                                              namePartList: List<String>,
                                                              visitedElementSet: Set<PsiElement>) {
-        val unaliasedName = unaliasedName(match, namePartList)
+        // An alias of something that is not a module resolves to nothing
+        val unaliasedName = unaliasedName(match, namePartList) ?: return
 
         val project = match.project
 
@@ -166,11 +167,11 @@ class MultiResolve internal constructor(private val name: String, private val in
             return multiResolve.resolveResults()
         }
 
-        private fun unaliasedName(match: PsiNamedElement, namePartList: List<String>): String {
-            val matchUnaliasedName = UnaliasedName.unaliasedName(match)
+        private fun unaliasedName(match: PsiNamedElement, namePartList: List<String>): String? {
+            val matchUnaliasedName = UnaliasedName.unaliasedName(match) ?: return null
 
             val unaliasedNamePartList = ArrayList<String>(namePartList.size)
-            unaliasedNamePartList.add(matchUnaliasedName!!)
+            unaliasedNamePartList.add(matchUnaliasedName)
 
             for (i in 1 until namePartList.size) {
                 unaliasedNamePartList.add(namePartList[i])

--- a/src/org/elixir_lang/reference/Callable.kt
+++ b/src/org/elixir_lang/reference/Callable.kt
@@ -15,7 +15,6 @@ import com.intellij.usageView.UsageViewTypeLocation
 import com.intellij.util.IncorrectOperationException
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.annotator.Parameter
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.ElementDescriptionProvider.Companion.VARIABLE_USAGE_VIEW_TYPE_LOCATION_ELEMENT_DESCRIPTION
 import org.elixir_lang.psi.call.Call
@@ -369,17 +368,8 @@ class Callable : PsiReferenceBase<Call>, PsiPolyVariantReference {
                 is Call -> // MUST be after any operations because operations also implement Call
                     isVariable(ancestor)
 
-                else -> {
-                    if (!(ancestor is AtUnqualifiedBracketOperation ||
-                                ancestor is AtOperation ||
-                                ancestor is BracketOperation ||
-                                ancestor is PsiFile ||
-                                ancestor is QualifiedMultipleAliases)
-                    ) {
-                        error("Don't know how to check if variable", ancestor)
-                    }
-                    false
-                }
+                // Anything else cannot hold a variable declaration
+                else -> false
             }
 
         @RequiresReadLock
@@ -427,10 +417,6 @@ class Callable : PsiReferenceBase<Call>, PsiPolyVariantReference {
         @JvmStatic
         fun variableUseScope(match: UnqualifiedNoArgumentsCall<*>): LocalSearchScope =
             variableUseScope(match as PsiElement)
-
-        private fun error(message: String, element: PsiElement) {
-            Logger.error(Callable::class.java, message, element)
-        }
 
         /**
          * Searches downward from `ancestor`, only returning true if `element` is a type, unit, size or
@@ -597,10 +583,8 @@ class Callable : PsiReferenceBase<Call>, PsiPolyVariantReference {
                        declaration, so it has no use scope */
                     LocalSearchScope.EMPTY
 
-                else -> {
-                    error("Don't know how to find variable use scope", ancestor)
-                    LocalSearchScope.EMPTY
-                }
+                // Anything else cannot declare a variable either, so a use there has no scope
+                else -> LocalSearchScope.EMPTY
             }
     }
 }

--- a/src/org/elixir_lang/reference/module/UnaliasedName.kt
+++ b/src/org/elixir_lang/reference/module/UnaliasedName.kt
@@ -2,7 +2,6 @@ package org.elixir_lang.reference.module
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
-import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function
@@ -47,15 +46,8 @@ object UnaliasedName {
 
                 is ElixirAtom -> ":${element.name}"
                 is QualifiableAlias -> element.name
-                else -> {
-                    Logger.error(
-                        javaClass,
-                        "Don't know how to search down below ${element.javaClass} for unaliased name",
-                        element
-                    )
-
-                    "?"
-                }
+                // Anything else, such as a string, names no module
+                else -> null
             }
 
     private fun unaliasedName(qualifiableAlias: QualifiableAlias): String? =

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.kt
@@ -124,13 +124,8 @@ class CallDefinitionClause(val callDefinition: CallDefinition, call: Call) :
                 } else if (org.elixir_lang.psi.CallDefinitionClause.`is`(quoteEnclosingMacroCall)) {
                     val callDefinitionClause = CallDefinitionClause.fromCall(quoteEnclosingMacroCall)
 
-                    if (callDefinitionClause == null) {
-                        Logger.error(
-                            CallDefinitionClause::class.java,
-                            "Cannot construct CallDefinitionClause from quote's enclosing macro call",
-                            quoteEnclosingMacroCall
-                        )
-                    } else {
+                    // A headless `defmacro` has no clause to hang the quote on yet
+                    if (callDefinitionClause != null) {
                         quote = Quote(
                             callDefinitionClause,
                             enclosingMacroCall

--- a/testData/org/elixir_lang/injection/markdown/unlisted_metadata.ex
+++ b/testData/org/elixir_lang/injection/markdown/unlisted_metadata.ex
@@ -1,0 +1,11 @@
+defmodule UnlistedMetadata do
+  @doc tags: [:api]
+  def tagged_function(arg) do
+    arg
+  end
+
+  @doc "Adds " <> "two."
+  def concatenated_doc(arg) do
+    arg
+  end
+end

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/headless_macro_quote.ex
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/headless_macro_quote.ex
@@ -1,0 +1,7 @@
+defmodule HeadlessMacroQuote do
+  defmacro do
+    quote do
+      def foo, do: :ok
+    end
+  end
+end

--- a/testData/org/elixir_lang/navigation/goto_symbol_contributor/top_level_definitions.exs
+++ b/testData/org/elixir_lang/navigation/goto_symbol_contributor/top_level_definitions.exs
@@ -1,0 +1,3 @@
+def foo, do: :ok
+@spec f() :: term
+@callback g() :: term

--- a/testData/org/elixir_lang/reference/callable/unquote_variable_bound_to_literal/unquote_variable_bound_to_literal.ex
+++ b/testData/org/elixir_lang/reference/callable/unquote_variable_bound_to_literal/unquote_variable_bound_to_literal.ex
@@ -1,0 +1,13 @@
+defmodule BoundToLiteral do
+  @moduledoc false
+
+  @callback docs_uri() :: binary()
+  defmacro __using__(_opts) do
+    docs_uri = "https://example.com/docs"
+
+    quote do
+      @moduledoc unquote(module_doc)
+      unquote(docs_uri)
+    end
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/unquote_variable_from_keyword_parameter/unquote_variable_from_keyword_parameter.ex
+++ b/testData/org/elixir_lang/reference/callable/unquote_variable_from_keyword_parameter/unquote_variable_from_keyword_parameter.ex
@@ -1,0 +1,11 @@
+defmodule FromKeywordParameter do
+  @moduledoc false
+
+  @callback docs_uri() :: binary()
+  defmacro __using__(_opts, docs_uri: docs_uri) do
+    quote do
+      @moduledoc unquote(module_doc)
+      unquote(docs_uri)
+    end
+  end
+end

--- a/testData/org/elixir_lang/reference/module/unaliased_name/string_alias.ex
+++ b/testData/org/elixir_lang/reference/module/unaliased_name/string_alias.ex
@@ -1,0 +1,1 @@
+alias "Foo", as: A<caret>s

--- a/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
+++ b/tests/org/elixir_lang/annotator/ModuleAttributeTest.java
@@ -200,16 +200,13 @@ public class ModuleAttributeTest extends PlatformTestCase {
      * stopped reporting at all. If captures gain a branch, swap the fixture for another unclassifiable
      * construct rather than deleting this.
      */
-    public void testUnclassifiableTypeElementIsReported() {
-        myFixture.configureByFile("capture_in_type.ex");
-
-        List<LoggedError> reported = loggedErrors();
-
-        assertFalse(
-                "Expected an unclassifiable element in a type to be reported, but nothing was logged",
-                reported.isEmpty()
-        );
-        assertEquals("Cannot highlight types", reported.get(0).getTitle());
+    /**
+     * A construct the annotator does not colour keeps its default colour, and that is not an error.
+     * A capture is such a construct: it can appear in a type while one is being written, and the
+     * annotator has nothing to say about it.
+     */
+    public void testCaptureInTypeIsNotReported() {
+        assertNoTypeHighlightingError("capture_in_type.ex");
     }
 
     /*

--- a/tests/org/elixir_lang/documentation/UnhandledDocOwnerTest.kt
+++ b/tests/org/elixir_lang/documentation/UnhandledDocOwnerTest.kt
@@ -1,0 +1,50 @@
+package org.elixir_lang.documentation
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.beam.BeamLibraryTestCase
+import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
+
+/**
+ * Documentation lookup is a positive filter: the elements that carry docs are named, and anything
+ * else simply has none. Neither a `@spec` asked for its doc owner nor a decompiled `@type` asked for
+ * its docs is an error; each is an ordinary element without documentation.
+ */
+class UnhandledDocOwnerTest : BeamLibraryTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/type"
+
+    fun testNonDocumentationAttributeHasNoOwner() {
+        myFixture.configureByText(
+            "spec.ex",
+            """
+            defmodule Spec do
+              @spec f() :: term
+              def f, do: 1
+            end
+            """.trimIndent()
+        )
+        val spec = PsiTreeUtil.findChildOfType(myFixture.file, AtUnqualifiedNoParenthesesCall::class.java)
+        assertNotNull("fixture did not parse to a module attribute", spec)
+
+        val (owner, errors) = captureLoggedErrors {
+            ElixirDocumentationProvider().findDocComment(myFixture.file, spec!!.textRange)!!.owner
+        }
+
+        assertEmpty("a non-documentation attribute is not an error", errors)
+        assertNull("a `@spec` documents nothing", owner)
+    }
+
+    fun testDecompiledTypeHasNoDocs() {
+        openBeam("queue.beam")
+        val module = myFixture.file.children.single() as ModuleImpl<*>
+        val type = module.typeDefinitions().firstOrNull()
+        assertNotNull("queue.beam decompiled without a type definition", type)
+
+        val (doc, errors) = captureLoggedErrors {
+            ElixirDocumentationProvider().generateDoc(type!!, null)
+        }
+
+        assertEmpty("an element without docs is not an error", errors)
+        assertNull("types only exist for builtins, so there are no docs", doc)
+    }
+}

--- a/tests/org/elixir_lang/ecto/QueryTest.kt
+++ b/tests/org/elixir_lang/ecto/QueryTest.kt
@@ -1,0 +1,106 @@
+package org.elixir_lang.ecto
+
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall
+
+/**
+ * Variable resolution walks into an `Ecto.Query` macro call to find the bindings the query DSL
+ * declares. The walker names the binding shapes it declares from; a shape it does not name declares
+ * nothing, which is the ordinary case for a pinned option list or a query part-way through being
+ * typed, and is not an error. The `from/2` keyword keys are different: Ecto's set is finite and
+ * documented, and a new key may declare bindings, so an unlisted key is the one thing reported.
+ *
+ * The walker only runs when the call resolves to a macro in a module named `Ecto.Query`, so a stub
+ * of that module is added to the project first.
+ */
+class QueryTest : PlatformTestCase() {
+    override fun setUp() {
+        super.setUp()
+        myFixture.addFileToProject(
+            "lib/ecto/query.ex",
+            """
+            defmodule Ecto.Query do
+              defmacro from(expr, kw \\ []), do: nil
+              defmacro where(query, binding \\ [], expr), do: nil
+              defmacro with_cte(query, name, list), do: nil
+            end
+            """.trimIndent()
+        )
+    }
+
+    fun testBindingDeclaredByInResolvesFromSelect() {
+        val results = resolveSilently("from(p in Post, select: <caret>p)")
+
+        assertTrue(
+            "`p` in `select:` should resolve to the `p` bound by `in`",
+            results.any { it.isValidResult && it.element?.text == "p" }
+        )
+    }
+
+    fun testUnlistedKeywordKeyIsReported() {
+        val (_, errors) = resolve("from(p in Post, foo: <caret>q)")
+
+        assertEquals(
+            listOf("Don't know how to find reference variables for keyword key foo"),
+            errors.map { it.title }.distinct()
+        )
+    }
+
+    fun testPinnedOptionsDeclareNothing() {
+        resolveSilently("from(p in Post, ^<caret>q)")
+    }
+
+    fun testPinnedSourceDeclaresNothing() {
+        resolveSilently("from(^<caret>q in Post)")
+    }
+
+    fun testBracketedWithCteListDeclaresNothing() {
+        resolveSilently("q |> with_cte(\"c\", [as: ^<caret>cte])")
+    }
+
+    fun testBindingTupleOfUnexpectedArityDeclaresNothing() {
+        resolveSilently("where(q, [{p, 1, 2}], <caret>x)")
+    }
+
+    fun testUnpinnedUnaryBindingDeclaresNothing() {
+        resolveSilently("where(q, [!p], <caret>x)")
+    }
+
+    fun testLiteralBindingDeclaresNothing() {
+        resolveSilently("where(q, [\"p\"], <caret>x)")
+    }
+
+    private fun resolveSilently(query: String): Array<ResolveResult> {
+        val (results, errors) = resolve(query)
+
+        assertEmpty("a query shape the walker does not declare from is not an error", errors)
+
+        return results
+    }
+
+    private fun resolve(query: String): Pair<Array<ResolveResult>, List<LoggedError>> {
+        myFixture.configureByText(
+            "query_test.ex",
+            """
+            defmodule QueryTest do
+              import Ecto.Query
+
+              def run(q) do
+                $query
+              end
+            end
+            """.trimIndent()
+        )
+        val usage = PsiTreeUtil.getParentOfType(
+            myFixture.file.findElementAt(myFixture.caretOffset),
+            UnqualifiedNoArgumentsCall::class.java
+        )
+        assertNotNull("caret is not on a variable usage", usage)
+        val reference = usage!!.reference as PsiPolyVariantReference
+
+        return captureLoggedErrors { reference.multiResolve(false) }
+    }
+}

--- a/tests/org/elixir_lang/injection/markdown/DelegateToInjectorTest.kt
+++ b/tests/org/elixir_lang/injection/markdown/DelegateToInjectorTest.kt
@@ -195,6 +195,33 @@ class DelegateToInjectorTest : PlatformTestCase() {
         )
     }
 
+    /**
+     * ExDoc lets `@doc` carry any metadata key, and a doc value can be any expression. Neither an
+     * unlisted key such as `tags:` nor a `<>` concatenation is prose to inject Markdown into, and
+     * neither is an error: the injector names what it injects and passes over the rest.
+     */
+    fun testUnlistedMetadataKeyAndValueShapeAreNotReported() {
+        myFixture.configureByFile("unlisted_metadata.ex")
+
+        val (_, loggedErrors) = captureLoggedErrors {
+            myFixture.doHighlighting()
+        }
+
+        assertEmpty(
+            "The markdown Injector must pass over documentation it does not inject into",
+            loggedErrors.filter { it.category.contains("elixir_lang.injection.markdown.Injector") }
+        )
+
+        val tagsDoc = PsiTreeUtil.findChildrenOfType(myFixture.file, AtUnqualifiedNoParenthesesCall::class.java)
+            .single { it.text.contains("tags:") }
+        val injectedLanguageManager = InjectedLanguageManager.getInstance(myFixture.project)
+        val markdownInjected = PsiTreeUtil.collectElements(tagsDoc) { true }
+            .flatMap { element -> injectedLanguageManager.getInjectedPsiFiles(element).orEmpty() }
+            .filter { it.first.language == MarkdownLanguage.INSTANCE }
+
+        assertEmpty("`tags:` is metadata, not Markdown prose", markdownInjected)
+    }
+
     fun testCodeBlockTrailingEndIsInjectedWithElixir() {
         myFixture.configureByFile("trailing_end_code_block.ex")
 

--- a/tests/org/elixir_lang/leex/reference/resolver/AssignTest.kt
+++ b/tests/org/elixir_lang/leex/reference/resolver/AssignTest.kt
@@ -1,0 +1,139 @@
+package org.elixir_lang.leex.reference.resolver
+
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.common.runAll
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryFixture
+import org.elixir_lang.psi.AtOperation
+
+/**
+ * An `@assign` in a LiveView layout resolves by walking the Phoenix functions that set it, naming
+ * the expression shapes an assignment can hide in. A shape the walk does not name assigns nothing,
+ * which is what a stray literal or an operation in such a function means, and is not an error.
+ *
+ * A template under `layout/` is used because that is the branch the resolver can reach without a
+ * view module as the template's context. The resolver searches libraries only, as Phoenix is a
+ * dependency, so the stub Phoenix module is registered as a library. The walk reads a `do` block's
+ * body last expression first and stops once the assign resolves, so an unmodelled shape sits after
+ * the assignment or replaces it.
+ */
+class AssignTest : PlatformTestCase() {
+    override fun tearDown() {
+        runAll(
+            { BeamLibraryFixture.removeLibrary(project, myFixture.module, LIBRARY) },
+            { super.tearDown() },
+        )
+    }
+
+    fun testLiveActionResolvesToTheAtomAssignedByAssignAction() {
+        addPhoenixFunction(
+            """
+            def assign_action(socket, action) do
+              assign(socket, :live_action, action)
+            end
+            """.trimIndent()
+        )
+
+        val results = resolveSilently("live_action")
+
+        assertTrue("@live_action should resolve to the `:live_action` assigned", results.any(ResolveResult::isValidResult))
+    }
+
+    fun testLiteralExpressionInAssigningFunctionAssignsNothing() {
+        addPhoenixFunction(
+            """
+            def assign_action(socket, action) do
+              assign(socket, :live_action, action)
+              1
+            end
+            """.trimIndent()
+        )
+
+        resolveSilently("live_action")
+    }
+
+    fun testNonAtomAssignKeyAssignsNothing() {
+        addPhoenixFunction(
+            """
+            def assign_action(socket, action) do
+              assign(socket, "live_action", action)
+            end
+            """.trimIndent()
+        )
+
+        resolveSilently("live_action")
+    }
+
+    fun testLiteralInToRenderedAssignsNothing() {
+        addPhoenixFunction(
+            """
+            def to_rendered(content, view) do
+              1
+            end
+            """.trimIndent()
+        )
+
+        resolveSilently("inner_content")
+    }
+
+    fun testOperationInRenderPendingComponentsAssignsNothing() {
+        addPhoenixFunction(
+            """
+            def render_pending_components(socket) do
+              a + b
+            end
+            """.trimIndent()
+        )
+
+        resolveSilently("myself")
+    }
+
+    fun testLiteralInRenderPendingComponentsAssignsNothing() {
+        addPhoenixFunction(
+            """
+            def render_pending_components(socket) do
+              1
+            end
+            """.trimIndent()
+        )
+
+        resolveSilently("myself")
+    }
+
+    private fun addPhoenixFunction(definition: String) {
+        myFixture.addFileToProject(
+            "deps/phoenix_live_view/lib/utils.ex",
+            "defmodule Phoenix.LiveView.Utils do\n" + definition.prependIndent("  ") + "\nend\n"
+        )
+        val dependency = myFixture.tempDirFixture.findOrCreateDir("deps/phoenix_live_view")
+        BeamLibraryFixture.addLibrary(project, myFixture.module, LIBRARY, listOf(dependency))
+    }
+
+    private fun resolveSilently(assign: String): Array<ResolveResult> {
+        val template = myFixture.addFileToProject("lib/app_web/templates/layout/app.html.leex", "<%= @$assign %>")
+        myFixture.configureFromExistingVirtualFile(template.virtualFile)
+        val atOperation = PsiTreeUtil.findChildOfType(
+            myFixture.file.viewProvider.allFiles.first { it.language.id == "Elixir" },
+            AtOperation::class.java
+        )
+        assertNotNull("template did not parse to an assign", atOperation)
+        val elixirRoot = atOperation!!.containingFile
+        assertNull("a layout template has no view module as its context", elixirRoot.context)
+        assertEquals("the template must sit under layout/", "layout", elixirRoot.containingDirectory?.name)
+        val reference = atOperation.reference
+        assertInstanceOf(reference, org.elixir_lang.leex.reference.Assign::class.java)
+        reference as PsiPolyVariantReference
+
+        val (results, errors) = captureLoggedErrors { reference.multiResolve(false) }
+
+        assertEmpty("an expression the resolver does not assign from is not an error", errors)
+
+        return results
+    }
+
+    private companion object {
+        const val LIBRARY = "phoenix_live_view"
+    }
+}

--- a/tests/org/elixir_lang/mix/DepTest.kt
+++ b/tests/org/elixir_lang/mix/DepTest.kt
@@ -65,6 +65,28 @@ class DepTest : PlatformTestCase() {
         assertEquals("An unknown option must still leave the accumulated dep", "deps/my_dep", deps.single()?.path)
     }
 
+    /**
+     * A quoted atom is a legal dep name: `{:"my-dep", "~> 1.0"}` checks out under `deps/my-dep`. The
+     * quoting was reported as an unconvertible name and the dep dropped, so nothing under it resolved.
+     */
+    fun testQuotedAtomNameIsTheDepName() {
+        val (deps, errorTitles) = depsFrom("{:\"my-dep\", \"~> 1.0\"}")
+
+        assertEmpty("A quoted atom is an ordinary dep name", errorTitles)
+        assertEquals("deps/my-dep", deps.single()?.path)
+    }
+
+    /**
+     * A `path:` value the plugin cannot read as a string leaves the dep where it was, exactly as a
+     * `path:` given by a call does; it is not something to report.
+     */
+    fun testUnreadablePathValueLeavesDepsPath() {
+        val (deps, errorTitles) = depsFrom("{:my_dep, path: ~s(../my_dep)}")
+
+        assertEmpty("An unreadable `path` value is not an error", errorTitles)
+        assertEquals("deps/my_dep", deps.single()?.path)
+    }
+
     fun testPathOptionReplacesDepsPath() {
         val (deps, errorTitles) = depsFrom("{:my_dep, path: \"../my_dep\"}")
 

--- a/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.kt
+++ b/tests/org/elixir_lang/navigation/GotoSymbolContributorTest.kt
@@ -35,6 +35,40 @@ class GotoSymbolContributorTest : PlatformTestCase() {
      * Tests
      */
 
+    /**
+     * A `def`, `@spec` or `@callback` outside any module is legal in a script, but there is no module
+     * to list it under, so Go to Symbol has no entry for it. That is not an error.
+     */
+    fun testDefinitionsOutsideAModuleHaveNoEntry() {
+        myFixture.configureByFile("top_level_definitions.exs")
+        val gotoSymbolContributor = gotoSymbolContributor()
+
+        val (items, errors) = captureLoggedErrors {
+            listOf("foo", "f", "g").flatMap { name ->
+                gotoSymbolContributor.getItemsByName(name, name, myFixture.project, false).toList()
+            }
+        }
+
+        assertEmpty("a definition with no enclosing module is not an error", errors)
+        assertEmpty("a definition with no enclosing module has nowhere to be listed", items)
+    }
+
+    /**
+     * A `defmacro` still missing its head has no name to construct a clause from, so a `def` in the
+     * `quote` inside it has no enclosing modular yet. That is a macro being typed, not an error.
+     */
+    fun testDefinitionInsideHeadlessMacroQuoteHasNoEntry() {
+        myFixture.configureByFile("headless_macro_quote.ex")
+        val gotoSymbolContributor = gotoSymbolContributor()
+
+        val (items, errors) = captureLoggedErrors {
+            gotoSymbolContributor.getItemsByName("foo", "foo", myFixture.project, false).toList()
+        }
+
+        assertEmpty("a headless macro is not an error", errors)
+        assertEmpty("a definition quoted in a headless macro has nowhere to be listed", items)
+    }
+
     fun testIssue472() {
         myFixture.configureByFile("issue_472.ex")
         val gotoSymbolContributor = gotoSymbolContributor()

--- a/tests/org/elixir_lang/psi/impl/SetNameTest.kt
+++ b/tests/org/elixir_lang/psi/impl/SetNameTest.kt
@@ -1,0 +1,31 @@
+package org.elixir_lang.psi.impl
+
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.IncorrectOperationException
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.call.Named
+import org.elixir_lang.psi.operation.Addition
+
+/**
+ * A rename that cannot be carried out must say so, as the platform setName contract requires,
+ * rather than report an error and leave the name unchanged. An operator is named by its operator
+ * token, which is not an identifier the rename knows how to replace.
+ */
+class SetNameTest : PlatformTestCase() {
+    fun testRenamingAnOperatorReportsItCannotRename() {
+        myFixture.configureByText("operation.ex", "a + b\n")
+        val addition = PsiTreeUtil.findChildOfType(myFixture.file, Addition::class.java) as Named
+
+        val (thrown, errors) = captureLoggedErrors {
+            try {
+                addition.setName("x")
+                null
+            } catch (incorrectOperation: IncorrectOperationException) {
+                incorrectOperation
+            }
+        }
+
+        assertEmpty("a refused rename is reported through the exception, not the log", errors)
+        assertNotNull("renaming an operator must be refused", thrown)
+    }
+}

--- a/tests/org/elixir_lang/psi/impl/declarations/UnhandledTypeRestrictionTest.kt
+++ b/tests/org/elixir_lang/psi/impl/declarations/UnhandledTypeRestrictionTest.kt
@@ -1,0 +1,34 @@
+package org.elixir_lang.psi.impl.declarations
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall
+import org.elixir_lang.psi.scope.type.MultiResolve
+
+/**
+ * A `when` guard on a `@spec` declares type variables through keyword restrictions. A guard that is
+ * something else, here a string, declares none, and meeting it while resolving a type is not an
+ * error.
+ */
+class UnhandledTypeRestrictionTest : PlatformTestCase() {
+    fun testUnrestrictedGuardDeclaresNothingWithoutAnError() {
+        myFixture.configureByText(
+            "guard.ex",
+            """
+            defmodule Guard do
+              @spec f(a) :: <caret>a when "x"
+              def f(a), do: a
+            end
+            """.trimIndent()
+        )
+        val usage = PsiTreeUtil.getParentOfType(
+            myFixture.file.findElementAt(myFixture.caretOffset),
+            UnqualifiedNoArgumentsCall::class.java
+        )
+        assertNotNull("caret is not on a type usage", usage)
+
+        val (_, errors) = captureLoggedErrors { MultiResolve.resolveResults("a", 0, false, usage!!) }
+
+        assertEmpty("a guard that restricts nothing is not an error", errors)
+    }
+}

--- a/tests/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentationTest.kt
+++ b/tests/org/elixir_lang/psi/impl/qualifiable_alias/ItemPresentationTest.kt
@@ -37,6 +37,20 @@ class ItemPresentationTest : PlatformTestCase() {
         assertEquals("alias Prefix", presentableText)
     }
 
+    /**
+     * `As` in `alias "Foo", as: As` has no module to be unaliased to. Its presentation falls back to the
+     * alias's own name rather than printing a placeholder, and asking for it is not an error.
+     */
+    fun testGetPresentableTextForAliasOfSomethingThatIsNotAModule() {
+        myFixture.configureByText("string_alias.ex", "alias \"Foo\", as: A<caret>s\n")
+        val elixirAlias = myFixture.file.findElementAt(myFixture.caretOffset)!!.parent as ElixirAlias
+
+        val (presentableText, errors) = captureLoggedErrors { elixirAlias.presentation!!.presentableText }
+
+        assertEmpty("presenting an alias of a non-module is not an error", errors)
+        assertEquals("As", presentableText)
+    }
+
     override fun getTestDataPath(): String =
         "testData/org/elixir_lang/psi/impl/qualifiable_alias/item_presentation"
 }

--- a/tests/org/elixir_lang/psi/impl/qualifiable_alias/UnhandledContainerTest.kt
+++ b/tests/org/elixir_lang/psi/impl/qualifiable_alias/UnhandledContainerTest.kt
@@ -1,0 +1,33 @@
+package org.elixir_lang.psi.impl.qualifiable_alias
+
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirAlias
+import org.elixir_lang.psi.QualifiableAlias
+
+/**
+ * Building an alias's fully-qualified name walks up through the containers that can qualify it and
+ * stops at the first that cannot. A container the walk does not name ends qualification the same
+ * way; it is not an error. Likewise a call qualifier that resolves to no module contributes a
+ * placeholder segment rather than a report.
+ */
+class UnhandledContainerTest : PlatformTestCase() {
+    fun testAliasInsideBitStringIsItsOwnName() {
+        assertFullyQualifiedName("<<Fo<caret>o>>\n", "Foo")
+    }
+
+    fun testCallQualifierResolvingToNoModuleIsAPlaceholder() {
+        assertFullyQualifiedName("__MODULE__.Fo<caret>o\n", "?.Foo")
+    }
+
+    private fun assertFullyQualifiedName(text: String, expected: String) {
+        myFixture.configureByText("alias.ex", text)
+        val alias = PsiTreeUtil.getParentOfType(myFixture.file.findElementAt(myFixture.caretOffset), ElixirAlias::class.java)
+        assertNotNull("caret is not on an alias", alias)
+
+        val (name, errors) = captureLoggedErrors { (alias as QualifiableAlias).fullyQualifiedName() }
+
+        assertEmpty("an unqualifiable container is not an error", errors)
+        assertEquals(expected, name)
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/UnquoteCallbackNamedVariableTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UnquoteCallbackNamedVariableTest.kt
@@ -42,10 +42,34 @@ class UnquoteCallbackNamedVariableTest : PlatformTestCase() {
         }
 
         assertEmpty(
-            "Logger.error should not be called for unquoted variable parent in $displayName",
+            "Logger.error should not be called for unquoted variable in $displayName",
             loggedErrors.filter {
-                it.title?.contains("Don't know how to walk unquoted variable parent") == true
+                it.title?.contains("Don't know how to walk unquoted variable") == true
             }
+        )
+    }
+
+    /**
+     * The unquoted variable is bound to a string literal rather than to a call. A literal has no
+     * declarations to walk into, so the walk stops there without comment.
+     */
+    fun testUnquoteVariableBoundToLiteral() {
+        testNoErrorLogged(
+            "unquote_variable_bound_to_literal",
+            "unquote_variable_bound_to_literal.ex",
+            "variable bound to a literal"
+        )
+    }
+
+    /**
+     * The unquoted variable is declared as the value of a keyword parameter, `docs_uri: docs_uri`, so
+     * its parent is a keyword pair whose key is not `do`. A parameter declares nothing further up.
+     */
+    fun testUnquoteVariableFromKeywordParameter() {
+        testNoErrorLogged(
+            "unquote_variable_from_keyword_parameter",
+            "unquote_variable_from_keyword_parameter.ex",
+            "variable from a keyword parameter"
         )
     }
 

--- a/tests/org/elixir_lang/reference/callable/VariableUseScopeUnhandledContainerTest.kt
+++ b/tests/org/elixir_lang/reference/callable/VariableUseScopeUnhandledContainerTest.kt
@@ -1,0 +1,28 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.psi.search.LocalSearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.UnqualifiedNoArgumentsCall
+import org.elixir_lang.reference.Callable
+
+/**
+ * The use-scope walk names the containers a variable can be declared through and stops, with an
+ * empty scope, at anything that cannot declare one. A container it does not name is the latter
+ * case, not an error: a match inside bracket access declares nothing outside the brackets.
+ */
+class VariableUseScopeUnhandledContainerTest : PlatformTestCase() {
+    fun testVariableInsideBracketArgumentsHasEmptyUseScope() {
+        myFixture.configureByText("brackets.ex", "foo[<caret>x = 1]\n")
+        val variable = PsiTreeUtil.getParentOfType(
+            myFixture.file.findElementAt(myFixture.caretOffset),
+            UnqualifiedNoArgumentsCall::class.java
+        )
+        assertNotNull("caret is not on a variable", variable)
+
+        val (useScope, errors) = captureLoggedErrors { Callable.variableUseScope(variable!!) }
+
+        assertEmpty("a container that declares nothing is not an error", errors)
+        assertEquals(LocalSearchScope.EMPTY, useScope)
+    }
+}

--- a/tests/org/elixir_lang/reference/module/UnaliasedNameTest.kt
+++ b/tests/org/elixir_lang/reference/module/UnaliasedNameTest.kt
@@ -141,6 +141,20 @@ class UnaliasedNameTest : PlatformTestCase() {
     // -------------------------------------------------------------------------
 
     /** Navigates from the caret token to the immediately enclosing [ElixirAlias]. */
+    /**
+     * `As` in `alias "Foo", as: As`. The first argument is a string, which names no module, so there is
+     * no unaliased name: `null`, not a placeholder, and not an error.
+     */
+    fun testUnnameableFirstArgumentHasNoUnaliasedName() {
+        myFixture.configureByFile("string_alias.ex")
+        val asAlias = caretElixirAlias()
+
+        val (unaliased, errors) = captureLoggedErrors { unaliasedName(asAlias) }
+
+        assertEmpty("an alias of something that is not a module is not an error", errors)
+        assertNull(unaliased)
+    }
+
     private fun caretElixirAlias(): ElixirAlias {
         val element = myFixture.file.findElementAt(myFixture.caretOffset)
         assertNotNull("Expected an element at the caret", element)


### PR DESCRIPTION
## Summary

#4014 made the scope processors under `psi/scope/` positive filters: a walker names the shapes it handles and silently answers the neutral value for everything else, which is the contract the platform's own `PsiScopeProcessor` implementations use. This carries the same change to the rest of the plugin, one package per commit. About 60 `Logger.error` fall-throughs in 13 files turned every unmodelled code shape into an error report; each now returns what its named neighbours already return. Refs #3985, whose sub-issues are the symptoms.

Three of the sites hid real defects rather than noise, and those are fixed rather than silenced: a dep named by a quoted atom, `{:"my-dep", "~> 1.0"}`, was dropped from the dep list; `alias "Foo", as: As` produced the string `"?"` as an unaliased module name, which flowed into name comparisons and `alias ?` presentations, and now yields `null`; and renaming a call named by an operator logged an error then replaced the name node with itself, so the user saw nothing, and now throws `IncorrectOperationException` as the rename dialog expects.

Kept as errors, with the reason in each commit: the unknown-option tripwire in `Dep.kt` (deliberate and test-pinned), the caught range exception in the Markdown injector, the `time`/`visibility` guesses in the structure view (unreachable behind `CallDefinitionClause.is`), the delegation-head inconsistency in Go to Symbol, the parameter use-scope disagreement, and the three grammar-unreachable checks in the module attribute annotator. `ChooseByNameContributor.kt:77` is owned by #4000 and is untouched.

## Tests

Every commit adds or extends a test that was run red against the unchanged production code and named the exact error title it now forbids. Two files get their first test coverage: `ecto/Query.kt` (the walker only runs when the call resolves to a `defmacro` in a module named `Ecto.Query`, so the test adds a stub) and `leex/reference/resolver/Assign.kt` (the resolver searches libraries only, so the Phoenix stub is registered as a library). The two sites the plan predicted no fixture could reach, `Callable.isVariable` and `Parameter.putParameterized`, rely on the existing issue regression tests.

Full suite result to follow in a comment when the background run finishes; each package's classes and their neighbours were green per commit.
