### PR TITLE
refactor(beam): model the decompiled symbols as a sealed interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 
 ### Bug Fixes
 
+- [#4016](https://github.com/KronicDeth/intellij-elixir/pull/4016) [@sh41](https://github.com/sh41)
+  - **Go To Symbol now finds types defined in a decompiled `.beam` instead of crashing.** Fixes [#4000](https://github.com/KronicDeth/intellij-elixir/issues/4000).
+
 - [#4015](https://github.com/KronicDeth/intellij-elixir/pull/4015) [@sh41](https://github.com/sh41)
   - **Resolving, highlighting, documentation and Go to Symbol no longer report an error for code
     shapes they do not model**, such as an unlisted `@doc` metadata key, a pinned Ecto query option,

--- a/src/org/elixir_lang/DefinitionsScopedSearch.kt
+++ b/src/org/elixir_lang/DefinitionsScopedSearch.kt
@@ -6,8 +6,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.search.searches.DefinitionsScopedSearch
 import com.intellij.util.Processor
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.CallDefinitionClause.enclosingModularMacroCall
 import org.elixir_lang.psi.Protocol
@@ -40,8 +40,8 @@ internal class DefinitionsScopedSearch :
     private fun processQuery(psiElement: PsiElement, consumer: Processor<in PsiElement>) {
         when (psiElement) {
             is Call -> processQuery(psiElement, consumer)
-            is ModuleImpl<*> -> processQuery(psiElement, consumer)
-            is CallDefinitionImpl<*> -> processQuery(psiElement, consumer)
+            is BeamModule -> processQuery(psiElement, consumer)
+            is BeamCallDefinition -> processQuery(psiElement, consumer)
         }
     }
 
@@ -96,7 +96,7 @@ internal class DefinitionsScopedSearch :
                                     }
                                 }
 
-                                is ModuleImpl<*> -> {
+                                is BeamModule -> {
                                     for (callDefinition in defimpl.callDefinitions()) {
                                         ProgressManager.checkCanceled()
 
@@ -125,13 +125,13 @@ internal class DefinitionsScopedSearch :
         }
     }
 
-    private fun processQuery(moduleImpl: ModuleImpl<*>, consumer: Processor<in PsiElement>) {
+    private fun processQuery(moduleImpl: BeamModule, consumer: Processor<in PsiElement>) {
         if (Protocol.`is`(moduleImpl)) {
             Protocol.processImplementations(moduleImpl, consumer)
         }
     }
 
-    private fun processQuery(callDefinitionImpl: CallDefinitionImpl<*>, consumer: Processor<in PsiElement>) {
+    private fun processQuery(callDefinitionImpl: BeamCallDefinition, consumer: Processor<in PsiElement>) {
         val moduleImpl = callDefinitionImpl.parent
 
         if (Protocol.`is`(moduleImpl)) {
@@ -166,7 +166,7 @@ internal class DefinitionsScopedSearch :
                             }
                         }
                     }
-                    is ModuleImpl<*> ->
+                    is BeamModule ->
                         for (callDefinition in defimpl.callDefinitions()) {
                             ProgressManager.checkCanceled()
 

--- a/src/org/elixir_lang/annotator/Callable.kt
+++ b/src/org/elixir_lang/annotator/Callable.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
 import org.elixir_lang.model.psi.variable.VariableSymbol
 import org.elixir_lang.ElixirSyntaxHighlighter
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.psi.AtOperation
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 import org.elixir_lang.psi.CallDefinitionClause
@@ -206,7 +206,7 @@ internal class Callable : Annotator, DumbAware {
     private fun callHighlight(resolved: PsiElement, previousCallHighlight: CallHighlight?): CallHighlight? =
         when (resolved) {
             is Call -> callHighlight(resolved, previousCallHighlight)
-            is CallDefinitionImpl<*> -> callHighlight(resolved, previousCallHighlight)
+            is BeamCallDefinition -> callHighlight(resolved, previousCallHighlight)
             else ->
                 when (VariableSymbol.classify(resolved)) {
                     VariableSymbol.Kind.IGNORED ->
@@ -228,7 +228,7 @@ internal class Callable : Annotator, DumbAware {
                 }
         }
 
-    private fun callHighlight(resolved: CallDefinitionImpl<*>, previousCallHighlight: CallHighlight?): CallHighlight {
+    private fun callHighlight(resolved: BeamCallDefinition, previousCallHighlight: CallHighlight?): CallHighlight {
         val referrerTextAttributesKeys = when (resolved.time) {
             Timed.Time.COMPILE -> referrerTextAttributesKeys(
                 resolved,
@@ -393,7 +393,7 @@ internal class Callable : Annotator, DumbAware {
             predefinedTextAttributesKeys: Array<TextAttributesKey>
         ): Array<TextAttributesKey> =
             when (psiElement) {
-                is CallDefinitionImpl<*> -> if (psiElement.parent.name in PREDEFINED_LOCATION_STRING_SET) {
+                is BeamCallDefinition -> if (psiElement.parent.name in PREDEFINED_LOCATION_STRING_SET) {
                     predefinedTextAttributesKeys
                 } else {
                     null

--- a/src/org/elixir_lang/beam/psi/BeamSymbol.kt
+++ b/src/org/elixir_lang/beam/psi/BeamSymbol.kt
@@ -1,0 +1,16 @@
+package org.elixir_lang.beam.psi
+
+import com.intellij.psi.NavigatablePsiElement
+import com.intellij.psi.PsiCompiledElement
+import org.elixir_lang.psi.NamedElement
+import org.elixir_lang.psi.call.CanonicallyNamed
+
+/**
+ * A named element of a decompiled `.beam`: the module itself, or one of its call or type definitions.
+ * These are exactly the elements whose stub types write into `AllName.KEY`, so a `when` over this is a
+ * complete account of what the symbol index can hand back from a decompiled file.
+ *
+ * Sealed, so adding a fourth fails the build at every dispatch site. [BeamFileImpl] is not a member
+ * because a file is not a symbol.
+ */
+sealed interface BeamSymbol : CanonicallyNamed, NamedElement, NavigatablePsiElement, PsiCompiledElement

--- a/src/org/elixir_lang/beam/psi/CallDefinition.kt
+++ b/src/org/elixir_lang/beam/psi/CallDefinition.kt
@@ -1,13 +1,13 @@
 package org.elixir_lang.beam.psi
 
-import com.intellij.psi.PsiCompiledElement
 import org.elixir_lang.NameArityInterval
-import org.elixir_lang.psi.NamedElement
-import org.elixir_lang.psi.call.CanonicallyNamed
 import org.elixir_lang.psi.call.MaybeExported
 import org.elixir_lang.structure_view.element.Timed.Time
 
-interface CallDefinition : CanonicallyNamed, MaybeExported, NamedElement, PsiCompiledElement {
+interface CallDefinition : BeamSymbol, MaybeExported {
+    /** The decompiled module this definition belongs to. */
+    override fun getParent(): Module
+
     val time: Time
     val nameArityInterval: NameArityInterval
 }

--- a/src/org/elixir_lang/beam/psi/Module.java
+++ b/src/org/elixir_lang/beam/psi/Module.java
@@ -1,8 +1,0 @@
-package org.elixir_lang.beam.psi;
-
-import com.intellij.psi.PsiCompiledElement;
-import org.elixir_lang.psi.NamedElement;
-import org.elixir_lang.psi.call.CanonicallyNamed;
-
-public interface Module extends CanonicallyNamed, NamedElement, PsiCompiledElement {
-}

--- a/src/org/elixir_lang/beam/psi/Module.kt
+++ b/src/org/elixir_lang/beam/psi/Module.kt
@@ -1,0 +1,9 @@
+package org.elixir_lang.beam.psi
+
+interface Module : BeamSymbol {
+    /** Never null: the stub always carries one, which is what makes this indexable by name. */
+    override fun getName(): String
+
+    fun callDefinitions(): Array<out CallDefinition>
+    fun typeDefinitions(): Array<out TypeDefinition>
+}

--- a/src/org/elixir_lang/beam/psi/TypeDefinition.kt
+++ b/src/org/elixir_lang/beam/psi/TypeDefinition.kt
@@ -1,12 +1,15 @@
 package org.elixir_lang.beam.psi
 
-import com.intellij.psi.PsiCompiledElement
 import org.elixir_lang.Arity
-import org.elixir_lang.psi.NamedElement
-import org.elixir_lang.psi.call.CanonicallyNamed
 import org.elixir_lang.type.Visibility
 
-interface TypeDefinition : CanonicallyNamed, NamedElement, PsiCompiledElement {
+interface TypeDefinition : BeamSymbol {
+    /** Never null: the stub always carries one, which is what makes this indexable by name. */
+    override fun getName(): String
+
+    /** The decompiled module this definition belongs to. */
+    override fun getParent(): Module
+
     val visibility: Visibility
     val arity: Arity
 }

--- a/src/org/elixir_lang/beam/psi/impl/ModuleImpl.kt
+++ b/src/org/elixir_lang/beam/psi/impl/ModuleImpl.kt
@@ -119,10 +119,10 @@ class ModuleImpl<T : ModuleStub<*>?>(private val stub: T) : ModuleElementImpl(),
         return element.psi.let { it as? Call }?.getModuleName() ?: "<unknown module>"
     }
 
-    fun callDefinitions(): Array<CallDefinitionImpl<*>> =
+    override fun callDefinitions(): Array<CallDefinitionImpl<*>> =
         stub!!.getChildrenByType(ModuleStubElementTypes.CALL_DEFINITION, emptyArray())
 
-    fun typeDefinitions(): Array<TypeDefinitionImpl<*>> =
+    override fun typeDefinitions(): Array<TypeDefinitionImpl<*>> =
         stub!!.getChildrenByType(ModuleStubElementTypes.TYPE_DEFINITION, emptyArray())
 
     /**

--- a/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
+++ b/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
@@ -3,7 +3,7 @@ package org.elixir_lang.code_insight.completion
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.PsiElement
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.code_insight.preferFunctionHeads
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.macroChildCalls
@@ -17,7 +17,7 @@ import org.elixir_lang.psi.CallDefinitionClause as CallDefinitionClausePsi
  * (exported) functions are offered because a remote / MFA dispatch (`Mod.fun(...)`,
  * `apply(Mod, :fun, args)`, `{Mod, :fun, arity}`) can never reach a private function - a private
  * function is callable only through a local unqualified call inside its own module. Handles both
- * source modules ([Call]) and BEAM-decompiled modules ([ModuleImpl]); any other element type yields
+ * source modules ([Call]) and BEAM-decompiled modules ([BeamModule]); any other element type yields
  * nothing.
  *
  * @param appendParentheses when `true` (qualified `Mod.<caret>` call completion) the inserted name is
@@ -33,14 +33,14 @@ fun callDefinitionClauseLookupElements(
     appendParentheses: Boolean = true
 ): Iterable<LookupElement> = when (scope) {
     is Call -> callDefinitionClauseLookupElements(scope, appendParentheses)
-    is ModuleImpl<*> -> callDefinitionClauseLookupElements(scope, appendParentheses)
+    is BeamModule -> callDefinitionClauseLookupElements(scope, appendParentheses)
     else -> emptyList()
 }
 
 /**
  * The remote-completion [LookupElement]s offered by the set of [modulars] a modular name resolved to
  * (via [org.elixir_lang.psi.impl.maybeModularNameToModulars]). Source modules ([Call]) are preferred
- * over BEAM-decompiled stubs ([ModuleImpl]) so a module available in both forms is not offered twice.
+ * over BEAM-decompiled stubs ([BeamModule]) so a module available in both forms is not offered twice.
  *
  * @see callDefinitionClauseLookupElements for the per-modular contract and [appendParentheses].
  */
@@ -65,11 +65,12 @@ private fun callDefinitionClauseLookupElements(scope: Call, appendParentheses: B
     }
 }
 
-private fun callDefinitionClauseLookupElements(moduleImpl: ModuleImpl<*>, appendParentheses: Boolean): Iterable<LookupElement> =
+private fun callDefinitionClauseLookupElements(moduleImpl: BeamModule, appendParentheses: Boolean): Iterable<LookupElement> =
     moduleImpl.callDefinitions()
         .filter { it.isExported }
-        .map { callDefinition ->
-            lookupElement(callDefinition.exportedName(), callDefinition, appendParentheses)
+        .mapNotNull { callDefinition ->
+            // MaybeExported documents exportedName() as null only when isExported() is false.
+            callDefinition.exportedName()?.let { lookupElement(it, callDefinition, appendParentheses) }
         }
 
 private fun lookupElement(name: String, element: PsiElement, appendParentheses: Boolean): LookupElement =

--- a/src/org/elixir_lang/code_insight/line_marker_provider/Implementation.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/Implementation.kt
@@ -14,7 +14,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.SmartPsiElementPointer
 import org.elixir_lang.Icons
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.CallDefinitionClause.enclosingModularMacroCall
 import org.elixir_lang.psi.Implementation
@@ -87,7 +87,7 @@ class Implementation : LineMarkerProvider {
                                             }
                                         }
 
-                                    is ModuleImpl<*> ->
+                                    is BeamModule ->
                                         for (callDefinition in defprotocol.callDefinitions()) {
                                             val protocolNameArityInterval = callDefinition.nameArityInterval
 

--- a/src/org/elixir_lang/code_insight/line_marker_provider/Protocol.kt
+++ b/src/org/elixir_lang/code_insight/line_marker_provider/Protocol.kt
@@ -15,7 +15,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.SmartPsiElementPointer
 import org.elixir_lang.Icons
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.navigation.ElixirImplementationCellRenderer
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.CallDefinitionClause.enclosingModularMacroCall
@@ -89,7 +89,7 @@ internal class Protocol : LineMarkerProvider {
                                             }
                                         }
 
-                                    is ModuleImpl<*> ->
+                                    is BeamModule ->
                                         for (callDefinition in defimpl.callDefinitions()) {
                                             val implNameArityInterval = callDefinition.nameArityInterval
 

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/CallDefinitionClause.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.ui.RowIcon;
 import org.elixir_lang.Icons;
+import org.elixir_lang.beam.psi.CallDefinition;
 import org.elixir_lang.call.Visibility;
 import org.elixir_lang.psi.call.Call;
 import org.jetbrains.annotations.NotNull;
@@ -116,16 +117,13 @@ public class CallDefinitionClause extends com.intellij.codeInsight.lookup.Lookup
     private void renderPsiElement(@NotNull PsiElement psiElement, @NotNull LookupElementPresentation presentation) {
         if (psiElement instanceof Call) {
             renderCall((Call) psiElement, presentation);
-        } else if (psiElement instanceof org.elixir_lang.beam.psi.impl.CallDefinitionImpl) {
-            renderCallDefinitionImpl(
-                    (org.elixir_lang.beam.psi.impl.CallDefinitionImpl<?>) psiElement,
-                    presentation
-            );
+        } else if (psiElement instanceof CallDefinition) {
+            renderBeamCallDefinition((CallDefinition) psiElement, presentation);
         }
     }
 
-    private void renderCallDefinitionImpl(
-            @NotNull org.elixir_lang.beam.psi.impl.CallDefinitionImpl<?> callDefinition,
+    private void renderBeamCallDefinition(
+            @NotNull CallDefinition callDefinition,
             @NotNull LookupElementPresentation presentation) {
         int arity = callDefinition.getNameArityInterval().getArityInterval().getMinimum();
         presentation.appendTailText("/" + arity, true);

--- a/src/org/elixir_lang/documentation/BeamDocsHelper.kt
+++ b/src/org/elixir_lang/documentation/BeamDocsHelper.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import org.elixir_lang.beam.Beam
 import org.elixir_lang.beam.psi.Module
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
 import org.elixir_lang.psi.Definition
 import org.elixir_lang.psi.call.MaybeExported
@@ -93,12 +94,13 @@ object BeamDocsHelper {
     /**
      * Returns the list of BEAM documentation "kind" strings to try when looking up docs for [element].
      *
-     * For [CallDefinitionImpl] elements, the stub's [Definition] tells us whether this is a function or macro.
+     * For [BeamCallDefinition] elements, the stub's [Definition] tells us whether this is a function or macro.
      * The preferred kind is tried first, but we fall back to the other kind in case the BEAM docs
      * use a different categorization than expected (e.g. guards stored as macros).
      */
     private fun kindForElement(element: MaybeExported): List<String> =
         when (element) {
+            // The stub, not the model: Definition is a stub-level detail with no interface counterpart.
             is CallDefinitionImpl<*> -> when (element.stub.definition) {
                 Definition.PUBLIC_MACRO, Definition.PRIVATE_MACRO -> listOf("macro", "function")
                 Definition.PUBLIC_FUNCTION, Definition.PRIVATE_FUNCTION -> listOf("function", "macro")

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -16,7 +16,7 @@ import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.Hidden
 import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.MarkdownByLanguage
 import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.None
 import org.elixir_lang.beam.psi.BeamFileImpl
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.CallDefinitionClause.enclosingModularMacroCall
 import org.elixir_lang.psi.ModuleAttribute.isDocumentationName
@@ -314,7 +314,7 @@ internal class ElixirDocumentationProvider : DocumentationProvider {
                     // Prefer source Call elements (CallDefinitionClause), fall back to BEAM stubs (CallDefinitionImpl)
                     fun bestMatch(elements: List<PsiElement>): PsiElement? =
                         elements.filterIsInstance<Call>().firstOrNull { CallDefinitionClause.`is`(it) }
-                            ?: elements.filterIsInstance<CallDefinitionImpl<*>>().firstOrNull()
+                            ?: elements.filterIsInstance<BeamCallDefinition>().firstOrNull()
 
                     // If no exact arity match (validResult), fall back to results with an exact name match
                     // from the same module (e.g., Enum.map/2 when call site has wrong arity).
@@ -326,7 +326,7 @@ internal class ElixirDocumentationProvider : DocumentationProvider {
                             .mapNotNull(ResolveResult::getElement)
                             .filter { element ->
                                 when (element) {
-                                    is CallDefinitionImpl<*> -> element.exportedName() == callName
+                                    is BeamCallDefinition -> element.exportedName() == callName
                                     is Call -> CallDefinitionClause.nameArityInterval(element, ResolveState.initial())
                                         ?.name == callName
 

--- a/src/org/elixir_lang/goto_decompiled/Provider.kt
+++ b/src/org/elixir_lang/goto_decompiled/Provider.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.ResolveState
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
 import org.elixir_lang.psi.Definition
 import org.elixir_lang.psi.Modular
@@ -119,7 +119,7 @@ class Provider : GotoRelatedProvider() {
                 scope,
                 NamedElement::class.java
         ).mapNotNull { namedElement ->
-            (namedElement as? ModuleImpl<*>)
+            (namedElement as? BeamModule)
                     ?.navigationElement
                     ?.let { it as Call }
         }.toSet()

--- a/src/org/elixir_lang/model/psi/function/CaptureFunctionReferenceProvider.kt
+++ b/src/org/elixir_lang/model/psi/function/CaptureFunctionReferenceProvider.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.model.psi.protocol.ProtocolFunction
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.call.Call
@@ -66,7 +66,7 @@ class CaptureFunctionReference(
                     // A source clause is already a `Call`, while a decompiled beam function exposes the
                     // equivalent clause as its navigation element, so capturing one navigates like calling it.
                     is Call -> element
-                    is CallDefinitionImpl<*> -> element.navigationElement as? Call
+                    is BeamCallDefinition -> element.navigationElement as? Call
                     else -> null
                 }
             }

--- a/src/org/elixir_lang/model/psi/function/FunctionCallReference.kt
+++ b/src/org/elixir_lang/model/psi/function/FunctionCallReference.kt
@@ -5,7 +5,7 @@ import com.intellij.model.psi.PsiSymbolReference
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.model.psi.protocol.ProtocolFunction
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.call.Call
@@ -52,7 +52,7 @@ class FunctionCallReference(
                     // the equivalent clause as its navigation element (the `.beam` mirror), so both flow through the
                     // same `FunctionSymbol.fromClause` pipeline and compare equal by module/name/arity/macro.
                     is Call -> element
-                    is CallDefinitionImpl<*> -> element.navigationElement as? Call
+                    is BeamCallDefinition -> element.navigationElement as? Call
                     else -> null
                 }
             }

--- a/src/org/elixir_lang/model/psi/module/ModuleReference.kt
+++ b/src/org/elixir_lang/model/psi/module/ModuleReference.kt
@@ -41,7 +41,7 @@ class ModuleReference(
                     // A module that exists only as compiled `.beam` resolves to the coarse stub element;
                     // its navigationElement is the `defmodule` Call in the decompiled mirror, which the
                     // source pipeline below accepts (same pattern as TypeReference/FunctionCallReference).
-                    is org.elixir_lang.beam.psi.impl.ModuleImpl<*> -> element.navigationElement as? Call
+                    is org.elixir_lang.beam.psi.Module -> element.navigationElement as? Call
                     else -> null
                 }
             }

--- a/src/org/elixir_lang/model/psi/type/TypeReference.kt
+++ b/src/org/elixir_lang/model/psi/type/TypeReference.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.ResolveResult
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
+import org.elixir_lang.beam.psi.TypeDefinition as BeamTypeDefinition
 import org.elixir_lang.psi.NamedElement
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.qualification.Qualified
@@ -39,7 +39,7 @@ class TypeReference(
          * Resolves [call] to the [TypeSymbol]s of the `@type`/`@typep`/`@opaque` definition(s) it names. Both source
          * definitions and decompiled BEAM definitions (`:queue.queue/0` from the Erlang stdlib, or a built-in like
          * `integer/0` faked onto `:erlang`) are covered: a source definition is already a `@type` [Call], while a
-         * decompiled [TypeDefinitionImpl] exposes the equivalent `@type` [Call] as its
+         * decompiled [BeamTypeDefinition] exposes the equivalent `@type` [Call] as its
          * [navigationElement][com.intellij.psi.PsiElement.getNavigationElement] (the decompiled `.beam` mirror), so
          * both flow through the same [TypeSymbol.fromTypeAttribute] pipeline and compare equal by module/name/arity.
          */
@@ -57,7 +57,7 @@ class TypeReference(
                 .mapNotNull { result ->
                     when (val element = result.element) {
                         is Call -> element
-                        is TypeDefinitionImpl<*> -> element.navigationElement as? Call
+                        is BeamTypeDefinition -> element.navigationElement as? Call
                         else -> null
                     }
                 }
@@ -69,7 +69,7 @@ class TypeReference(
 
         /**
          * Whether [call] resolves to any type definition, used by the unresolvable-type inspection to decide whether
-         * a name is a real type. More lenient than [resolveSymbols]: it counts a decompiled [TypeDefinitionImpl] as a
+         * a name is a real type. More lenient than [resolveSymbols]: it counts a decompiled [BeamTypeDefinition] as a
          * type on its own, without requiring the decompiled `.beam` mirror to expose a usable `@type` [Call], so the
          * inspection never false-flags a genuinely defined BEAM type even if its mirror cannot be rendered.
          */
@@ -82,7 +82,7 @@ class TypeReference(
                 .any { result ->
                     when (val element = result.element) {
                         is Call -> TypeElement.`is`(element)
-                        is TypeDefinitionImpl<*> -> true
+                        is BeamTypeDefinition -> true
                         else -> false
                     }
                 }

--- a/src/org/elixir_lang/navigation/ChooseByNameContributor.kt
+++ b/src/org/elixir_lang/navigation/ChooseByNameContributor.kt
@@ -9,8 +9,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
 import com.intellij.util.ArrayUtil
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.BeamSymbol
 import org.elixir_lang.call.Visibility
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
@@ -72,9 +71,12 @@ open class ChooseByNameContributor(private val stubIndexKey: StubIndexKey<String
                         callDefinitionByTuple,
                         element
                     )
-                is ModuleImpl<*> -> items.add(element)
-                is CallDefinitionImpl<*> -> items.add(element)
-                else -> TODO("Unknown element: ${element.javaClass.name} in ChooseByNameContributor")
+                is BeamSymbol -> items.add(element)
+                // `AllName.KEY` is keyed by the open `NamedElement`, so Kotlin cannot prove this
+                // unreachable, though its only writers are the three `BeamSymbol` stub types and the
+                // source one, whose PSI is always a `Call`. It reports index-versus-contributor drift
+                // without failing the whole result.
+                else -> error("Unknown element: ${element.javaClass.name} in ChooseByNameContributor", element)
             }
         }
 

--- a/src/org/elixir_lang/navigation/SourcePreferredItems.kt
+++ b/src/org/elixir_lang/navigation/SourcePreferredItems.kt
@@ -5,8 +5,10 @@ import com.intellij.navigation.NavigationItem
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import org.elixir_lang.beam.psi.BeamFileImpl
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.BeamSymbol
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
+import org.elixir_lang.beam.psi.TypeDefinition as BeamTypeDefinition
 import org.elixir_lang.structure_view.element.*
 import org.elixir_lang.structure_view.element.modular.Modular
 import org.elixir_lang.structure_view.element.modular.Module
@@ -164,10 +166,11 @@ class SourcePreferredItems {
     fun toTypedArray(): Array<NavigationItem> {
         val navigationItemList =
             modularListByName.values.flatten().map { it as NavigationItem } +
-                    moduleImplListByName.values.flatten() +
+                    beamModuleListByName.values.flatten() +
+                    beamTypeDefinitionListByName.values.flatten() +
                     callDefinitionClauseListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
                     callDefinitionListByArityByNameByModularName.values.flatMap { it.values.flatMap { it.values.flatten() } } +
-                    callDefinitionImplListByArityByNameByModularName.values.flatMap {
+                    beamCallDefinitionListByArityByNameByModularName.values.flatMap {
                         it.values.flatMap { it.values.flatten() }
                     } +
                     callDefinitionSpecificationList +
@@ -184,29 +187,56 @@ class SourcePreferredItems {
             .toTypedArray()
     }
 
-    fun add(element: ModuleImpl<*>) {
-        moduleImplListByName.compute(element.name) { _, currentModuleImplList ->
-            if (currentModuleImplList != null) {
-                currentModuleImplList.add(element)
+    /**
+     * Narrows a decompiled symbol to the overload that owns its bucket. The sealed set makes this
+     * exhaustive, so a fourth [BeamSymbol] fails the build here instead of being silently dropped.
+     */
+    fun add(element: BeamSymbol) = when (element) {
+        is BeamModule -> add(element)
+        is BeamTypeDefinition -> add(element)
+        is BeamCallDefinition -> add(element)
+    }
 
-                currentModuleImplList
+    fun add(element: BeamModule) {
+        beamModuleListByName.compute(element.name) { _, currentBeamModuleList ->
+            if (currentBeamModuleList != null) {
+                currentBeamModuleList.add(element)
+
+                currentBeamModuleList
             } else {
                 mutableListOf(element)
             }
         }
     }
 
-    fun add(element: CallDefinitionImpl<*>) {
+    /**
+     * Keyed by name, not name and arity: a type name can carry several arities - `@type queue` and
+     * `@opaque queue(item)` - and both belong in the results for the name typed. Like the other decompiled
+     * overloads it applies no source preference, leaving that to [toTypedArray]'s `distinctBy`.
+     */
+    fun add(element: BeamTypeDefinition) {
+        beamTypeDefinitionListByName.compute(element.name) { _, currentBeamTypeDefinitionList ->
+            if (currentBeamTypeDefinitionList != null) {
+                currentBeamTypeDefinitionList.add(element)
+
+                currentBeamTypeDefinitionList
+            } else {
+                mutableListOf(element)
+            }
+        }
+    }
+
+    fun add(element: BeamCallDefinition) {
         val modularName = element.parent.name
-        val callDefinitionImplListByArityByName =
-            callDefinitionImplListByArityByNameByModularName.computeIfAbsent(modularName) { mutableMapOf() }
+        val beamCallDefinitionListByArityByName =
+            beamCallDefinitionListByArityByNameByModularName.computeIfAbsent(modularName) { mutableMapOf() }
         val nameArityInterval = element.nameArityInterval
-        val callDefinitionImplListByArity =
-            callDefinitionImplListByArityByName.computeIfAbsent(nameArityInterval.name) { mutableMapOf() }
+        val beamCallDefinitionListByArity =
+            beamCallDefinitionListByArityByName.computeIfAbsent(nameArityInterval.name) { mutableMapOf() }
 
         for (arity in nameArityInterval.arityInterval.closed()) {
-            val callDefinitionImplList = callDefinitionImplListByArity.computeIfAbsent(arity) { mutableListOf() }
-            callDefinitionImplList.add(element)
+            val beamCallDefinitionList = beamCallDefinitionListByArity.computeIfAbsent(arity) { mutableListOf() }
+            beamCallDefinitionList.add(element)
         }
     }
 
@@ -217,11 +247,12 @@ class SourcePreferredItems {
     private val callDefinitionHeadListByArityByNameByModularName =
         mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinitionHead>>>>()
     private val callDefinitionSpecificationList = mutableListOf<CallDefinitionSpecification>()
-    private val callDefinitionImplListByArityByNameByModularName =
-        mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<CallDefinitionImpl<*>>>>>()
+    private val beamCallDefinitionListByArityByNameByModularName =
+        mutableMapOf<ModularName, MutableMap<Name, MutableMap<Arity, MutableList<BeamCallDefinition>>>>()
     private val callbackList = mutableListOf<Callback>()
     private val modularListByName = mutableMapOf<Name, MutableList<Modular>>()
-    private val moduleImplListByName = mutableMapOf<Name, MutableList<ModuleImpl<*>>>()
+    private val beamModuleListByName = mutableMapOf<Name, MutableList<BeamModule>>()
+    private val beamTypeDefinitionListByName = mutableMapOf<Name, MutableList<BeamTypeDefinition>>()
 }
 
 private fun Any.isDecompiled(): Boolean =

--- a/src/org/elixir_lang/psi/ElementDescriptionProvider.kt
+++ b/src/org/elixir_lang/psi/ElementDescriptionProvider.kt
@@ -7,9 +7,9 @@ import com.intellij.usageView.UsageViewNodeTextLocation
 import com.intellij.usageView.UsageViewShortNameLocation
 import com.intellij.usageView.UsageViewTypeLocation
 import org.elixir_lang.annotator.Parameter
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
-import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
+import org.elixir_lang.beam.psi.TypeDefinition as BeamTypeDefinition
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.ALIAS
 import org.elixir_lang.psi.call.name.Module.KERNEL
@@ -34,9 +34,9 @@ internal class ElementDescriptionProvider : com.intellij.psi.ElementDescriptionP
             is ElixirKeywordKey -> getElementDescription(element, location)
             is ElixirVariable -> getElementDescription(element, location)
             is MaybeModuleName -> getElementDescription(element, location)
-            is ModuleImpl<*> -> getElementDescription(element, location)
-            is TypeDefinitionImpl<*> -> getElementDescription(element, location)
-            is CallDefinitionImpl<*> -> getElementDescription(element, location)
+            is BeamModule -> getElementDescription(element, location)
+            is BeamTypeDefinition -> getElementDescription(element, location)
+            is BeamCallDefinition -> getElementDescription(element, location)
             else -> null
         }
 
@@ -138,7 +138,7 @@ internal class ElementDescriptionProvider : com.intellij.psi.ElementDescriptionP
         return elementDescription
     }
 
-    private fun getElementDescription(moduleImpl: ModuleImpl<*>, location: ElementDescriptionLocation): String? =
+    private fun getElementDescription(moduleImpl: BeamModule, location: ElementDescriptionLocation): String? =
         when (location) {
             UsageViewNodeTextLocation.INSTANCE -> "defmodule ${moduleImpl.name}"
             UsageViewLongNameLocation.INSTANCE, UsageViewShortNameLocation.INSTANCE -> moduleImpl.name
@@ -147,7 +147,7 @@ internal class ElementDescriptionProvider : com.intellij.psi.ElementDescriptionP
         }
 
     private fun getElementDescription(
-        typeDefinitionImpl: TypeDefinitionImpl<*>,
+        typeDefinitionImpl: BeamTypeDefinition,
         location: ElementDescriptionLocation
     ): String? =
         when (location) {
@@ -164,7 +164,7 @@ internal class ElementDescriptionProvider : com.intellij.psi.ElementDescriptionP
         }
 
     private fun getElementDescription(
-        callDefinitionImpl: CallDefinitionImpl<*>,
+        callDefinitionImpl: BeamCallDefinition,
         location: ElementDescriptionLocation
     ): String? =
         when (location) {

--- a/src/org/elixir_lang/psi/Import.kt
+++ b/src/org/elixir_lang/psi/Import.kt
@@ -11,8 +11,8 @@ import com.intellij.util.Function
 import org.elixir_lang.Arity
 import org.elixir_lang.Name
 import org.elixir_lang.NameArityInterval
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.model.psi.FunctionArityKeywordPair
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.IMPORT
@@ -77,7 +77,7 @@ object Import {
     ): Boolean =
         when (importedModular) {
             is Call -> treeWalkUpImportedModular(importedModular, filter, resolveState, keepProcessing)
-            is ModuleImpl<*> -> treeWalkUpImportedModular(importedModular, filter, resolveState, keepProcessing)
+            is BeamModule -> treeWalkUpImportedModular(importedModular, filter, resolveState, keepProcessing)
             else -> true
         }
 
@@ -97,7 +97,7 @@ object Import {
             ?: true
 
     private fun treeWalkUpImportedModular(
-        importedModular: ModuleImpl<*>,
+        importedModular: BeamModule,
         filter: (NameArityInterval) -> Boolean,
         resolveState: ResolveState,
         keepProcessing: (PsiElement, ResolveState) -> Boolean
@@ -144,7 +144,7 @@ object Import {
 
     private fun treeWalkUpImportedModularChildExpression(
         filter: (NameArityInterval) -> Boolean,
-        importedCall: CallDefinitionImpl<*>,
+        importedCall: BeamCallDefinition,
         resolveState: ResolveState,
         keepProcessing: (PsiElement, ResolveState) -> Boolean
     ): Boolean {

--- a/src/org/elixir_lang/psi/Modular.kt
+++ b/src/org/elixir_lang/psi/Modular.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.Name
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.macroChildCallSequence
 import org.elixir_lang.psi.impl.call.macroChildCalls
@@ -25,7 +25,7 @@ object Modular {
     ): Boolean =
         when (modular) {
             is Call -> callDefinitionClauseCallWhile(modular, resolveState, function)
-            is ModuleImpl<*> -> callDefinitionClauseCallWhile(modular, resolveState, function)
+            is BeamModule -> callDefinitionClauseCallWhile(modular, resolveState, function)
             else -> true
         }
 
@@ -87,7 +87,7 @@ object Modular {
     ): AccumulatorContinue<R> =
         when (modular) {
             is Call -> callDefinitionClauseCallFoldWhile(modular, functionName, initial, foldWhile)
-            is ModuleImpl<*> -> callDefinitionClauseCallFoldWhile(modular, functionName, initial, foldWhile)
+            is BeamModule -> callDefinitionClauseCallFoldWhile(modular, functionName, initial, foldWhile)
             else -> AccumulatorContinue(initial, true)
         }
 
@@ -112,7 +112,7 @@ object Modular {
         }
 
     inline fun <R> callDefinitionClauseCallFoldWhile(
-        modular: ModuleImpl<*>,
+        modular: BeamModule,
         functionName: Name,
         initial: R,
         foldWhile: (PsiElement, Name, ArityInterval, R) -> AccumulatorContinue<R>

--- a/src/org/elixir_lang/psi/Protocol.kt
+++ b/src/org/elixir_lang/psi/Protocol.kt
@@ -8,8 +8,8 @@ import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.Processor
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.beam.psi.stubs.ModuleStub
 import org.elixir_lang.beam.psi.stubs.ModuleStubElementTypes
 import org.elixir_lang.psi.call.Call
@@ -23,14 +23,14 @@ object Protocol {
     fun `is`(call: Call): Boolean =
         call.isCallingMacro(org.elixir_lang.psi.call.name.Module.KERNEL, Function.DEFPROTOCOL, 2)
 
-    fun `is`(moduleImpl: ModuleImpl<*>): Boolean =
+    fun `is`(moduleImpl: BeamModule): Boolean =
         moduleImpl.callDefinitions().any { callDefinitionImpl ->
             callDefinitionImpl.name == "__protocol__" && callDefinitionImpl.exportedArity(ResolveState.initial()) == 1
         }
 
     fun `is`(moduleStub: ModuleStub<*>): Boolean =
         moduleStub
-            .getChildrenByType(ModuleStubElementTypes.CALL_DEFINITION, emptyArray<CallDefinitionImpl<*>>())
+            .getChildrenByType(ModuleStubElementTypes.CALL_DEFINITION, emptyArray<BeamCallDefinition>())
             .any { callDefinition ->
                 callDefinition.name == "__protocol__" && callDefinition.exportedArity(ResolveState.initial()) == 1
             }
@@ -70,7 +70,7 @@ object Protocol {
         processImplementations(defprotocol.project, Module.name(defprotocol), consumer)
     }
 
-    fun processImplementations(defprotocol: ModuleImpl<*>, consumer: Processor<in PsiElement>) {
+    fun processImplementations(defprotocol: BeamModule, consumer: Processor<in PsiElement>) {
         processImplementations(defprotocol.project, defprotocol.name, consumer)
     }
 

--- a/src/org/elixir_lang/psi/Using.kt
+++ b/src/org/elixir_lang/psi/Using.kt
@@ -6,8 +6,8 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.name.Function.*
@@ -32,7 +32,7 @@ object Using {
     ): Boolean =
         when (using) {
             is Call -> treeWalkUp(using, use, resolveState, keepProcessing)
-            is CallDefinitionImpl<*> -> TODO()
+            is BeamCallDefinition -> TODO()
             else -> true
         }
 
@@ -233,7 +233,7 @@ object Using {
     fun definers(modular: PsiElement): Sequence<PsiElement> =
         when (modular) {
             is Call -> definers(modular)
-            is ModuleImpl<*> -> definers(modular)
+            is BeamModule -> definers(modular)
             else -> emptySequence()
         }
 
@@ -243,7 +243,7 @@ object Using {
             .macroChildCallSequence()
             .filter { isDefiner(it) }
 
-    fun definers(moduleImpl: ModuleImpl<*>): Sequence<CallDefinitionImpl<*>> =
+    fun definers(moduleImpl: BeamModule): Sequence<BeamCallDefinition> =
         moduleImpl
             .callDefinitions()
             .asSequence()
@@ -265,7 +265,7 @@ object Using {
     fun isCaseTemplate(modular: PsiElement, resolveState: ResolveState): Boolean {
         if (resolveState.hasBeenVisited(modular)) return false
         return when (modular) {
-            is ModuleImpl<*> -> modular.name == EXUNIT_CASE_TEMPLATE
+            is BeamModule -> modular.name == EXUNIT_CASE_TEMPLATE
             is Call -> {
                 val updatedState = resolveState.putVisitedElement(modular)
                 modular.name == EXUNIT_CASE_TEMPLATE ||
@@ -314,7 +314,7 @@ object Using {
                 }
                 ?: false
 
-    private fun isDefiner(callDefinitionImpl: CallDefinitionImpl<*>): Boolean =
+    private fun isDefiner(callDefinitionImpl: BeamCallDefinition): Boolean =
         callDefinitionImpl.time == Timed.Time.COMPILE &&
                 callDefinitionImpl.name == USING &&
                 callDefinitionImpl.exportedArity(ResolveState.initial()) == ARITY

--- a/src/org/elixir_lang/psi/Using.kt
+++ b/src/org/elixir_lang/psi/Using.kt
@@ -32,6 +32,9 @@ object Using {
     ): Boolean =
         when (using) {
             is Call -> treeWalkUp(using, use, resolveState, keepProcessing)
+            /* Unreachable while `isDefiner` compares a decompiled definition's always-null `name`, which leaves
+               `definers` empty for a beam module. Giving `CallDefinitionImpl` a `getName()` arms this, so the two
+               have to change together. */
             is BeamCallDefinition -> TODO()
             else -> true
         }

--- a/src/org/elixir_lang/psi/__module__/PsiScopeProcessor.kt
+++ b/src/org/elixir_lang/psi/__module__/PsiScopeProcessor.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.ResolveState
 import com.intellij.psi.scope.PsiScopeProcessor
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.CallDefinitionClause.enclosingModularMacroCall
 import org.elixir_lang.psi.call.Call
@@ -45,9 +45,9 @@ class PsiScopeProcessor(val call: Call, val useCall: Call?) : PsiScopeProcessor 
                                 GlobalSearchScope.allScope(project),
                                 NamedElement::class.java
                             ) { namedElement ->
-                                if (namedElement is CallDefinitionImpl<*>) {
+                                if (namedElement is BeamCallDefinition) {
                                     namedElement.parent.let { module ->
-                                        if (module.name == "Kernel.SpecialForms" && namedElement.stub.callDefinitionClauseHeadArity() == 0) {
+                                        if (module.name == "Kernel.SpecialForms" && namedElement.exportedArity(state) == 0) {
                                             resolveResultList.add(PsiElementResolveResult(namedElement))
                                         }
                                     }

--- a/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
+++ b/src/org/elixir_lang/psi/impl/QualifiableAliasImpl.kt
@@ -125,7 +125,7 @@ private fun PsiReference.toModulars(): Set<PsiNamedElement> =
 private fun PsiReference.toModulars(resolved: PsiElement): Set<PsiNamedElement> =
     if (resolved is Call && isModular(resolved)) {
         (resolved as? PsiNamedElement)?.let { setOf(it) } ?: emptySet()
-    } else if (resolved is org.elixir_lang.beam.psi.impl.ModuleImpl<*>) {
+    } else if (resolved is org.elixir_lang.beam.psi.Module) {
         setOf(resolved)
     } else if (resolved.isEquivalentTo(element)) {
         // resolved to self, but not a modular, so stop looking

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
@@ -9,8 +9,8 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.isAncestor
 import org.elixir_lang.EEx
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.ecto.query.WindowAPI
 import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.*
@@ -44,8 +44,8 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
     override fun execute(element: PsiElement, state: ResolveState): Boolean =
         when (element) {
             is Call -> execute(element, state)
-            is ModuleImpl<*> -> execute(element, state)
-            is CallDefinitionImpl<*> -> execute(element, state)
+            is BeamModule -> execute(element, state)
+            is BeamCallDefinition -> execute(element, state)
             is ElixirFile -> execute(element, state)
             else -> true
         }
@@ -217,12 +217,12 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
             true
         }
 
-    private fun execute(element: ModuleImpl<*>, state: ResolveState): Boolean =
+    private fun execute(element: BeamModule, state: ResolveState): Boolean =
         whileIn(element.callDefinitions()) {
             execute(it, state)
         }
 
-    protected abstract fun execute(element: CallDefinitionImpl<*>, state: ResolveState): Boolean
+    protected abstract fun execute(element: BeamCallDefinition, state: ResolveState): Boolean
 
     private fun executeOnUnknownMacroCall(macroCall: Call, state: ResolveState): Boolean =
         if (macroCall.isAncestor(state.get(ENTRANCE), strict = true)) {
@@ -315,7 +315,7 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
                             )
                         }
                     }
-                    is ModuleImpl<*> -> whileIn(namedElement.callDefinitions()) {
+                    is BeamModule -> whileIn(namedElement.callDefinitions()) {
                         execute(it, state)
                     }
                     else -> true
@@ -325,11 +325,11 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
 
     /**
      * Returns the [NamedElement]s for [moduleName] within [scope] to walk, preferring source [Call]s
-     * over decompiled [ModuleImpl] beam stubs: when the module is available as source, the beam stubs
+     * over decompiled [BeamModule] beam stubs: when the module is available as source, the beam stubs
      * are dropped entirely so a module present in both forms is not visited twice.
      *
      * Dropping the beam stubs matters for Variants-style completion, where [keepProcessing] is always
-     * `true`, so a source [Call] and its [ModuleImpl] beam counterpart would otherwise both be visited
+     * `true`, so a source [Call] and its [BeamModule] beam counterpart would otherwise both be visited
      * and offer every definition twice (e.g. each `Kernel.SpecialForms` macro). For resolution, where
      * [keepProcessing] stops after the first result, the surviving source [Call]s are still ordered
      * first so the walk short-circuits on source before any beam stub (which are now only present when

--- a/src/org/elixir_lang/psi/scope/Type.kt
+++ b/src/org/elixir_lang/psi/scope/Type.kt
@@ -7,9 +7,9 @@ import com.intellij.psi.scope.PsiScopeProcessor
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.util.isAncestor
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
-import org.elixir_lang.beam.psi.impl.ModuleImpl
-import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
+import org.elixir_lang.beam.psi.Module as BeamModule
+import org.elixir_lang.beam.psi.TypeDefinition as BeamTypeDefinition
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.Module
 import org.elixir_lang.psi.ModuleAttribute.isTypeSpecName
@@ -44,9 +44,9 @@ abstract class Type : PsiScopeProcessor {
             is ElixirStructOperation, is ElixirTuple, is QualifiableAlias, is WholeNumber
             -> false
 
-            is ModuleImpl<*> -> execute(element, state)
-            is TypeDefinitionImpl<*> -> execute(element, state)
-            is CallDefinitionImpl<*> -> true
+            is BeamModule -> execute(element, state)
+            is BeamTypeDefinition -> execute(element, state)
+            is BeamCallDefinition -> true
             // Anything else declares no type; keep walking.
             else -> true
         }
@@ -86,7 +86,7 @@ abstract class Type : PsiScopeProcessor {
             }
         }
 
-    private fun execute(moduleImpl: ModuleImpl<*>, state: ResolveState): Boolean =
+    private fun execute(moduleImpl: BeamModule, state: ResolveState): Boolean =
         if (moduleImpl.isAncestor(state.get(ENTRANCE), false)) {
             whileIn(moduleImpl.typeDefinitions()) {
                 execute(it, state)
@@ -95,7 +95,7 @@ abstract class Type : PsiScopeProcessor {
             true
         }
 
-    protected abstract fun execute(typeDefinitionImpl: TypeDefinitionImpl<*>, state: ResolveState): Boolean
+    protected abstract fun execute(typeDefinition: BeamTypeDefinition, state: ResolveState): Boolean
 
     private fun execute(
         atUnqualifiedNoParenthesesCall: AtUnqualifiedNoParenthesesCall<*>,
@@ -132,8 +132,8 @@ abstract class Type : PsiScopeProcessor {
                 GlobalSearchScope.allScope(project),
                 NamedElement::class.java
             ) { modular ->
-                // use `ModuleImpl` to only use decompiled
-                if (modular is ModuleImpl<*>) {
+                // use `BeamModule` to only use decompiled
+                if (modular is BeamModule) {
                     // reset the resolve state as only `defmodule` that is an ancestor of entrance will be walked
                     execute(
                         modular,

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/MultiResolve.kt
@@ -4,7 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.NameArityInterval
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.CallDefinitionClause.nameArityInterval
 import org.elixir_lang.psi.call.Call
@@ -40,7 +40,7 @@ private constructor(
                     ?.let { addIfNameOrArityToResolveResults(element, it, state) }
                     ?: true
 
-    override fun execute(element: CallDefinitionImpl<*>, state: ResolveState): Boolean =
+    override fun execute(element: BeamCallDefinition, state: ResolveState): Boolean =
         addIfNameOrArityToResolveResults(element, element.nameArityInterval, state)
 
     override fun executeOnCallback(element: AtUnqualifiedNoParenthesesCall<*>, state: ResolveState): Boolean =
@@ -85,7 +85,7 @@ private constructor(
                                             modularResultResult.isValidResult,
                                             state
                                         )
-                                        is CallDefinitionImpl<*> -> addToResolveResults(
+                                        is BeamCallDefinition -> addToResolveResults(
                                             modularResultResultElement,
                                             nameInDefiningModule,
                                             modularResultResult.isValidResult,
@@ -170,13 +170,13 @@ private constructor(
         return addIfNameOrArityToResolveResults(call, name, validArity, state)
     }
 
-    private fun addIfNameOrArityToResolveResults(callDefinitionImpl: CallDefinitionImpl<*>,
+    private fun addIfNameOrArityToResolveResults(callDefinition: BeamCallDefinition,
                                                  nameArityInterval: NameArityInterval,
                                                  state: ResolveState): Boolean {
         val name = nameArityInterval.name
         val validArity = resolvedPrimaryArity in nameArityInterval.arityInterval
 
-        return addIfNameOrArityToResolveResults(callDefinitionImpl, name, validArity, state)
+        return addIfNameOrArityToResolveResults(callDefinition, name, validArity, state)
     }
 
     private fun addIfNameOrArityToResolveResults(call: Call, name: String, validArity: Boolean, state: ResolveState): Boolean =
@@ -189,7 +189,7 @@ private constructor(
                 true
             }
 
-    private fun addIfNameOrArityToResolveResults(callDefinitionImpl: CallDefinitionImpl<*>,
+    private fun addIfNameOrArityToResolveResults(callDefinition: BeamCallDefinition,
                                                  name: String,
                                                  validArity: Boolean,
                                                  state: ResolveState) : Boolean =
@@ -197,7 +197,7 @@ private constructor(
             (this.name != null && name.startsWith(this.name))) {
             val validResult = validArity && name == this.name
 
-            addToResolveResults(callDefinitionImpl, name, validResult, state)
+            addToResolveResults(callDefinition, name, validResult, state)
         } else {
             true
         }
@@ -218,11 +218,11 @@ private constructor(
                 keepProcessing()
             } ?: true
 
-    private fun addToResolveResults(callDefinitionImpl: CallDefinitionImpl<*>,
+    private fun addToResolveResults(callDefinition: BeamCallDefinition,
                                     name: String,
                                     validResult: Boolean,
                                     state: ResolveState): Boolean {
-        resolveResultOrderedSet.add(callDefinitionImpl, name, validResult, state.visitedElementSet())
+        resolveResultOrderedSet.add(callDefinition, name, validResult, state.visitedElementSet())
 
         return keepProcessing()
     }

--- a/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
+++ b/src/org/elixir_lang/psi/scope/call_definition_clause/Variants.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.annotator.Parameter
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.Named
@@ -40,7 +40,7 @@ class Variants : CallDefinitionClause() {
         return true
     }
 
-    override fun execute(element: CallDefinitionImpl<*>, state: ResolveState): Boolean {
+    override fun execute(element: BeamCallDefinition, state: ResolveState): Boolean {
         // BEAM-decompiled call definitions are never the entrance clause (which is always source),
         // so the entrance guard from executeOnCallDefinitionClause does not apply here.
         if (element.isExported()) {
@@ -50,8 +50,10 @@ class Variants : CallDefinitionClause() {
         return true
     }
 
-    private fun addCallDefinitionToLookupElementByPsiElement(element: CallDefinitionImpl<*>) {
-        val name = element.exportedName()
+    private fun addCallDefinitionToLookupElementByPsiElement(element: BeamCallDefinition) {
+        // MaybeExported documents exportedName() as null only when isExported() is false, which the
+        // sole caller checks.
+        val name = element.exportedName() ?: return
 
         lookupElementByPsiElementName.computeIfAbsent(element to name) { (el, n) ->
             LookupElementBuilder.createWithSmartPointer(n, el)

--- a/src/org/elixir_lang/psi/scope/type/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/type/MultiResolve.kt
@@ -4,8 +4,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
-import org.elixir_lang.beam.psi.impl.ModuleImpl
-import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
+import org.elixir_lang.beam.psi.Module as BeamModule
+import org.elixir_lang.beam.psi.TypeDefinition as BeamTypeDefinition
 import org.elixir_lang.psi.*
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.call.qualification.Qualified
@@ -60,14 +60,14 @@ private constructor(private val name: String,
                 }
             } ?: true
 
-    override fun execute(typeDefinitionImpl: TypeDefinitionImpl<*>, state: ResolveState): Boolean {
-        val name = typeDefinitionImpl.name
+    override fun execute(typeDefinition: BeamTypeDefinition, state: ResolveState): Boolean {
+        val name = typeDefinition.name
 
         return if (name.startsWith(this.name)) {
-            val arity = typeDefinitionImpl.arity
+            val arity = typeDefinition.arity
             val validResult = name == this.name && arity == this.arity
 
-            resolveResultOrderedSet.add(typeDefinitionImpl, "$name/$arity", validResult, state.visitedElementSet())
+            resolveResultOrderedSet.add(typeDefinition, "$name/$arity", validResult, state.visitedElementSet())
 
             keepProcessing()
         } else {
@@ -199,7 +199,7 @@ private constructor(private val name: String,
             val maxScope = entrance.containingFile
             val entranceResolveState = resolveState.put(ElixirPsiImplUtil.ENTRANCE, entrance).putInitialVisitedElement(entrance)
 
-            if (entrance is ModuleImpl<*>) {
+            if (entrance is BeamModule) {
                 multiResolve.execute(entrance, entranceResolveState)
             } else {
                 PsiTreeUtil.treeWalkUp(multiResolve, entrance, maxScope, entranceResolveState)

--- a/src/org/elixir_lang/psi/stub/index/AllName.java
+++ b/src/org/elixir_lang/psi/stub/index/AllName.java
@@ -16,7 +16,7 @@ public class AllName extends StringStubIndexExtension<NamedElement> {
     // 9 - `Definition.MODULE_ATTRIBUTE` added
     // 10 - `Definition.VARIABLE` added
     // 11 - `TypeDefinitionImpl` added
-    public static final int VERSION = 10;
+    public static final int VERSION = 11;
 
     @Override
     public int getVersion() {

--- a/src/org/elixir_lang/reference/CaptureNameArity.kt
+++ b/src/org/elixir_lang/reference/CaptureNameArity.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.ResolveState
 import com.intellij.psi.impl.source.resolve.ResolveCache
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.code_insight.completion.callDefinitionClauseLookupElements
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.call.Call
@@ -74,7 +74,7 @@ class CaptureNameArity(element: NonNumeric, val nameElement: Call, val arity: Ar
     private fun Iterable<LookupElement>.ofRequestedArity(): List<LookupElement> = filter { lookupElement ->
         val nameArityInterval = when (val candidate = lookupElement.psiElement) {
             is Call -> CallDefinitionClause.nameArityInterval(candidate, ResolveState.initial())
-            is CallDefinitionImpl<*> -> candidate.nameArityInterval
+            is BeamCallDefinition -> candidate.nameArityInterval
             else -> null
         }
 

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -114,7 +114,7 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
                     /**
                      * Don't use `namedElement.navigationElement` as it triggers decompiling of the whole module,
                      * which will parse the whole Module text, which is overkill to get the module's name that is
-                     * available in the `ModuleImpl` alone.
+                     * available in the `BeamModule` alone.
                      */
                     resolveResultList.add(VisitedElementSetResolveResult(namedElement))
                 }

--- a/tests/org/elixir_lang/code_insight/BehaviouralGestures.kt
+++ b/tests/org/elixir_lang/code_insight/BehaviouralGestures.kt
@@ -88,7 +88,7 @@ sealed interface GtduNavigation {
  * (it too front-runs the EP providers), but returns only the *branch decision* (`GTD`/`SU`/`null`). It
  * throws away the *resolved destination*, which the beam bug demands: the failure mode is "the gesture
  * decides GTD but resolves onto the coarse self-named definition, i.e. navigates nowhere". The coarse
- * `TypeDefinitionImpl`/`CallDefinitionImpl` spans the WHOLE definition, so a caret-position read after
+ * `BeamTypeDefinition`/`BeamCallDefinition` spans the WHOLE definition, so a caret-position read after
  * `performEditorAction` cannot tell "went nowhere (self)" from "landed on the definition" - it stayed
  * green with the fix removed. Only the resolved [GtduTarget.destination] leaf distinguishes broken from
  * fixed; capturing it is why this reaches past the public hook into the internal result tree.

--- a/tests/org/elixir_lang/code_insight/completion/contributor/BeamCallDefinitionClauseTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/BeamCallDefinitionClauseTest.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.common.runAll
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.beam.BeamLibraryFixture
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import java.io.File
 
 /**
@@ -19,15 +19,15 @@ import java.io.File
  *
  * Three fixed bugs:
  *
- * 1. **`Variants.execute(CallDefinitionImpl<*>)`** was a no-op: the always-false `element is Named`
+ * 1. **`Variants.execute(BeamCallDefinition)`** was a no-op: the always-false `element is Named`
  *    guard meant exported BEAM functions never appeared in unqualified scope-walk completion after
  *    `import SomeBeamModule`.  Tested by [testBeamExportedFunctionAppearsInUnqualifiedCompletion].
  *
- * 2. **`element_renderer.CallDefinitionClause`** had no branch for `CallDefinitionImpl`, so the
+ * 2. **`element_renderer.CallDefinitionClause`** had no branch for `BeamCallDefinition`, so the
  *    tail text (arity) was missing from BEAM completion items.  Tested by
  *    [testBeamExportedFunctionRendersWithArity].
  *
- * 3. The same renderer set no icon for `CallDefinitionImpl`, so BEAM items rendered without the
+ * 3. The same renderer set no icon for `BeamCallDefinition`, so BEAM items rendered without the
  *    function/macro + visibility icon that source items get.  Tested by
  *    [testBeamExportedFunctionRendersWithIcon].
  *
@@ -73,7 +73,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
     /**
      * Adds this suite's own `ebin/Elixir.Code.beam` as a library CLASSES root.
      * `ebin/` contains only the `.beam` file (its companion `code.ex` lives in `lib/`, which is
-     * NOT added here), so completion resolves through `CallDefinitionImpl` stubs rather than source
+     * NOT added here), so completion resolves through `BeamCallDefinition` stubs rather than source
      * PSI.  Uses the test method name to produce a unique library name, avoiding collisions across
      * tests in the same light-project instance.
      */
@@ -126,7 +126,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
     /**
      * When both the source (`code.ex`) and decompiled (`Elixir.Code.beam`) forms of the `Code`
      * module are in scope, UNQUALIFIED completion after `import Code` must NOT offer the BEAM
-     * (`CallDefinitionImpl`) variants alongside the source clauses - exactly like resolution
+     * (`BeamCallDefinition`) variants alongside the source clauses - exactly like resolution
      * prefers source over decompiled (see PreferSourceOverDecompiledTest).
      *
      * Regression guard for the source-over-decompiled preference at the *module-alias resolution*
@@ -136,7 +136,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
      * the `Code` alias via `QualifiableAlias.maybeModularNameToModulars` -> `reference.multiResolve`,
      * which returns only the source `defmodule Code` when source exists.  As a result the walk takes
      * the source `executeOnCallDefinitionClause(Call)` path and never reaches
-     * `Variants.execute(CallDefinitionImpl<*>)` for `Code`, so no BEAM lookup elements are produced.
+     * `Variants.execute(BeamCallDefinition)` for `Code`, so no BEAM lookup elements are produced.
      *
      * This test should fail only if that alias-resolution preference regresses (e.g. the alias
      * starts resolving to both the source and BEAM modulars), which would let BEAM duplicates leak
@@ -155,7 +155,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
             stringToQuotedElements.isEmpty()
         )
 
-        val beamElements = stringToQuotedElements.filter { it.psiElement is CallDefinitionImpl<*> }
+        val beamElements = stringToQuotedElements.filter { it.psiElement is BeamCallDefinition }
         assertTrue(
             "Unqualified completion offered BEAM-decompiled 'string_to_quoted' variants " +
                 "(${beamElements.size}) even though source code.ex is in scope; source should be " +
@@ -166,10 +166,10 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
 
     /**
      * Exported functions from a BEAM module must appear in UNQUALIFIED completion after
-     * `import Code`.  This exercises `Variants.execute(CallDefinitionImpl<*>)` - the method
+     * `import Code`.  This exercises `Variants.execute(BeamCallDefinition)` - the method
      * that was previously a no-op due to the always-false `element is Named` guard.
      *
-     * Without the fix, the scope walker visits each `CallDefinitionImpl` from the imported
+     * Without the fix, the scope walker visits each `BeamCallDefinition` from the imported
      * BEAM module but returns `true` without adding it to the lookup, so no BEAM functions
      * appear in unqualified completion.  With the fix, exported functions are added.
      *
@@ -194,7 +194,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
      * The lookup element for a BEAM-decompiled function must render with `/arity` tail text.
      *
      * This verifies the fix in `element_renderer.CallDefinitionClause` that adds a
-     * `renderCallDefinitionImpl` branch, since `CallDefinitionImpl` is not a `Call` and the
+     * `renderBeamCallDefinition` branch, since `BeamCallDefinition` is not a `Call` and the
      * pre-fix code path left the tail text empty for BEAM elements.
      */
     fun testBeamExportedFunctionRendersWithArity() {
@@ -223,7 +223,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
     /**
      * The lookup element for a BEAM-decompiled function must render with an icon, just like a
      * source-defined function does (the source path forwards `ItemPresentation.getIcon` via
-     * `renderItemPresentation`).  `renderCallDefinitionImpl` builds the equivalent RowIcon
+     * `renderItemPresentation`).  `renderBeamCallDefinition` builds the equivalent RowIcon
      * (time/function-vs-macro, visibility, call-definition-clause) so the popup is visually
      * consistent and keeps those cues.
      */
@@ -242,7 +242,7 @@ class BeamCallDefinitionClauseTest : PlatformTestCase() {
 
         assertNotNull(
             "Expected a non-null icon for BEAM completion item 'string_to_quoted' - " +
-                "renderCallDefinitionImpl should set the same icon as the source render path",
+                "renderBeamCallDefinition should set the same icon as the source render path",
             presentation.icon
         )
     }

--- a/tests/org/elixir_lang/code_insight/completion/contributor/ErlangModuleCompletionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/ErlangModuleCompletionTest.kt
@@ -59,7 +59,7 @@ class ErlangModuleCompletionTest : BeamLibraryTestCase() {
      * `:math.s<caret>` offers `sqrt` - the exported functions of a decompiled Erlang module, reached
      * through the atom qualifier.
      *
-     * Only the `ModuleImpl` branch of `callDefinitionClauseLookupElements` makes BEAM functions
+     * Only the `BeamModule` branch of `callDefinitionClauseLookupElements` makes BEAM functions
      * offerable; a `Call`-only path discards the decompiled module and offers nothing.
      */
     fun testErlangModuleFunctionsAreOfferedAfterAtomQualifier() {
@@ -110,7 +110,7 @@ class ErlangModuleCompletionTest : BeamLibraryTestCase() {
      * `apply(:math, :s<caret>, [1])` offers `sqrt` - the `apply/3` shape of the same MFA path.
      *
      * `AtomCompletionTest` covers this for an Elixir source module; a BEAM module reaches
-     * `callDefinitionClauseLookupElements` through the `ModuleImpl` branch instead.
+     * `callDefinitionClauseLookupElements` through the `BeamModule` branch instead.
      */
     fun testErlangApplyFunctionAtomOffersModuleFunctions() {
         myFixture.configureByText(

--- a/tests/org/elixir_lang/model/psi/function/BeamFunctionGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/function/BeamFunctionGotoDeclarationTest.kt
@@ -9,7 +9,7 @@ import org.elixir_lang.code_insight.nonDeclarationUsageCountAtCaret
 
 /**
  * Behavioural Go To Declaration and Find Usages coverage for functions defined in decompiled BEAM modules, e.g.
- * `:queue.new/0` from the Erlang stdlib. Unlike source `def`s these resolve to `CallDefinitionImpl` decompiled PSI,
+ * `:queue.new/0` from the Erlang stdlib. Unlike source `def`s these resolve to `BeamCallDefinition` decompiled PSI,
  * so they exercise the branch of the call reference that navigates into the `.beam` mirror rather than a source clause.
  */
 class BeamFunctionGotoDeclarationTest : BeamLibraryTestCase() {

--- a/tests/org/elixir_lang/model/psi/type/BeamTypeGotoDeclarationTest.kt
+++ b/tests/org/elixir_lang/model/psi/type/BeamTypeGotoDeclarationTest.kt
@@ -8,7 +8,7 @@ import java.io.File
 /**
  * Behavioural Go To Declaration coverage for types defined in decompiled BEAM modules: remote Erlang
  * library types (`:queue.queue/0`) and the built-in types faked onto `:erlang` (`integer/0`). Unlike
- * source `@type`s these resolve to `TypeDefinitionImpl` decompiled PSI, so they exercise the branch of
+ * source `@type`s these resolve to `BeamTypeDefinition` decompiled PSI, so they exercise the branch of
  * the type reference that navigates into the `.beam` mirror rather than a source attribute.
  */
 class BeamTypeGotoDeclarationTest : BeamLibraryTestCase() {

--- a/tests/org/elixir_lang/navigation/BeamTypeGotoSymbolTest.kt
+++ b/tests/org/elixir_lang/navigation/BeamTypeGotoSymbolTest.kt
@@ -1,0 +1,41 @@
+package org.elixir_lang.navigation
+
+import com.intellij.navigation.ChooseByNameRegistry
+import com.intellij.navigation.NavigationItem
+import org.elixir_lang.beam.BeamLibraryTestCase
+import org.elixir_lang.beam.psi.TypeDefinition
+
+/**
+ * Go To Symbol over types defined in decompiled BEAM modules.
+ *
+ * The two tests fail differently on purpose: the first covers the crash, the second covers a fix that
+ * stops the crash but omits the `toTypedArray()` concatenation, leaving the symbol silently absent.
+ */
+class BeamTypeGotoSymbolTest : BeamLibraryTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/model/psi/type"
+
+    private fun itemsNamed(name: String): Array<NavigationItem> =
+        ChooseByNameRegistry
+            .getInstance()
+            .symbolModelContributors
+            .filterIsInstance<GotoSymbolContributor>()
+            .single()
+            .getItemsByName(name, name, myFixture.project, true)
+
+    fun testGoToSymbolOnADecompiledTypeDoesNotThrow() {
+        myFixture.configureByFiles("beam_qualified_type_goto.ex")
+
+        itemsNamed("queue")
+    }
+
+    fun testGoToSymbolOffersTheDecompiledTypeDefinition() {
+        myFixture.configureByFiles("beam_qualified_type_goto.ex")
+
+        val items = itemsNamed("queue")
+
+        assertTrue(
+            "Go To Symbol should offer the decompiled `@type queue`, got: ${items.map { it.name }}",
+            items.any { it is TypeDefinition }
+        )
+    }
+}

--- a/tests/org/elixir_lang/psi/scope/UnhandledElementTest.kt
+++ b/tests/org/elixir_lang/psi/scope/UnhandledElementTest.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.ResolveState
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.PlatformTestCase
-import org.elixir_lang.beam.psi.impl.TypeDefinitionImpl
+import org.elixir_lang.beam.psi.TypeDefinition as BeamTypeDefinition
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 import org.elixir_lang.psi.ElixirDoBlock
 import org.elixir_lang.psi.ElixirFile
@@ -32,7 +32,7 @@ class UnhandledElementTest : PlatformTestCase() {
             override fun executeOnType(definition: AtUnqualifiedNoParenthesesCall<*>, state: ResolveState) = true
             override fun executeOnParameter(parameter: PsiElement, state: ResolveState) = true
             override fun keepProcessing() = true
-            override fun execute(typeDefinitionImpl: TypeDefinitionImpl<*>, state: ResolveState) = true
+            override fun execute(typeDefinition: BeamTypeDefinition, state: ResolveState) = true
         }
 
         assertKeepsWalkingSilently(processor)

--- a/tests/org/elixir_lang/psi/scope/call_definition_clause/SpecialFormSourceOverBeamTest.kt
+++ b/tests/org/elixir_lang/psi/scope/call_definition_clause/SpecialFormSourceOverBeamTest.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.testFramework.common.runAll
 import org.elixir_lang.PlatformTestCase
 import org.elixir_lang.beam.BeamLibraryFixture
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import java.io.File
 
 /**
@@ -23,7 +23,7 @@ import java.io.File
  * (the real mise/SDK layout), each macro was offered twice.
  *
  * These tests pin both fixture scenarios:
- *  - only the decompiled BEAM present -> each macro offered once (from the `CallDefinitionImpl` stub);
+ *  - only the decompiled BEAM present -> each macro offered once (from the `BeamCallDefinition` stub);
  *  - source `special_forms.ex` present alongside the BEAM -> source is preferred, the BEAM variants are
  *    dropped, and each macro is still offered exactly once (no duplicate).
  *
@@ -136,7 +136,7 @@ class SpecialFormSourceOverBeamTest : PlatformTestCase() {
 
     /**
      * Source and BEAM both in scope (the real mise/SDK layout): the source `special_forms.ex` clauses
-     * are preferred, the decompiled `CallDefinitionImpl` variants are dropped, and each macro is still
+     * are preferred, the decompiled `BeamCallDefinition` variants are dropped, and each macro is still
      * offered exactly once - the fix for the IDE duplicate.
      *
      * Special forms are offered like any other implicitly-imported macro: they come from the normal
@@ -156,7 +156,7 @@ class SpecialFormSourceOverBeamTest : PlatformTestCase() {
             )
         )
 
-        val beamVariants = elements.filter { it.psiElement is CallDefinitionImpl<*> }
+        val beamVariants = elements.filter { it.psiElement is BeamCallDefinition }
         assertTrue(
             "Unqualified completion offered decompiled BEAM special-form variants " +
                 "(${beamVariants.map { it.lookupString }}) even though source special_forms.ex is in " +

--- a/tests/org/elixir_lang/reference/callable/ErlangAtomQualifierTest.kt
+++ b/tests/org/elixir_lang/reference/callable/ErlangAtomQualifierTest.kt
@@ -11,7 +11,7 @@ import java.io.File
  * Uses a real `math.beam` file (Erlang stdlib) as a library class root to exercise
  * the BEAM decompilation → stub indexing → atom reference resolution path.
  *
- * The BEAM-decompiled `ModuleImpl` must not be filtered out by the `as? Call` cast
+ * The BEAM-decompiled `BeamModule` must not be filtered out by the `as? Call` cast
  * in `PsiReference.maybeModularNameToModulars()`.
  */
 class ErlangAtomQualifierTest : BeamLibraryTestCase() {

--- a/tests/org/elixir_lang/reference/mfa_tuple/ErlangMfaTupleReferenceTest.kt
+++ b/tests/org/elixir_lang/reference/mfa_tuple/ErlangMfaTupleReferenceTest.kt
@@ -3,7 +3,7 @@ package org.elixir_lang.reference.mfa_tuple
 import com.intellij.model.psi.PsiSymbolReferenceService
 import com.intellij.psi.util.PsiTreeUtil
 import org.elixir_lang.beam.BeamLibraryTestCase
-import org.elixir_lang.beam.psi.impl.CallDefinitionImpl
+import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.model.psi.atom.AtomReference
 import org.elixir_lang.psi.ElixirAtom
 import java.io.File
@@ -39,9 +39,9 @@ class ErlangMfaTupleReferenceTest : BeamLibraryTestCase() {
         assertNotNull("Valid resolve result has null element", element)
         assertTrue(
             "Expected BEAM CallDefinitionImpl, got ${element?.javaClass?.simpleName}",
-            element is CallDefinitionImpl<*>
+            element is BeamCallDefinition
         )
-        val resolvedName = (element as CallDefinitionImpl<*>).nameArityInterval.name
+        val resolvedName = (element as BeamCallDefinition).nameArityInterval.name
         assertEquals("sqrt", resolvedName)
     }
 
@@ -55,9 +55,9 @@ class ErlangMfaTupleReferenceTest : BeamLibraryTestCase() {
         assertNotNull("resolve() returned null for Erlang MFA {:math, :sqrt, 1}", resolved)
         assertTrue(
             "Expected BEAM CallDefinitionImpl, got ${resolved?.javaClass?.simpleName}",
-            resolved is CallDefinitionImpl<*>
+            resolved is BeamCallDefinition
         )
-        assertEquals("sqrt", (resolved as CallDefinitionImpl<*>).nameArityInterval.name)
+        assertEquals("sqrt", (resolved as BeamCallDefinition).nameArityInterval.name)
     }
 
     /**


### PR DESCRIPTION
Fixes #4000.

`Module`, `CallDefinition` and `TypeDefinition` are the named elements of a decompiled `.beam`, and the only things whose stub types write into `AllName.KEY`. `BeamSymbol` states that as a sealed interface, so a `when` over them is exhaustive and a fourth would fail the build at every dispatch site.

Sealing constrains a type's *direct* subtypes to its package. The direct subtypes here are the three interfaces, which already share `org.elixir_lang.beam.psi`; the implementations are indirect subtypes and unconstrained. `Module` becomes Kotlin because javac enforces the emitted `permits` clause against a Java subtype.

`BeamFileImpl` is not a member: a file is not a symbol.

## Dispatch on the model

Thirty call sites type-tested `ModuleImpl`, `CallDefinitionImpl` or `TypeDefinitionImpl` where the interface now suffices — including the abstract `execute(…)` signatures in the scope processors and their overrides. They did so because four members consumers needed lived only on the implementations, so `callDefinitions()`, `typeDefinitions()`, the owning module and navigability now sit on the interfaces. `Module` was an empty marker; it now says what a decompiled module is.

Two sites keep the implementation and say why: `getStub()` comes from `StubBasedPsiElement` and has no counterpart on the model.

## The crash

`GotoSymbolContributor` named only two of the three decompiled symbols, so the third reached a `TODO()` and Go To Symbol threw `NotImplementedError` on a type from a decompiled `.beam`. Five reports, all on published builds (`24.0.0-pre-4`, `24.0.1`).

`SourcePreferredItems` needed a collection as well as an arm: `toTypedArray()` concatenates its backing fields by name, so a collection added but not concatenated would stop the crash and leave the symbol silently absent. `BeamTypeGotoSymbolTest` covers that half separately from the crash.

The outer `else` remains and cannot be removed — `AllName.KEY` is keyed by the open `NamedElement`, so Kotlin cannot prove exhaustiveness there. It now guards index-versus-contributor drift rather than an unmodelled shape.

## The index

`TypeDefinitionType` began writing into `AllName.KEY` in `e4af4c6f2` without `AllName.VERSION` being bumped. Stub indices are invalidated by that number, so an index built before that commit has no type-definition entries and nothing forces a rebuild — Go To Symbol finds no decompiled type however the contributor behaves. Tests miss it because the fixture builds a fresh index every run.

## Verification

Exhaustiveness is proved, not assumed: removing an arm gives `'when' expression must be exhaustive. Add the 'is TypeDefinition' branch or an 'else' branch.`

`BeamTypeGotoSymbolTest` was run red against unmodified `main` with the exact production message. 2304 tests across 131 classes pass (`navigation`, `beam`, `model.psi`, `psi.scope`, `reference`, `code_insight`, `documentation`), `skipped="0"`. Each commit compiles alone. `gen/` is untouched.

## Noted, not changed

`MaybeExported` documents `exportedName()` as null when `isExported()` is false. The decompiled implementation returns the stub name unconditionally, and two consumers — `ModuleImpl.setMirror` and the Quick Docs name match — depend on that, so making the implementation obey its interface would be a regression. The documentation is what is wrong. Left for its own issue.
