### PR TITLE
fix(tests): stop the sync test helper starving its own worker

### DIFF
--- a/tests/org/elixir_lang/mix/sync/MixSyncTestHelpers.kt
+++ b/tests/org/elixir_lang/mix/sync/MixSyncTestHelpers.kt
@@ -48,6 +48,11 @@ internal object MixSyncTestHelpers {
                 throw AssertionError("runSuspendOnPooledThread timed out after ${timeoutMillis} ms")
             }
             PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+            // Pumping without pause keeps the EDT permanently inside a prioritized activity, which
+            // makes CoreProgressManager park the pooled thread for 1ms at every checkCanceled().
+            if (!done.get()) {
+                Thread.sleep(1)
+            }
         }
         error?.let { throw it }
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
`runSuspendOnPooledThread` pumped the event queue with no pause, keeping the EDT inside a prioritized activity. `CoreProgressManager` then parked the pooled thread 1ms at every `checkCanceled()` — which PSI traversal calls per element — so the walk each test waited on crawled, and cases saturated at the platform's 12s de-prioritization ceiling instead of finishing.

Yielding briefly between pumps lets the walk run uncontended. No assertion is weakened.

Windows-only in effect: `parkNanos(1ms)` rounds up to Windows' ~15.6ms timer granularity, so Linux never paid it.

| | before | after |
|---|---|---|
| `test (Win25, IDEA 2025.3.6)` | 7416 tests / 9m38s | 7338 tests / 6m13s |
| `test (1.17.3+27.1.2)` (Linux) | 7455 tests / 5m41s | 7377 tests / 5m43s |
| local Windows suite | 7359 tests / 11m16s | 7306 tests / 4m57s |

`TransitiveResolutionTest` alone: 316.6s → 5.2s.