### PR TITLE
Follow a quote bound by destructuring to the value at its position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,8 +83,8 @@
     [#1613](https://github.com/KronicDeth/intellij-elixir/issues/1613).
 
 - [#4031](https://github.com/KronicDeth/intellij-elixir/pull/4031) [@sh41](https://github.com/sh41)
-  - **A definition inside a quote bound by destructuring now resolves at the `unquote` that splices
-    it.** Fixes [#4025](https://github.com/KronicDeth/intellij-elixir/issues/4025).
+  - **A definition inside a quote bound by destructuring now resolves at the `unquote` or `use` that
+    splices it.** Fixes [#4025](https://github.com/KronicDeth/intellij-elixir/issues/4025).
 
 - [#4020](https://github.com/KronicDeth/intellij-elixir/pull/4020) [@sh41](https://github.com/sh41)
   - **Variable resolution, Find Usages and rename no longer report errors or miss bindings for code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
     `defdelegate`, including delegations into compiled modules such as `Map.values/1`.** Fixes
     [#1613](https://github.com/KronicDeth/intellij-elixir/issues/1613).
 
+- [#4031](https://github.com/KronicDeth/intellij-elixir/pull/4031) [@sh41](https://github.com/sh41)
+  - **A definition inside a quote bound by destructuring now resolves at the `unquote` that splices
+    it.** Fixes [#4025](https://github.com/KronicDeth/intellij-elixir/issues/4025).
+
 - [#4020](https://github.com/KronicDeth/intellij-elixir/pull/4020) [@sh41](https://github.com/sh41)
   - **Variable resolution, Find Usages and rename no longer report errors or miss bindings for code
     shapes they did not model.** Fixes [#4019](https://github.com/KronicDeth/intellij-elixir/issues/4019).

--- a/src/org/elixir_lang/psi/Destructure.kt
+++ b/src/org/elixir_lang/psi/Destructure.kt
@@ -1,0 +1,250 @@
+package org.elixir_lang.psi
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.psi.impl.childExpressions
+import org.elixir_lang.psi.impl.stripAccessExpression
+import org.elixir_lang.psi.operation.Match
+import org.elixir_lang.psi.operation.Pipe
+
+/**
+ * Correlates a position in a match's pattern with the value at the same position on the right, so a name bound by
+ * destructuring carries the one value it was bound to instead of the whole right-hand side.
+ */
+object Destructure {
+    /**
+     * The values [declaration] is bound to by `[pattern] = [value]`, empty when it is bound to nothing.
+     *
+     * A value this cannot take apart is answered whole to *every* position, so `[_, x] = fragments()` claims
+     * everything `fragments/0` returns. Deliberate: refusing it would cost `[x] = fragments()`, which is how a
+     * `__using__` usually reaches its fragments. A quote is the one exception, refused below. The `t` of `[h | t]`
+     * binds nothing - issue #4067.
+     */
+    @RequiresReadLock
+    fun valuesAt(pattern: PsiElement?, value: PsiElement?, declaration: PsiElement): List<PsiElement> =
+        valuesAt(pattern, value, declaration, emptySet())
+
+    private fun valuesAt(
+        pattern: PsiElement?,
+        value: PsiElement?,
+        declaration: PsiElement,
+        followed: Set<PsiElement>
+    ): List<PsiElement> {
+        val strippedPattern = pattern?.stripAccessExpression() ?: return emptyList()
+        val strippedValue = value?.stripAccessExpression() ?: return emptyList()
+
+        if (strippedPattern == declaration) {
+            return listOf(strippedValue)
+        }
+
+        if (!PsiTreeUtil.isAncestor(strippedPattern, declaration, true)) {
+            return emptyList()
+        }
+
+        if (!sameShapeAs(strippedPattern, strippedValue)) {
+            // two containers of different kinds are a match that raises, so nothing is bound
+            if (isContainer(strippedValue)) {
+                return emptyList()
+            }
+
+            val bounds = boundValues(strippedValue, followed)
+
+            return if (bounds.isEmpty()) {
+                listOf(strippedValue)
+            } else {
+                bounds.flatMap { bound -> valuesAt(strippedPattern, bound.value, declaration, bound.followed) }
+            }
+        }
+
+        val (nextPattern, nextValue) = descend(strippedPattern, strippedValue, declaration) ?: return emptyList()
+
+        return valuesAt(nextPattern, nextValue, declaration, followed)
+    }
+
+    private data class Bound(val value: PsiElement, val followed: Set<PsiElement>)
+
+    /**
+     * What a name on the right of a match was itself bound to. [followed] bounds a chain of them; a read on the right
+     * of `=` resolves to a strictly earlier binding, so it is insurance against that rule changing, not a live cycle.
+     */
+    private fun boundValues(value: PsiElement, followed: Set<PsiElement>): List<Bound> =
+        // a variable read is the only shape whose binding is a match, and resolving anything else costs a stub-index
+        // or decompiler round trip to reach the same empty answer
+        (value as? UnqualifiedNoArgumentsCall<*>)
+            ?.let { it.reference as? PsiPolyVariantReference }
+            ?.multiResolve(false)
+            ?.filter { it.isValidResult }
+            ?.mapNotNull { it.element }
+            ?.filterNot { it in followed }
+            ?.flatMap { declaration ->
+                PsiTreeUtil
+                    .getParentOfType(declaration, Match::class.java)
+                    ?.let { match ->
+                        val stepped = followed + declaration
+
+                        valuesAt(match.leftOperand(), match.rightOperand(), declaration, stepped)
+                            .map { bound -> Bound(bound, stepped) }
+                    }
+                    .orEmpty()
+            }
+            .orEmpty()
+
+    /** The shapes [descend] can take apart, and so the ones whose kind has to agree for the match to bind at all. */
+    private fun isContainer(element: PsiElement): Boolean =
+        element is ElixirTuple || element is ElixirList || element is ElixirMapOperation
+
+    private fun sameShapeAs(pattern: PsiElement, value: PsiElement): Boolean =
+        when (pattern) {
+            is ElixirTuple -> value is ElixirTuple
+            is ElixirList -> value is ElixirList
+            is ElixirMapOperation -> value is ElixirMapOperation
+            else -> false
+        }
+
+    /** The pair one level in from [pattern] and [value] that still contains [declaration]. */
+    private fun descend(
+        pattern: PsiElement,
+        value: PsiElement,
+        declaration: PsiElement
+    ): Pair<PsiElement, PsiElement>? =
+        when (pattern) {
+            is ElixirMapOperation -> (value as? ElixirMapOperation)?.let { byKey(pattern, it, declaration) }
+            else -> byPosition(pattern, value, declaration)
+        }
+
+    private fun byPosition(
+        pattern: PsiElement,
+        value: PsiElement,
+        declaration: PsiElement
+    ): Pair<PsiElement, PsiElement>? {
+        val (heads, tail) = positions(pattern)
+        val (valueElements, valueTail) = positions(value)
+
+        // a cons on the right leaves the value's length unknown; conservative, since `[x] = [h | t]` matches only
+        // when `t` is empty
+        if (valueTail != null) {
+            return null
+        }
+
+        // `[h | t]` matches any list at least as long as its heads; without a tail the lengths have to agree exactly
+        val linesUp = if (tail == null) heads.size == valueElements.size else heads.size <= valueElements.size
+
+        if (!linesUp) {
+            return null
+        }
+
+        // the rest of a list is not an element of it, so a name bound by `t` finds no index here and answers nothing
+        val index = heads.indexOfFirst { PsiTreeUtil.isAncestor(it, declaration, false) }
+
+        return if (index == -1) {
+            null
+        } else {
+            heads[index] to valueElements[index]
+        }
+    }
+
+    /** The positions of a tuple or list: those matched by index, and the one `[h | t]` binds the rest to. */
+    private data class Positions(val heads: List<PsiElement>, val tail: PsiElement?)
+
+    private fun positions(container: PsiElement): Positions {
+        val elements = elements(container)
+        // `[a, b | t]` parses as the elements before `b | t`, then one pipe operation carrying the last two positions
+        val cons = elements.lastOrNull()?.stripAccessExpression() as? Pipe ?: return Positions(elements, null)
+        val head = cons.leftOperand() ?: return Positions(elements, null)
+
+        return Positions(elements.dropLast(1) + head, cons.rightOperand())
+    }
+
+    /**
+     * A container's elements as Elixir counts them. `containerArguments` is a private rule, so they are its own child
+     * expressions - except that it collapses a trailing keyword list into one `keywords` child, where Elixir sees one
+     * element per pair: `[value, k: 1, j: 2]` is a list of three.
+     */
+    private fun elements(container: PsiElement): List<PsiElement> =
+        container.childExpressions().toList().flatMap { child ->
+            val stripped = child.stripAccessExpression()
+
+            // The list rule only: `[q, k: 1, j: 2]` is a list of three, but `{q, k: 1, j: 2}` is a tuple of two, whose
+            // second element is the whole keyword list. `QuotableImpl.quote` draws the same distinction.
+            if (container is ElixirList && stripped is ElixirKeywords) {
+                stripped.keywordPairList
+            } else {
+                listOf(child)
+            }
+        }
+
+    /** A map pattern names a subset of the value's keys, so the sides are paired by key rather than by position. */
+    private fun byKey(
+        pattern: ElixirMapOperation,
+        value: ElixirMapOperation,
+        declaration: PsiElement
+    ): Pair<PsiElement, PsiElement>? {
+        val (key, patternElement) = entries(pattern)
+            .firstOrNull { (_, element) -> PsiTreeUtil.isAncestor(element, declaration, false) }
+            ?: return null
+        // a duplicate key takes its last value - `%{a: 1, a: 2}` is `%{a: 2}` - so the last entry is the binding one
+        val valueElement = entries(value).lastOrNull { (valueKey, _) -> valueKey == key }?.second ?: return null
+
+        return patternElement to valueElement
+    }
+
+    /**
+     * Every key of [element], with the expression it maps to, and none at all when it is not a map. An update,
+     * `%{base | a: value}`, carries its associations and keywords the same way a construction does, and only the keys
+     * it names are known here - the ones it inherits from `base` are not, so they pair with nothing, as an absent key
+     * does.
+     */
+    private fun entries(mapOperation: ElixirMapOperation): List<Pair<String, PsiElement>> {
+        val mapArguments = mapOperation.mapArguments
+        val constructionArguments = mapArguments.mapConstructionArguments
+        val updateArguments = mapArguments.mapUpdateArguments
+        val associationsBase =
+            constructionArguments?.let { it.associations?.associationsBase ?: it.associationsBase }
+                ?: updateArguments?.let { it.associations?.associationsBase ?: it.associationsBase }
+        val associationEntries = associationsBase
+            ?.containerAssociationOperationList
+            ?.mapNotNull { association ->
+                // `associationInfixOperator` is a private rule, so `=>` is a leaf and the operands are what is left
+                val children = association.childExpressions().toList()
+                val keyElement = children.firstOrNull()
+                val valueElement = children.lastOrNull()
+
+                if (keyElement != null && valueElement != null && keyElement !== valueElement) {
+                    key(keyElement) to valueElement
+                } else {
+                    null
+                }
+            }
+            .orEmpty()
+        val keywordEntries = (constructionArguments?.keywords ?: updateArguments?.keywords)
+            ?.keywordPairList
+            ?.map { keywordPair -> key(keywordPair.keywordKey) to keywordPair.keywordValue as PsiElement }
+            .orEmpty()
+
+        return associationEntries + keywordEntries
+    }
+
+    /**
+     * A key's identity for pairing. `a:`, `:a`, `:"a"` and `"a":` are one atom; `"a" =>` is a binary and distinct. An
+     * escape sequence answers as written, so `"\x61":` fails to pair with `a:` though Elixir says they are equal.
+     */
+    private fun key(element: PsiElement): String =
+        when (val stripped = element.stripAccessExpression()) {
+            is ElixirAtom -> stripped.line?.let(::quotedName) ?: "atom ${stripped.text.removePrefix(":")}"
+            is ElixirKeywordKey -> stripped.line?.let(::quotedName) ?: "atom ${stripped.text}"
+            else -> "term ${stripped.text}"
+        }
+
+    /** The atom a quoted key spells. Interpolation is unknowable here, so it gets an identity pairing with nothing. */
+    private fun quotedName(line: ElixirLine): String {
+        val body = line.lineBody
+
+        return if (body == null || PsiTreeUtil.findChildOfType(body, ElixirInterpolation::class.java) != null) {
+            "interpolated ${line.textOffset}"
+        } else {
+            "atom ${body.text}"
+        }
+    }
+}

--- a/src/org/elixir_lang/psi/Destructure.kt
+++ b/src/org/elixir_lang/psi/Destructure.kt
@@ -4,10 +4,12 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.childExpressions
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.Match
 import org.elixir_lang.psi.operation.Pipe
+import org.elixir_lang.psi.walk.ShapeTable
 
 /**
  * Correlates a position in a match's pattern with the value at the same position on the right, so a name bound by
@@ -45,7 +47,7 @@ object Destructure {
 
         if (!sameShapeAs(strippedPattern, strippedValue)) {
             // two containers of different kinds are a match that raises, so nothing is bound
-            if (isContainer(strippedValue)) {
+            if (bucket(strippedValue) != Bucket.OPAQUE) {
                 return emptyList()
             }
 
@@ -58,9 +60,9 @@ object Destructure {
             }
         }
 
-        val (nextPattern, nextValue) = descend(strippedPattern, strippedValue, declaration) ?: return emptyList()
-
-        return valuesAt(nextPattern, nextValue, declaration, followed)
+        return descend(strippedPattern, strippedValue, declaration).flatMap { (nextPattern, nextValue) ->
+            valuesAt(nextPattern, nextValue, declaration, followed)
+        }
     }
 
     private data class Bound(val value: PsiElement, val followed: Set<PsiElement>)
@@ -91,84 +93,104 @@ object Destructure {
             }
             .orEmpty()
 
-    /** The shapes [descend] can take apart, and so the ones whose kind has to agree for the match to bind at all. */
-    private fun isContainer(element: PsiElement): Boolean =
-        element is ElixirTuple || element is ElixirList || element is ElixirMapOperation
+    /**
+     * How a shape can be taken apart by a match. Read from [ShapeTable], so a new grammar shape fails
+     * `ShapeCoverageTest` until somebody classifies it rather than defaulting silently.
+     */
+    enum class Bucket {
+        /** Positions matched by index; `[h | t]` matches any list at least as long as its heads. */
+        LIST,
+        /** Positions matched by index, counting a trailing keyword list as the single element it is. */
+        TUPLE,
+        /** Keys, of which the pattern may name a subset. */
+        MAP,
+        /** One key and its value, as a keyword list's elements are. */
+        KEYWORD_PAIR,
+        /** Cannot be taken apart here, so a name in the pattern may carry whatever it holds. */
+        OPAQUE
+    }
+
+    val classifier = ShapeTable.column(Bucket.OPAQUE) { it.destructure }
+
+    private fun bucket(element: PsiElement): Bucket = classifier.classify(element)
 
     private fun sameShapeAs(pattern: PsiElement, value: PsiElement): Boolean =
-        when (pattern) {
-            is ElixirTuple -> value is ElixirTuple
-            is ElixirList -> value is ElixirList
-            is ElixirMapOperation -> value is ElixirMapOperation
-            else -> false
-        }
+        bucket(pattern).let { it != Bucket.OPAQUE && it == bucket(value) }
 
-    /** The pair one level in from [pattern] and [value] that still contains [declaration]. */
+    /** The pair one level in from [pattern] and [value] that still contains [declaration], or none. */
     private fun descend(
         pattern: PsiElement,
         value: PsiElement,
         declaration: PsiElement
-    ): Pair<PsiElement, PsiElement>? =
-        when (pattern) {
-            is ElixirMapOperation -> (value as? ElixirMapOperation)?.let { byKey(pattern, it, declaration) }
-            else -> byPosition(pattern, value, declaration)
+    ): List<Pair<PsiElement, PsiElement>> =
+        when (bucket(pattern)) {
+            Bucket.MAP -> byKey(pattern, value, declaration)
+            Bucket.LIST, Bucket.TUPLE -> byPosition(pattern, value, declaration)
+            Bucket.KEYWORD_PAIR -> byPairedKey(pattern, value, declaration)
+            // `sameShapeAs` has already answered false, so `valuesAt` never descends into one
+            Bucket.OPAQUE -> emptyList()
         }
 
     private fun byPosition(
         pattern: PsiElement,
         value: PsiElement,
         declaration: PsiElement
-    ): Pair<PsiElement, PsiElement>? {
-        val (heads, tail) = positions(pattern)
-        val (valueElements, valueTail) = positions(value)
+    ): List<Pair<PsiElement, PsiElement>> {
+        val (heads, tail) = positions(pattern) ?: return emptyList()
+        val (valueElements, valueTail) = positions(value) ?: return emptyList()
 
         // a cons on the right leaves the value's length unknown; conservative, since `[x] = [h | t]` matches only
         // when `t` is empty
         if (valueTail != null) {
-            return null
+            return emptyList()
         }
 
         // `[h | t]` matches any list at least as long as its heads; without a tail the lengths have to agree exactly
         val linesUp = if (tail == null) heads.size == valueElements.size else heads.size <= valueElements.size
 
         if (!linesUp) {
-            return null
+            return emptyList()
         }
 
-        // the rest of a list is not an element of it, so a name bound by `t` finds no index here and answers nothing
         val index = heads.indexOfFirst { PsiTreeUtil.isAncestor(it, declaration, false) }
 
-        return if (index == -1) {
-            null
-        } else {
-            heads[index] to valueElements[index]
+        if (index != -1) {
+            return listOf(heads[index] to valueElements[index])
         }
+
+        // `[h | t]`'s tail binds nothing - issue #4067; `valuesAt`'s KDoc records why, and a test pins it
+        return emptyList()
     }
 
     /** The positions of a tuple or list: those matched by index, and the one `[h | t]` binds the rest to. */
     private data class Positions(val heads: List<PsiElement>, val tail: PsiElement?)
 
-    private fun positions(container: PsiElement): Positions {
+    private fun positions(container: PsiElement): Positions? {
         val elements = elements(container)
+
+        if (bucket(container) != Bucket.LIST) {
+            return Positions(elements, null)
+        }
+
         // `[a, b | t]` parses as the elements before `b | t`, then one pipe operation carrying the last two positions
         val cons = elements.lastOrNull()?.stripAccessExpression() as? Pipe ?: return Positions(elements, null)
-        val head = cons.leftOperand() ?: return Positions(elements, null)
+        // null, not a fixed-length reading: a half-typed cons would otherwise be less conservative than a whole one
+        val head = cons.leftOperand() ?: return null
+        val tail = cons.rightOperand() ?: return null
 
-        return Positions(elements.dropLast(1) + head, cons.rightOperand())
+        return Positions(elements.dropLast(1) + head, tail)
     }
 
     /**
-     * A container's elements as Elixir counts them. `containerArguments` is a private rule, so they are its own child
-     * expressions - except that it collapses a trailing keyword list into one `keywords` child, where Elixir sees one
-     * element per pair: `[value, k: 1, j: 2]` is a list of three.
+     * A container's elements as Elixir counts them: `containerArguments` is private, so they are its own child
+     * expressions, except that a trailing keyword list is one child but one element per pair.
      */
     private fun elements(container: PsiElement): List<PsiElement> =
         container.childExpressions().toList().flatMap { child ->
             val stripped = child.stripAccessExpression()
 
-            // The list rule only: `[q, k: 1, j: 2]` is a list of three, but `{q, k: 1, j: 2}` is a tuple of two, whose
-            // second element is the whole keyword list. `QuotableImpl.quote` draws the same distinction.
-            if (container is ElixirList && stripped is ElixirKeywords) {
+            // `[q, k: 1, j: 2]` is a list of three but `{q, k: 1, j: 2}` a tuple of two, as `QuotableImpl.quote` has it
+            if (bucket(container) == Bucket.LIST && stripped is ElixirKeywords) {
                 stripped.keywordPairList
             } else {
                 listOf(child)
@@ -177,17 +199,43 @@ object Destructure {
 
     /** A map pattern names a subset of the value's keys, so the sides are paired by key rather than by position. */
     private fun byKey(
-        pattern: ElixirMapOperation,
-        value: ElixirMapOperation,
+        pattern: PsiElement,
+        value: PsiElement,
         declaration: PsiElement
-    ): Pair<PsiElement, PsiElement>? {
+    ): List<Pair<PsiElement, PsiElement>> {
         val (key, patternElement) = entries(pattern)
             .firstOrNull { (_, element) -> PsiTreeUtil.isAncestor(element, declaration, false) }
-            ?: return null
+            ?: return emptyList()
         // a duplicate key takes its last value - `%{a: 1, a: 2}` is `%{a: 2}` - so the last entry is the binding one
-        val valueElement = entries(value).lastOrNull { (valueKey, _) -> valueKey == key }?.second ?: return null
+        val valueElement =
+            entries(value).lastOrNull { (valueKey, _) -> valueKey == key }?.second ?: return emptyList()
 
-        return patternElement to valueElement
+        return listOf(patternElement to valueElement)
+    }
+
+    /**
+     * A keyword list is a list of pairs, so its pairs line up by position and must then agree on the key. A pair
+     * spelled as a tuple, `[{:a, x}] = [a: value]`, does match in Elixir but binds nothing here.
+     */
+    private fun byPairedKey(
+        pattern: PsiElement,
+        value: PsiElement,
+        declaration: PsiElement
+    ): List<Pair<PsiElement, PsiElement>> {
+        val patternPair = pattern as? ElixirKeywordPair ?: return emptyList()
+        val valuePair = value as? ElixirKeywordPair ?: return emptyList()
+
+        if (key(patternPair.keywordKey) != key(valuePair.keywordKey)) {
+            return emptyList()
+        }
+
+        val patternValue = patternPair.keywordValue
+
+        return if (PsiTreeUtil.isAncestor(patternValue, declaration, false)) {
+            listOf(patternValue as PsiElement to valuePair.keywordValue as PsiElement)
+        } else {
+            emptyList()
+        }
     }
 
     /**
@@ -196,8 +244,9 @@ object Destructure {
      * it names are known here - the ones it inherits from `base` are not, so they pair with nothing, as an absent key
      * does.
      */
-    private fun entries(mapOperation: ElixirMapOperation): List<Pair<String, PsiElement>> {
-        val mapArguments = mapOperation.mapArguments
+    private fun entries(element: PsiElement): List<Pair<String, PsiElement>> {
+        // the only shape in the `MAP` bucket; a wider one would answer no keys rather than throw
+        val mapArguments = (element as? ElixirMapOperation)?.mapArguments ?: return emptyList()
         val constructionArguments = mapArguments.mapConstructionArguments
         val updateArguments = mapArguments.mapUpdateArguments
         val associationsBase =

--- a/src/org/elixir_lang/psi/Destructure.kt
+++ b/src/org/elixir_lang/psi/Destructure.kt
@@ -4,7 +4,6 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.concurrency.annotations.RequiresReadLock
-import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.childExpressions
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.Match
@@ -20,9 +19,8 @@ object Destructure {
      * The values [declaration] is bound to by `[pattern] = [value]`, empty when it is bound to nothing.
      *
      * A value this cannot take apart is answered whole to *every* position, so `[_, x] = fragments()` claims
-     * everything `fragments/0` returns. Deliberate: refusing it would cost `[x] = fragments()`, which is how a
-     * `__using__` usually reaches its fragments. A quote is the one exception, refused below. The `t` of `[h | t]`
-     * binds nothing - issue #4067.
+     * everything `fragments/0` returns; refusing it would cost `[x] = fragments()`, which is how a `__using__`
+     * usually reaches its fragments. The `t` of `[h | t]` binds nothing - issue #4067.
      */
     @RequiresReadLock
     fun valuesAt(pattern: PsiElement?, value: PsiElement?, declaration: PsiElement): List<PsiElement> =
@@ -63,6 +61,62 @@ object Destructure {
         return descend(strippedPattern, strippedValue, declaration).flatMap { (nextPattern, nextValue) ->
             valuesAt(nextPattern, nextValue, declaration, followed)
         }
+    }
+
+    /**
+     * Whether `[pattern] = [value]` can match at all, for a caller holding the whole match rather than a declaration
+     * inside it. `true` whenever this cannot tell - an unreadable side, an unmodelled shape.
+     */
+    @RequiresReadLock
+    fun matches(pattern: PsiElement?, value: PsiElement?): Boolean {
+        val strippedPattern = pattern?.stripAccessExpression() ?: return true
+        val strippedValue = value?.stripAccessExpression() ?: return true
+
+        if (bucket(strippedPattern) == Bucket.OPAQUE || bucket(strippedValue) == Bucket.OPAQUE) {
+            return true
+        }
+
+        if (!sameShapeAs(strippedPattern, strippedValue)) {
+            return oneShapeTwoSpellings(bucket(strippedPattern), bucket(strippedValue))
+        }
+
+        return when (bucket(strippedPattern)) {
+            Bucket.LIST, Bucket.TUPLE -> linesUp(strippedPattern, strippedValue)
+            Bucket.KEYWORD_PAIR -> keysAgree(strippedPattern, strippedValue)
+            // a `__using__` whose returned value holds a literal map never compiles, so judging one decides nothing
+            Bucket.MAP, Bucket.OPAQUE -> true
+        }
+    }
+
+    private fun keysAgree(pattern: PsiElement, value: PsiElement): Boolean {
+        val patternPair = pattern as? ElixirKeywordPair ?: return true
+        val valuePair = value as? ElixirKeywordPair ?: return true
+
+        return keysCanAgree(key(patternPair.keywordKey), key(valuePair.keywordKey)) &&
+                matches(patternPair.keywordValue, valuePair.keywordValue)
+    }
+
+    /** A key [key] could not read pairs with nothing when binding, but rules nothing out when judging a whole match. */
+    private fun keysCanAgree(pattern: String?, value: String?): Boolean =
+        pattern == null || value == null || pattern == value
+
+    /** Whether the buckets differ only in spelling - `{:a, x}` and `a: x` are one shape written two ways. */
+    private fun oneShapeTwoSpellings(pattern: Bucket, value: Bucket): Boolean =
+        (pattern == Bucket.KEYWORD_PAIR && value == Bucket.TUPLE) ||
+                (pattern == Bucket.TUPLE && value == Bucket.KEYWORD_PAIR)
+
+    private fun linesUp(pattern: PsiElement, value: PsiElement): Boolean {
+        val (heads, tail) = positions(pattern) ?: return true
+        val (valueElements, valueTail) = positions(value) ?: return true
+
+        // a cons on the right leaves the length unknown, so nothing is ruled out
+        if (valueTail != null) {
+            return true
+        }
+
+        val lengthAccepted = if (tail == null) heads.size == valueElements.size else heads.size <= valueElements.size
+
+        return lengthAccepted && heads.zip(valueElements).all { (head, element) -> matches(head, element) }
     }
 
     private data class Bound(val value: PsiElement, val followed: Set<PsiElement>)
@@ -206,6 +260,10 @@ object Destructure {
         val (key, patternElement) = entries(pattern)
             .firstOrNull { (_, element) -> PsiTreeUtil.isAncestor(element, declaration, false) }
             ?: return emptyList()
+        if (key == null) {
+            return emptyList()
+        }
+
         // a duplicate key takes its last value - `%{a: 1, a: 2}` is `%{a: 2}` - so the last entry is the binding one
         val valueElement =
             entries(value).lastOrNull { (valueKey, _) -> valueKey == key }?.second ?: return emptyList()
@@ -225,7 +283,9 @@ object Destructure {
         val patternPair = pattern as? ElixirKeywordPair ?: return emptyList()
         val valuePair = value as? ElixirKeywordPair ?: return emptyList()
 
-        if (key(patternPair.keywordKey) != key(valuePair.keywordKey)) {
+        val patternKey = key(patternPair.keywordKey) ?: return emptyList()
+
+        if (patternKey != key(valuePair.keywordKey)) {
             return emptyList()
         }
 
@@ -244,7 +304,7 @@ object Destructure {
      * it names are known here - the ones it inherits from `base` are not, so they pair with nothing, as an absent key
      * does.
      */
-    private fun entries(element: PsiElement): List<Pair<String, PsiElement>> {
+    private fun entries(element: PsiElement): List<Pair<String?, PsiElement>> {
         // the only shape in the `MAP` bucket; a wider one would answer no keys rather than throw
         val mapArguments = (element as? ElixirMapOperation)?.mapArguments ?: return emptyList()
         val constructionArguments = mapArguments.mapConstructionArguments
@@ -276,24 +336,33 @@ object Destructure {
     }
 
     /**
-     * A key's identity for pairing. `a:`, `:a`, `:"a"` and `"a":` are one atom; `"a" =>` is a binary and distinct. An
-     * escape sequence answers as written, so `"\x61":` fails to pair with `a:` though Elixir says they are equal.
+     * A key's identity for pairing, or `null` when the key cannot be read. `a:`, `:a`, `:"a"` and `"a":` are one atom;
+     * `"a" =>` is a binary and distinct.
      */
-    private fun key(element: PsiElement): String =
+    private fun key(element: PsiElement): String? =
         when (val stripped = element.stripAccessExpression()) {
-            is ElixirAtom -> stripped.line?.let(::quotedName) ?: "atom ${stripped.text.removePrefix(":")}"
-            is ElixirKeywordKey -> stripped.line?.let(::quotedName) ?: "atom ${stripped.text}"
+            is ElixirAtom -> name(stripped.line, stripped.text.removePrefix(":"))
+            is ElixirKeywordKey -> name(stripped.line, stripped.text)
             else -> "term ${stripped.text}"
         }
 
-    /** The atom a quoted key spells. Interpolation is unknowable here, so it gets an identity pairing with nothing. */
-    private fun quotedName(line: ElixirLine): String {
-        val body = line.lineBody
-
-        return if (body == null || PsiTreeUtil.findChildOfType(body, ElixirInterpolation::class.java) != null) {
-            "interpolated ${line.textOffset}"
+    /**
+     * The atom a key spells, read from [line] when it is quoted and taken as [unquoted] when it is not. `null` when an
+     * interpolation or an escape sequence hides what the quotes spell, since `"\x61":` is `a:` to Elixir.
+     */
+    private fun name(line: ElixirLine?, unquoted: String): String? =
+        if (line == null) {
+            "atom $unquoted"
         } else {
-            "atom ${body.text}"
+            line
+                .lineBody
+                ?.takeIf {
+                    PsiTreeUtil.findChildOfAnyType(
+                        it,
+                        ElixirInterpolation::class.java,
+                        EscapeSequence::class.java
+                    ) == null
+                }
+                ?.let { "atom ${it.text}" }
         }
-    }
 }

--- a/src/org/elixir_lang/psi/Unquote.kt
+++ b/src/org/elixir_lang/psi/Unquote.kt
@@ -10,6 +10,8 @@ import org.elixir_lang.psi.call.name.Function.UNQUOTE
 import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.call.qualification.Qualified
 import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.psi.impl.childExpressions
+import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.Match
 import org.elixir_lang.psi.scope.WhileIn.whileIn
 
@@ -65,13 +67,18 @@ object Unquote {
                     Using.treeWalkUp(unquoted, null, unquotedResolveState, keepProcessing)
                 } else {
                     // The walk's answer is dropped, so a consumer's stop signal does not end the loop here
-                    treeWalkUpUnquotedVariable(unquoted, unquotedResolveState, keepProcessing)
+                    treeWalkUpUnquotedVariable(unquoted, unquoted, unquotedResolveState, keepProcessing)
 
                     true
                 }
             }
 
+    /**
+     * [declaration] is the variable the walk started from, so [Destructure] can pair it with the value at its own
+     * position once a [Match] is reached; [unquoted] is the current hop, whose own position is lost as the walk climbs.
+     */
     private tailrec fun treeWalkUpUnquotedVariable(unquoted: PsiElement,
+                                                   declaration: PsiElement,
                                                    resolveState: ResolveState,
                                                    keepProcessing: (PsiElement, ResolveState) -> Boolean): Boolean {
         // a detached element binds nothing above
@@ -81,18 +88,13 @@ object Unquote {
             UnquotedVariableWalk.Bucket.MATCH -> {
                 val match = parent as Match
 
-                // variable = ...
-                if (match.leftOperand() == unquoted) {
-                    match.rightOperand()?.let { value ->
-                        treeWalkUpValue(value, resolveState, keepProcessing)
-                    } ?: true
-                }
-                // ... = variable: a use, which binds nothing further up
-                else {
-                    true
+                // empty for `... = variable`, or for two sides that do not line up: neither binds anything further up
+                whileIn(Destructure.valuesAt(match.leftOperand(), match.rightOperand(), declaration)) { value ->
+                    treeWalkUpValue(value, resolveState, keepProcessing)
                 }
             }
-            UnquotedVariableWalk.Bucket.RECURSE -> treeWalkUpUnquotedVariable(parent, resolveState, keepProcessing)
+            UnquotedVariableWalk.Bucket.RECURSE ->
+                treeWalkUpUnquotedVariable(parent, declaration, resolveState, keepProcessing)
             UnquotedVariableWalk.Bucket.STOP,
             UnquotedVariableWalk.Bucket.UNFOLLOWED,
             UnquotedVariableWalk.Bucket.LEAF -> true
@@ -104,9 +106,31 @@ object Unquote {
                                 keepProcessing: (PsiElement, ResolveState) -> Boolean): Boolean =
             when (value) {
                 is Call -> treeWalkUpValue(value, resolveState, keepProcessing)
-                // A literal or container value is not walked into, so a quote destructured out of one is not found
+                // the compiler expands a list literal's elements, so a list of fragments defines each of them
+                is ElixirList -> treeWalkUpFragments(value, resolveState, keepProcessing)
+                // Only a two-element tuple is a quoted literal. `{:__block__, [], [fragment]}` splices too, but that
+                // needs the node's shape read rather than its size, and is not modelled.
+                is ElixirTuple ->
+                    value.takeIf { it.childExpressions().count() == 2 }
+                            ?.let { tuple -> treeWalkUpFragments(tuple, resolveState, keepProcessing) }
+                            ?: true
                 else -> true
             }
+
+    /** Each element of [container] read as a fragment. Marked visited first: a fragment can answer this container. */
+    private fun treeWalkUpFragments(container: PsiElement,
+                                    resolveState: ResolveState,
+                                    keepProcessing: (PsiElement, ResolveState) -> Boolean): Boolean =
+            container
+                    .takeUnlessHasBeenVisited(resolveState)
+                    ?.let { entered ->
+                        val enteredResolveState = resolveState.putVisitedElement(entered)
+
+                        whileIn(entered.childExpressions().toList()) { fragment ->
+                            treeWalkUpValue(fragment.stripAccessExpression(), enteredResolveState, keepProcessing)
+                        }
+                    }
+                    ?: true
 
     private fun treeWalkUpValue(value: Call,
                                 resolveState: ResolveState,

--- a/src/org/elixir_lang/psi/UnquotedVariableWalk.kt
+++ b/src/org/elixir_lang/psi/UnquotedVariableWalk.kt
@@ -4,8 +4,9 @@ import com.intellij.psi.PsiElement
 import org.elixir_lang.psi.walk.ShapeTable
 
 /**
- * The parents of an unquoted variable that lead to the value it carries, for [Unquote]. Following a declaration out of
- * a container to its match over-approximates: every name destructured from one value claims that value's definitions.
+ * The parents of an unquoted variable that lead to the value it carries, for [Unquote]. A container is climbed through
+ * to reach the match; [Destructure] then pairs the declaration with the value at its own position wherever it can take
+ * the right-hand side apart, so a name destructured from one value does not claim the whole of it.
  */
 object UnquotedVariableWalk {
     enum class Bucket {

--- a/src/org/elixir_lang/psi/UnquotedVariableWalk.kt
+++ b/src/org/elixir_lang/psi/UnquotedVariableWalk.kt
@@ -14,7 +14,7 @@ object UnquotedVariableWalk {
         MATCH,
         /** Nothing to follow. Parentheses arguments are `QuotableArguments`, so this comes before `RECURSE`. */
         STOP,
-        /** A container a variable can be declared through, which this walk does not enter yet. Answers as `STOP`. */
+        /** A shape a variable could be declared through that this walk does not follow. Answers as `STOP`. */
         UNFOLLOWED,
         /** A wrapper the value passes through, so ask the parent. */
         RECURSE,

--- a/src/org/elixir_lang/psi/Using.kt
+++ b/src/org/elixir_lang/psi/Using.kt
@@ -58,7 +58,10 @@ object Using {
                 treeWalkUpFragments(last, last.childExpressions().toList(), use, resolveState, keepProcessing)
             // `{conditional, imports}` returned bare; without its own arm the `else` reads an earlier statement
             is ElixirTuple -> treeWalkUpValue(last, use, resolveState, keepProcessing)
-            is Match -> treeWalkUpValue(last.rightOperand(), use, resolveState, keepProcessing)
+            // a `__using__` returns its last statement's value, so a match that raises defines nothing in the caller
+            is Match ->
+                !Destructure.matches(last.leftOperand(), last.rightOperand()) ||
+                        treeWalkUpValue(last.rightOperand(), use, resolveState, keepProcessing)
             else ->
                 statements
                     .filterIsInstance<Call>()
@@ -115,8 +118,8 @@ object Using {
             is ElixirTuple -> {
                 val fragments = stripped.childExpressions().toList()
 
-                // Only a two-element tuple is a quoted literal. Three is a call node whose arguments also expand, so
-                // `{:__block__, [], [fragment]}` splices too - that needs the shape read, not the arity, and is not.
+                // Only a two-element tuple is a quoted literal. `{:__block__, [], [fragment]}` splices too, but
+                // that needs the node's shape read rather than its size, and is not modelled.
                 if (fragments.size == 2) {
                     treeWalkUpFragments(stripped, fragments, use, resolveState, keepProcessing)
                 } else {

--- a/src/org/elixir_lang/psi/Using.kt
+++ b/src/org/elixir_lang/psi/Using.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.ResolveState
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.beam.psi.CallDefinition as BeamCallDefinition
 import org.elixir_lang.beam.psi.Module as BeamModule
@@ -15,6 +16,7 @@ import org.elixir_lang.psi.call.name.Module.KERNEL
 import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.psi.impl.call.macroChildCallSequence
 import org.elixir_lang.psi.impl.call.stabBodyChildExpressions
+import org.elixir_lang.psi.impl.childExpressions
 import org.elixir_lang.psi.impl.maybeModularNameToModulars
 import org.elixir_lang.psi.impl.stripAccessExpression
 import org.elixir_lang.psi.operation.Match
@@ -24,6 +26,7 @@ import org.elixir_lang.structure_view.element.Timed
 import org.elixir_lang.util.AccumulatorContinue
 
 object Using {
+    @RequiresReadLock
     fun treeWalkUp(
         using: PsiElement,
         use: Call?,
@@ -49,12 +52,12 @@ object Using {
         val statements = using.stabBodyChildExpressions(forward = false)?.toList() ?: return true
 
         return when (val last = statements.firstOrNull()?.stripAccessExpression()) {
-            // `[conditional, imports]` - the fragments a `__using__` splices into the caller
-            // (Phoenix.Component.__using__/1), usually variables bound earlier in the body.
+            // `[conditional, imports]` - the fragments a `__using__` splices (Phoenix.Component.__using__/1). Read
+            // via `childExpressions`, not `unmatchedExpressionList`, which omits a nested container's accessExpression.
             is ElixirList ->
-                whileIn(last.unmatchedExpressionList) { element ->
-                    treeWalkUpListElement(element, use, resolveState, keepProcessing)
-                }
+                treeWalkUpFragments(last, last.childExpressions().toList(), use, resolveState, keepProcessing)
+            // `{conditional, imports}` returned bare; without its own arm the `else` reads an earlier statement
+            is ElixirTuple -> treeWalkUpValue(last, use, resolveState, keepProcessing)
             is Match -> treeWalkUpValue(last.rightOperand(), use, resolveState, keepProcessing)
             else ->
                 statements
@@ -65,7 +68,7 @@ object Using {
         }
     }
 
-    /** A variable element resolves to its `variable = value` bindings; anything else is walked as is. */
+    /** A variable element resolves to its `pattern = value` bindings; anything else is walked as is. */
     private fun treeWalkUpListElement(
         element: PsiElement,
         use: Call?,
@@ -76,8 +79,7 @@ object Using {
             ?.multiResolve(false)
             ?.filter { it.isValidResult }
             ?.mapNotNull { it.element }
-            ?.mapNotNull { declaration -> (declaration.parent as? Match)?.takeIf { it.leftOperand() == declaration } }
-            ?.mapNotNull { binding -> binding.rightOperand() }
+            ?.flatMap { declaration -> boundValues(declaration) }
             .orEmpty()
 
         return if (boundValues.isEmpty()) {
@@ -87,16 +89,65 @@ object Using {
         }
     }
 
+    /**
+     * The values the enclosing `pattern = value` binds [declaration] to, however deeply the pattern destructures it.
+     */
+    private fun boundValues(declaration: PsiElement): List<PsiElement> =
+        PsiTreeUtil
+            .getParentOfType(declaration, Match::class.java)
+            ?.let { match -> Destructure.valuesAt(match.leftOperand(), match.rightOperand(), declaration) }
+            .orEmpty()
+
     private fun treeWalkUpValue(
         value: PsiElement?,
         use: Call?,
         resolveState: ResolveState,
         keepProcessing: (PsiElement, ResolveState) -> Boolean
     ): Boolean =
-        (value?.stripAccessExpression() as? Call)
-            ?.takeUnlessHasBeenVisited(resolveState)
-            ?.let { call -> treeWalkUpFromLastChildCall(call, use, resolveState, keepProcessing) }
+        when (val stripped = value?.stripAccessExpression()) {
+            is Call ->
+                stripped
+                    .takeUnlessHasBeenVisited(resolveState)
+                    ?.let { call -> treeWalkUpFromLastChildCall(call, use, resolveState, keepProcessing) }
+                    ?: true
+            is ElixirList ->
+                treeWalkUpFragments(stripped, stripped.childExpressions().toList(), use, resolveState, keepProcessing)
+            is ElixirTuple -> {
+                val fragments = stripped.childExpressions().toList()
+
+                // Only a two-element tuple is a quoted literal. Three is a call node whose arguments also expand, so
+                // `{:__block__, [], [fragment]}` splices too - that needs the shape read, not the arity, and is not.
+                if (fragments.size == 2) {
+                    treeWalkUpFragments(stripped, fragments, use, resolveState, keepProcessing)
+                } else {
+                    true
+                }
+            }
+            else -> true
+        }
+
+    /**
+     * Each element of [container] read as a fragment. Marked visited first: [Destructure] can answer a container
+     * again, so only the resolver's earlier-binding rule would otherwise stop that arriving back here.
+     */
+    private fun treeWalkUpFragments(
+        container: PsiElement,
+        fragments: List<PsiElement>,
+        use: Call?,
+        resolveState: ResolveState,
+        keepProcessing: (PsiElement, ResolveState) -> Boolean
+    ): Boolean =
+        container
+            .takeUnlessHasBeenVisited(resolveState)
+            ?.let { entered ->
+                val enteredResolveState = resolveState.putVisitedElement(entered)
+
+                whileIn(fragments) { fragment ->
+                    treeWalkUpListElement(fragment, use, enteredResolveState, keepProcessing)
+                }
+            }
             ?: true
+
     private fun treeWalkUpFromLastChildCall(
         lastChildCall: Call,
         useCall: Call?,

--- a/src/org/elixir_lang/psi/walk/ShapeTable.kt
+++ b/src/org/elixir_lang/psi/walk/ShapeTable.kt
@@ -33,7 +33,8 @@ object ShapeTable {
         val unquote: UnquotedVariableWalk.Bucket? = null,
         val descent: VariableDescent.Bucket? = null,
         val typeDescent: TypeDescent.Bucket? = null,
-        val typeAscent: TypeAscent.Bucket? = null
+        val typeAscent: TypeAscent.Bucket? = null,
+        val destructure: Destructure.Bucket? = null
     )
 
     val ROWS: List<Row> = listOf(
@@ -47,6 +48,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STAB_NO_PARENTHESES_SIGNATURE,
             typeDescent = TypeDescent.Bucket.STAB_NO_PARENTHESES_SIGNATURE,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirStabOperation::class.java,
@@ -57,6 +59,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STAB_OPERATION,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirStabParenthesesSignature::class.java,
@@ -67,6 +70,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STAB_PARENTHESES_SIGNATURE,
             typeDescent = TypeDescent.Bucket.STAB_PARENTHESES_SIGNATURE,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             InMatch::class.java,
@@ -91,6 +95,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             Type::class.java,
@@ -100,7 +105,11 @@ object ShapeTable {
             typeAscent = TypeAscent.Bucket.PARENT,
         ),
         Row(When::class.java, parameter = ParameterWalk.Bucket.RECURSE),
-        Row(ElixirMatchedWhenOperation::class.java, descent = VariableDescent.Bucket.WHEN),
+        Row(
+            ElixirMatchedWhenOperation::class.java,
+            descent = VariableDescent.Bucket.WHEN,
+            destructure = Destructure.Bucket.OPAQUE
+        ),
         Row(In::class.java, descent = VariableDescent.Bucket.IN),
 
         // operations and lookups
@@ -113,6 +122,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // a match inside `m[...]` binds afterwards, so the brackets are read; the receiver is a value
         Row(
@@ -124,6 +134,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.BRACKET,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             AtUnqualifiedBracketOperation::class.java,
@@ -134,6 +145,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.AT_BRACKET,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // `@1[key]`, a lookup on a number, binds nothing
         Row(
@@ -145,6 +157,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             AtOperation::class.java,
@@ -155,6 +168,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.AT_OPERATION,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(Addition::class.java, descent = VariableDescent.Bucket.NON_DECLARING_INFIX),
         Row(And::class.java, descent = VariableDescent.Bucket.NON_DECLARING_INFIX),
@@ -182,6 +196,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CALL,
             typeDescent = TypeDescent.Bucket.CALL,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
 
         // containers, arguments and blocks
@@ -196,6 +211,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirAccessExpression::class.java,
@@ -206,6 +222,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.CHILDREN,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirAssociations::class.java,
@@ -216,6 +233,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirAssociationsBase::class.java,
@@ -226,6 +244,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirBitString::class.java,
@@ -236,6 +255,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirBlockItem::class.java,
@@ -246,6 +266,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirBlockList::class.java,
@@ -255,6 +276,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirContainerAssociationOperation::class.java,
@@ -265,6 +287,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CONTAINER_ASSOCIATION,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirDoBlock::class.java,
@@ -274,6 +297,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirEex::class.java,
@@ -284,6 +308,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // a template is one expression, so a tag is a statement in it and its variables are searched above the tag
         Row(
@@ -295,6 +320,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // `%{key: name}` is a pattern to climb out of; `do: block` reaches no match, and pairing drops it there
         Row(
@@ -306,6 +332,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.KEYWORD_PAIR,
         ),
         Row(
             ElixirKeywords::class.java,
@@ -314,6 +341,10 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.RECURSE,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            /* A list's trailing keywords are expanded into their pairs, which carry the `KEYWORD_PAIR` bucket. A
+               tuple's are not - `{_a, k: 1}` leaves this whole in a pattern position - and pairing it would need a
+               keyword list read as a list of pairs, which is not modelled. */
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirList::class.java,
@@ -324,6 +355,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.HALT,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.LIST,
         ),
         Row(
             ElixirMapArguments::class.java,
@@ -334,6 +366,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.MAP_ARGUMENTS,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirMapConstructionArguments::class.java,
@@ -343,6 +376,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirMapOperation::class.java,
@@ -353,6 +387,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.MAP_OPERATION,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.MAP,
         ),
         // an update is a value, read through its map arguments; a match inside binds afterwards
         Row(
@@ -364,6 +399,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirMatchedParenthesesArguments::class.java,
@@ -374,6 +410,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirNoParenthesesOneArgument::class.java,
@@ -382,6 +419,7 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.RECURSE,
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.CHILDREN,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirNoParenthesesArguments::class.java,
@@ -391,6 +429,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirNoParenthesesKeywordPair::class.java,
@@ -401,6 +440,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirNoParenthesesKeywords::class.java,
@@ -409,6 +449,7 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.RECURSE,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirNoParenthesesManyStrictNoParenthesesExpression::class.java,
@@ -419,6 +460,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // syntax errors met while typing; the ascents look above them, the descents do not enter
         Row(
@@ -428,6 +470,7 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.RECURSE,
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirParenthesesArguments::class.java,
@@ -437,6 +480,7 @@ object ShapeTable {
             unquote = UnquotedVariableWalk.Bucket.STOP,
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirParentheticalStab::class.java,
@@ -447,6 +491,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.HALT,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirStab::class.java,
@@ -457,6 +502,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirStabBody::class.java,
@@ -467,6 +513,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirStructOperation::class.java,
@@ -477,6 +524,8 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STRUCT_OPERATION,
             typeDescent = TypeDescent.Bucket.HALT,
             typeAscent = TypeAscent.Bucket.PARENT,
+            // a struct's keys are a map's, but `%Foo{} = %Bar{}` raises, so pairing has to compare the names first
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirTuple::class.java,
@@ -487,6 +536,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.HALT,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.TUPLE,
         ),
         Row(QuotableArguments::class.java, unquote = UnquotedVariableWalk.Bucket.RECURSE),
         Row(
@@ -494,7 +544,7 @@ object ShapeTable {
             unquote = UnquotedVariableWalk.Bucket.RECURSE,
             descent = VariableDescent.Bucket.KEYWORD_LIST,
         ),
-        Row(ElixirLine::class.java, typeDescent = TypeDescent.Bucket.HALT),
+        Row(ElixirLine::class.java, typeDescent = TypeDescent.Bucket.HALT, destructure = Destructure.Bucket.OPAQUE),
         Row(Arguments::class.java, typeAscent = TypeAscent.Bucket.PARENT),
 
         // aliases
@@ -508,6 +558,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // `Qualifier.` typed above a tuple pattern; the resolver declares through it
         Row(
@@ -519,6 +570,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.QUALIFIED_MULTIPLE_ALIASES,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // an alias must expand to an atom at compile time, so its qualifier is never a variable
         Row(
@@ -528,6 +580,7 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.STOP,
             unquote = UnquotedVariableWalk.Bucket.STOP,
             descent = VariableDescent.Bucket.STOP,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         leaf(ElixirAlias::class.java, typeDescent = null, typeAscent = null),
         Row(QualifiableAlias::class.java, typeDescent = TypeDescent.Bucket.HALT, typeAscent = TypeAscent.Bucket.NONE),
@@ -544,6 +597,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.PARAMETER,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         // the token `isVariable` starts from; never an ancestor
         Row(
@@ -555,6 +609,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.VARIABLE,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         leaf(Operator::class.java),
         leaf(Digits::class.java),
@@ -578,6 +633,7 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.STOP,
             unquote = UnquotedVariableWalk.Bucket.STOP,
             descent = VariableDescent.Bucket.STOP,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             ElixirLiteralSigilHeredoc::class.java,
@@ -586,6 +642,7 @@ object ShapeTable {
             parameter = ParameterWalk.Bucket.STOP,
             unquote = UnquotedVariableWalk.Bucket.STOP,
             descent = VariableDescent.Bucket.STOP,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             Body::class.java,
@@ -596,6 +653,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.LEAF,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             Line::class.java,
@@ -606,6 +664,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.LEAF,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             HeredocLineable::class.java,
@@ -616,6 +675,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.LEAF,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         Row(
             HeredocLiteral::class.java,
@@ -626,6 +686,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.LEAF,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         leaf(ElixirHeredocPrefix::class.java),
         leaf(ElixirHeredocLinePrefix::class.java),
@@ -641,6 +702,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.CHILDREN_READING,
             typeDescent = TypeDescent.Bucket.HALT,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         leaf(ElixirAtomKeyword::class.java),
         leaf(ElixirAtIdentifier::class.java),
@@ -655,6 +717,7 @@ object ShapeTable {
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.LEAF,
             typeAscent = TypeAscent.Bucket.LEAF,
+            destructure = Destructure.Bucket.OPAQUE,
         ),
         leaf(ElixirBlockIdentifier::class.java),
         leaf(ElixirEmptyParentheses::class.java),
@@ -669,7 +732,12 @@ object ShapeTable {
             unquote = UnquotedVariableWalk.Bucket.STOP,
             descent = VariableDescent.Bucket.FILE,
         ),
-        Row(ElixirFile::class.java, typeDescent = TypeDescent.Bucket.HALT, typeAscent = TypeAscent.Bucket.NONE)
+        Row(
+            ElixirFile::class.java,
+            typeDescent = TypeDescent.Bucket.HALT,
+            typeAscent = TypeAscent.Bucket.NONE,
+            destructure = Destructure.Bucket.OPAQUE
+        )
     )
 
     /** A token-only shape: a leaf to every walk unless the type walks say otherwise. */
@@ -685,7 +753,8 @@ object ShapeTable {
         unquote = UnquotedVariableWalk.Bucket.LEAF,
         descent = VariableDescent.Bucket.LEAF,
         typeDescent = typeDescent,
-        typeAscent = typeAscent
+        typeAscent = typeAscent,
+        destructure = Destructure.Bucket.OPAQUE
     )
 
     /** A walk's classifier: the rows that name a bucket in its column, in table order. */

--- a/src/org/elixir_lang/psi/walk/ShapeTable.kt
+++ b/src/org/elixir_lang/psi/walk/ShapeTable.kt
@@ -296,13 +296,13 @@ object ShapeTable {
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.NONE,
         ),
-        // `do: block` binds nothing further up for an unquote; read through its list by the descents
+        // `%{key: name}` is a pattern to climb out of; `do: block` reaches no match, and pairing drops it there
         Row(
             ElixirKeywordPair::class.java,
             variable = VariableWalk.Bucket.TRANSPARENT,
             useScope = VariableUseScopeWalk.Bucket.PARENT,
             parameter = ParameterWalk.Bucket.RECURSE,
-            unquote = UnquotedVariableWalk.Bucket.STOP,
+            unquote = UnquotedVariableWalk.Bucket.RECURSE,
             descent = VariableDescent.Bucket.STOP,
             typeDescent = TypeDescent.Bucket.PASS,
             typeAscent = TypeAscent.Bucket.PARENT,

--- a/tests/org/elixir_lang/psi/walk/ShapeCoverageTest.kt
+++ b/tests/org/elixir_lang/psi/walk/ShapeCoverageTest.kt
@@ -1,6 +1,7 @@
 package org.elixir_lang.psi.walk
 
 import junit.framework.TestCase
+import org.elixir_lang.psi.Destructure
 import org.elixir_lang.psi.ElixirAnonymousFunction
 import org.elixir_lang.psi.ElixirBlockItem
 import org.elixir_lang.psi.ElixirBlockList
@@ -67,6 +68,8 @@ class ShapeCoverageTest : TestCase() {
     fun testUnquotedVariableWalkNamesEveryShape() = assertCovers(UnquotedVariableWalk.classifier)
 
     fun testVariableDescentNamesEveryShape() = assertCovers(VariableDescent.classifier)
+
+    fun testDestructureNamesEveryShape() = assertCovers(Destructure.classifier)
 
     fun testTypeDescentNamesEveryShape() = assertCovers(
         TypeDescent.classifier,

--- a/tests/org/elixir_lang/reference/callable/UnquoteDestructuredBindingTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UnquoteDestructuredBindingTest.kt
@@ -1,26 +1,163 @@
 package org.elixir_lang.reference.callable
 
 import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.ResolveResult
 import org.elixir_lang.PlatformTestCase
 
 /**
- * A quote bound by destructuring, `{x, _} = {quote ... end, :other}`, is reached through the container but its value
- * is not a call the walk can follow, so nothing is injected. That is a limit, not an error to report.
+ * A quote bound by destructuring, `{x, _} = {quote ... end, :other}`, is reached through the container and then paired
+ * with the value at its own position, so the definitions it carries are injected at the `unquote` site.
  */
 class UnquoteDestructuredBindingTest : PlatformTestCase() {
-    fun testQuoteBoundThroughATupleReportsNoError() = assertNoErrorResolving(
-        "{x, _} = {quote do\n      def injected(), do: :ok\n    end, :other}"
-    )
+    fun testQuoteBoundThroughATupleResolves() = assertResolves("{x, _} = {$QUOTE, :other}")
 
-    fun testQuoteBoundThroughAListReportsNoError() = assertNoErrorResolving(
-        "[x] = [quote do\n      def injected(), do: :ok\n    end]"
-    )
+    fun testQuoteBoundThroughAListResolves() = assertResolves("[x] = [$QUOTE]")
 
-    private fun assertNoErrorResolving(binding: String) {
+    fun testQuoteBoundThroughAKeywordMapResolves() = assertResolves("%{a: x} = %{a: $QUOTE}")
+
+    /** `:a => value` and `a: value` name the same key, so a pattern may use either spelling. */
+    fun testQuoteBoundThroughAnAssociationMapResolves() = assertResolves("%{:a => x} = %{a: $QUOTE}")
+
+    /** Pairing is per level, so nesting needs no separate handling. */
+    fun testQuoteBoundThroughANestedContainerResolves() = assertResolves("{[_, x], _} = {[:first, $QUOTE], :other}")
+
+    /**
+     * The discriminating case. Reaching the match out of a container is not enough: without pairing, every name in the
+     * pattern claims the whole right-hand side, so this resolves too and every test above passes for the wrong reason.
+     */
+    fun testNameBoundBesideTheQuoteDoesNotResolve() = assertDoesNotResolve("{_, x} = {$QUOTE, :other}")
+
+    /** The same, one level of indirection away: `x` is `:other` whichever way the tuple is reached. */
+    fun testNameBoundBesideTheQuoteThroughAVariableDoesNotResolve() =
+        assertDoesNotResolve("pair = {$QUOTE, :other}\n    {_, x} = pair")
+
+    /** And the position that does hold the quote still finds it through the same indirection. */
+    fun testQuoteBoundThroughAVariableResolves() = assertResolves("pair = {$QUOTE, :other}\n    {x, _} = pair")
+
+    /** A rebound name reads as its latest binding, so the quote in that one is found. */
+    fun testQuoteInTheLatestBindingResolves() =
+        assertResolves("pair = {:first, :other}\n    pair = {$QUOTE, :other}\n    {x, _} = pair")
+
+    /** And a binding the rebinding shadows is not followed, so its quote is not claimed by the later read. */
+    fun testQuoteOnlyInAShadowedBindingDoesNotResolve() =
+        assertDoesNotResolve("pair = {$QUOTE, :other}\n    pair = {:second, :other}\n    {x, _} = pair")
+
+    /** Sides that cannot match bind nothing, rather than falling back to the value as a whole. */
+    fun testTupleOfADifferentLengthDoesNotResolve() = assertDoesNotResolve("{x, _, _} = {$QUOTE, :other}")
+
+    /** `[h | t]` matches any list at least as long as its heads, so a head pairs with the value at its own index. */
+    fun testQuoteBoundThroughAConsPatternResolves() = assertResolves("[x | _rest] = [$QUOTE, :other]")
+
+    /**
+     * A known limit, recorded in [org.elixir_lang.psi.Destructure.valuesAt]: the tail of `[h | t]` binds nothing,
+     * because no node stands for the sub-list it takes. Here that is also the right answer - `x` is `[:other]` - so
+     * the case below is the one that says why the limit is kept.
+     */
+    fun testNameBoundToAConsTailDoesNotClaimTheHead() = assertDoesNotResolve("[_h | x] = [$QUOTE, :other]")
+
+    /**
+     * Why the tail is not answered element by element: `x` is `:last` here, and answering the tail's elements
+     * separately would pair `[_p, x]` against one of them and resolve the quote that `_p` takes.
+     */
+    fun testConsTailDestructuredAgainDoesNotClaimTheWrongElement() =
+        assertDoesNotResolve("[_h | t] = [:first, $QUOTE, :last]\n    [_p, x] = t")
+
+    /** Lining up is not enough - a pair whose key differs matches nothing. */
+    fun testKeywordListPatternWithAnotherKeyDoesNotResolve() = assertDoesNotResolve("[b: x] = [a: $QUOTE]")
+
+    /** More heads than the value has elements is a match that raises. */
+    fun testConsPatternLongerThanTheValueDoesNotResolve() = assertDoesNotResolve("[_a, x | _rest] = [$QUOTE]")
+
+    /** A trailing keyword list is one PSI child but one element per pair, and Elixir counts the pairs. */
+    fun testQuoteBesideAKeywordTailResolves() = assertResolves("[x, _y, _z] = [$QUOTE, k: 1, j: 2]")
+
+    /** A tuple counts the same keyword tail as one element, so `{q, k: 1, j: 2}` has two, not three. */
+    fun testQuoteBesideAKeywordTailInATupleResolves() = assertResolves("{x, _opts} = {$QUOTE, k: 1, j: 2}")
+
+    /** The other side of that: three positions against that two-element tuple is a match that raises. */
+    fun testTupleCountingAKeywordTailAsSeparateElementsDoesNotResolve() =
+        assertDoesNotResolve("{x, _y, _z} = {$QUOTE, k: 1, j: 2}")
+
+    /** A list pattern against a tuple value raises, so the value must not be answered whole and spliced. */
+    fun testContainersOfDifferentKindsDoNotResolve() = assertDoesNotResolve("[x] = {$QUOTE, :other}")
+
+    /** A duplicate key takes its last value, so the later entry is the one that binds. */
+    fun testDuplicateMapKeyTakesTheLastValueResolves() =
+        assertResolves("%{a: x} = %{:a => :first, a: $QUOTE}")
+
+    /** A key the value does not carry binds nothing, for the same reason. */
+    fun testMapKeyMissingFromTheValueDoesNotResolve() = assertDoesNotResolve("%{b: x} = %{a: $QUOTE}")
+
+    /** The binary `"a"` and the atom `:a` are different keys, so spelling one as the other must not pair them. */
+    fun testMapKeyOfADifferentTypeDoesNotResolve() = assertDoesNotResolve("%{\"a\" => x} = %{a: $QUOTE}")
+
+    /** A quoted keyword key is the same atom as the bare one - Elixir warns that the quotes are not required. */
+    fun testQuotedKeywordKeyResolves() = assertResolves("%{\"a\": x} = %{a: $QUOTE}")
+
+    /** The same on the atom side: `:"a"` is `:a`. */
+    fun testQuotedAtomKeyResolves() = assertResolves("%{:\"a\" => x} = %{a: $QUOTE}")
+
+    /**
+     * An interpolated key names an atom only known once the code runs, so it pairs with nothing. Elixir does bind
+     * here - `"#{:a}":` is the atom `a:` - so this records a deliberate under-approximation, not the language. It does
+     * not discriminate the interpolation branch: the two keys differ as plain text too. Nothing can, because an
+     * interpolated key in a *pattern* does not compile, so only the value side ever reaches that branch.
+     */
+    fun testInterpolatedKeyDoesNotResolve() = assertDoesNotResolve("%{a: x} = %{\"#{:a}\": $QUOTE}")
+
+    /** A map update names its own keys, so one it names pairs exactly as a construction's does. */
+    fun testQuoteBoundThroughAMapUpdateResolves() =
+        assertResolves("base = %{a: nil}\n    %{a: x} = %{base | a: $QUOTE}")
+
+    /** A key the update does not name comes from `base`, which is unknown here, so it pairs with nothing. */
+    fun testMapKeyInheritedByAnUpdateDoesNotResolve() =
+        assertDoesNotResolve("base = %{a: nil}\n    %{a: x} = %{base | b: $QUOTE}")
+
+    /**
+     * `unquote(x)` splices whatever `x` holds, and the compiler expands a list literal's elements, so a list of
+     * fragments defines each of them at the splice site.
+     */
+    fun testQuoteBoundThroughAContainerOfFragmentsResolves() = assertResolves("{x, _} = {[$QUOTE], :other}")
+
+    /** The tuple counterpart of the list above: a two-element tuple is a quoted literal and splices both elements. */
+    fun testQuoteBoundThroughATupleOfFragmentsResolves() =
+        assertResolves("{x, _} = {{$QUOTE, :other}, :ignored}")
+
+    /**
+     * `:a` where a call node's metadata belongs is not a valid quoted expression, so this shape defines nothing. A
+     * fragment in the *name* position is fine - `Macro.validate({{:def, [], []}, [], []})` is `:ok` - and it is the
+     * shape, not the arity, that decides: `{:__block__, [], [fragment]}` is three elements and does splice.
+     */
+    fun testQuoteBoundThroughAThreeTupleOfFragmentsDoesNotResolve() =
+        assertDoesNotResolve("{x, _} = {{$QUOTE, :a, :b}, :other}")
+
+    /** The undestructured form the issue compares against, so a regression there is not read as one here. */
+    fun testQuoteBoundDirectlyResolves() = assertResolves("x = $QUOTE")
+
+    /**
+     * A value the pairing cannot take apart is followed whole, which is all that reaches a quote returned by a call.
+     * Pairing narrows what a destructured name claims; it must not narrow it to nothing. This program compiles and
+     * binds: the map spelling of it would not, so it is not asserted - answering the whole of an unknown value is a
+     * policy, and a test for it should not depend on a fixture that raises.
+     */
+    fun testQuoteBoundThroughAnOpaqueValueResolves() = assertResolves("[x] = fragments()", FRAGMENTS)
+
+    private fun assertResolves(binding: String, definitions: String = "") =
+        assertNotEmpty(resolveInjected(binding, definitions).toList())
+
+    private fun assertDoesNotResolve(binding: String, definitions: String = "") =
+        assertEmpty(resolveInjected(binding, definitions).toList())
+
+    /**
+     * Resolves `injected()` in a module that `use`s an injector whose `__using__` binds a quote with [binding] and
+     * unquotes the name it bound. [definitions] are extra members of the injector module, for a binding whose value
+     * is a call.
+     */
+    private fun resolveInjected(binding: String, definitions: String): Array<out ResolveResult> {
         myFixture.configureByText(
             "injector.ex",
             "defmodule Injector do\n  defmacro __using__(_opts) do\n    $binding\n    quote do\n      unquote(x)\n" +
-                "    end\n  end\nend\n"
+                "    end\n  end\n$definitions\nend\n"
         )
         myFixture.configureByText(
             "user.ex",
@@ -28,8 +165,17 @@ class UnquoteDestructuredBindingTest : PlatformTestCase() {
         )
         val reference = myFixture.file.findReferenceAt(myFixture.caretOffset)!! as PsiPolyVariantReference
 
-        val (_, errors) = captureLoggedErrors { reference.multiResolve(false) }
+        val (resolveResults, errors) = captureLoggedErrors { reference.multiResolve(false) }
 
         assertEmpty(errors)
+
+        return resolveResults
+    }
+
+    companion object {
+        private const val QUOTE = "quote do\n      def injected(), do: :ok\n    end"
+
+        /** A helper returning the fragments to splice, so a binding's value can be a call rather than a container. */
+        private const val FRAGMENTS = "  defp fragments do\n    [$QUOTE]\n  end"
     }
 }

--- a/tests/org/elixir_lang/reference/callable/UnquoteDestructuredBindingTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UnquoteDestructuredBindingTest.kt
@@ -115,11 +115,17 @@ class UnquoteDestructuredBindingTest : PlatformTestCase() {
 
     /**
      * An interpolated key names an atom only known once the code runs, so it pairs with nothing. Elixir does bind
-     * here - `"#{:a}":` is the atom `a:` - so this records a deliberate under-approximation, not the language. It does
-     * not discriminate the interpolation branch: the two keys differ as plain text too. Nothing can, because an
-     * interpolated key in a *pattern* does not compile, so only the value side ever reaches that branch.
+     * here - `"#{:a}":` is the atom `a:` - so this records a deliberate under-approximation, not the language. The two
+     * keys differ as plain text too, so [UsingDestructuredBindingTest.testEscapedKeyResolves] is what
+     * discriminates the branch.
      */
     fun testInterpolatedKeyDoesNotResolve() = assertDoesNotResolve("%{a: x} = %{\"#{:a}\": $QUOTE}")
+
+    /** Two keys neither side can read stay unequal, rather than pairing with each other for being equally unknown. */
+    fun testUnreadableMapKeysDoNotResolve() = assertDoesNotResolve("""%{"\x61": x} = %{"\x62": $QUOTE}""")
+
+    /** The same on the keyword list path, which pairs its keys by position rather than by lookup. */
+    fun testUnreadableKeywordKeysDoNotResolve() = assertDoesNotResolve("""["\x61": x] = ["\x62": $QUOTE]""")
 
     /** A map update names its own keys, so one it names pairs exactly as a construction's does. */
     fun testQuoteBoundThroughAMapUpdateResolves() =
@@ -127,7 +133,7 @@ class UnquoteDestructuredBindingTest : PlatformTestCase() {
 
     /** A key the update does not name comes from `base`, which is unknown here, so it pairs with nothing. */
     fun testMapKeyInheritedByAnUpdateDoesNotResolve() =
-        assertDoesNotResolve("base = %{a: nil}\n    %{a: x} = %{base | b: $QUOTE}")
+        assertDoesNotResolve("base = %{a: nil, b: nil}\n    %{a: x} = %{base | b: $QUOTE}")
 
     /**
      * `unquote(x)` splices whatever `x` holds, and the compiler expands a list literal's elements, so a list of
@@ -151,10 +157,8 @@ class UnquoteDestructuredBindingTest : PlatformTestCase() {
     fun testQuoteBoundDirectlyResolves() = assertResolves("x = $QUOTE")
 
     /**
-     * A value the pairing cannot take apart is followed whole, which is all that reaches a quote returned by a call.
-     * Pairing narrows what a destructured name claims; it must not narrow it to nothing. This program compiles and
-     * binds: the map spelling of it would not, so it is not asserted - answering the whole of an unknown value is a
-     * policy, and a test for it should not depend on a fixture that raises.
+     * A value the pairing cannot take apart is followed whole, which is all that reaches a quote returned by a
+     * call. Pairing narrows what a destructured name claims; it must not narrow it to nothing.
      */
     fun testQuoteBoundThroughAnOpaqueValueResolves() = assertResolves("[x] = fragments()", FRAGMENTS)
 

--- a/tests/org/elixir_lang/reference/callable/UnquoteDestructuredBindingTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UnquoteDestructuredBindingTest.kt
@@ -62,6 +62,22 @@ class UnquoteDestructuredBindingTest : PlatformTestCase() {
     fun testConsTailDestructuredAgainDoesNotClaimTheWrongElement() =
         assertDoesNotResolve("[_h | t] = [:first, $QUOTE, :last]\n    [_p, x] = t")
 
+    /** A keyword list is a list of pairs, so its pairs line up by position and then agree on the key. */
+    fun testQuoteInAKeywordListPatternResolves() = assertResolves("[a: x] = [a: $QUOTE]")
+
+    /** A cons whose tail is still being typed must not read as a fixed-length list, which a whole one does not. */
+    fun testHalfTypedConsOnTheValueSideDoesNotResolve() = assertDoesNotResolve("[x] = [$QUOTE | ]")
+
+    /** The same on the pattern side, against a one-element value so length alone does not answer it. */
+    fun testHalfTypedConsOnThePatternSideDoesNotResolve() = assertDoesNotResolve("[x | ] = [$QUOTE]")
+
+    /** The completed form of that, which does bind: `[x | rest] = [:only]` gives `rest == []`. */
+    fun testCompleteConsAgainstAOneElementListResolves() = assertResolves("[x | _rest] = [$QUOTE]")
+
+    fun testHalfTypedKeywordPairDoesNotResolve() = assertDoesNotResolve("[a: x] = [a:")
+
+    fun testHalfTypedMatchDoesNotResolve() = assertDoesNotResolve("[a: x] =")
+
     /** Lining up is not enough - a pair whose key differs matches nothing. */
     fun testKeywordListPatternWithAnotherKeyDoesNotResolve() = assertDoesNotResolve("[b: x] = [a: $QUOTE]")
 

--- a/tests/org/elixir_lang/reference/callable/UsingDestructuredBindingTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UsingDestructuredBindingTest.kt
@@ -61,6 +61,64 @@ class UsingDestructuredBindingTest : PlatformTestCase() {
      */
     fun testLastStatementBareTwoTupleResolves() = assertResolves("{$QUOTE, :other}")
 
+    /** A quote is opaque here, so it is answered whole to any pattern, including ones Elixir would raise on. */
+    fun testATuplePatternAgainstAQuoteResolves() = assertResolves("{_name, _meta, _args} = $QUOTE")
+
+    /** The pattern gained an element the value has not, a state a body is genuinely left in mid-edit. */
+    fun testPatternWithMoreElementsThanTheListDoesNotResolve() =
+        assertDoesNotResolve("[imports, _helpers] = [$QUOTE]")
+
+    /** The value changed from a map to a list, the pattern not yet updated. */
+    fun testMapPatternAgainstAListValueDoesNotResolve() =
+        assertDoesNotResolve("%{imports: imports} = [$QUOTE]")
+
+    /** A trailing keyword pair is matched by key, so an agreeing one leaves the list spliceable. */
+    fun testTrailingKeywordPairWithTheSameKeyResolves() =
+        assertResolves("[imports, a: _x] = [$QUOTE, a: 1]")
+
+    /** And a differing key raises, so the list is not spliced. */
+    fun testTrailingKeywordPairWithAnotherKeyDoesNotResolve() =
+        assertDoesNotResolve("[imports, a: _x] = [$QUOTE, b: 1]")
+
+    /** A keyword pair is a two-element tuple, so either side may be spelled either way and the match still holds. */
+    fun testKeywordPairSpelledAsATupleResolves() =
+        assertResolves("[imports, {:mode, _m}] = [$QUOTE, mode: :strict]")
+
+    /** And the mirror spelling. */
+    fun testTupleSpelledAsAKeywordPairResolves() =
+        assertResolves("[imports, mode: _m] = [$QUOTE, {:mode, :strict}]")
+
+    /** An escape sequence in a key is not read here, so the key pairs with nothing and the match cannot be ruled out. */
+    fun testEscapedKeyResolves() = assertResolves("""[imports, a: _x] = [$QUOTE, "\x61": 1]""")
+
+    /** And the other spelling the key cannot be read through. */
+    fun testInterpolatedKeyResolves() = assertResolves("""[imports, a: _x] = [$QUOTE, "#{:a}": 1]""")
+
+    /**
+     * A refusal stops the one match, not the walk, so an alias injected by an earlier `use` still resolves. Only an
+     * alias catches this: `CallDefinitionClause` drops the walk's answer, so no function resolve can see it.
+     */
+    fun testARefusalDoesNotStopTheWalk() {
+        myFixture.configureByText(
+            "injectors.ex",
+            "defmodule Some.Deep.Thing do\n  def hello, do: :ok\nend\n\n" +
+                "defmodule Aliaser do\n  defmacro __using__(_opts) do\n    quote do\n" +
+                "      alias Some.Deep.Thing\n    end\n  end\nend\n\n" +
+                "defmodule Refuser do\n  defmacro __using__(_opts) do\n    [_a, _b] = [$QUOTE]\n  end\nend\n"
+        )
+        // the modular walk runs backwards, so the refusing `use` has to sit nearer the caret than the aliasing one
+        myFixture.configureByText(
+            "user.ex",
+            "defmodule User do\n  use Aliaser\n  use Refuser\n  def call, do: <caret>Thing\nend\n"
+        )
+
+        val reference = myFixture.file.findReferenceAt(myFixture.caretOffset)!! as PsiPolyVariantReference
+        val (resolveResults, errors) = captureLoggedErrors { reference.multiResolve(false) }
+
+        assertEmpty(errors)
+        assertNotEmpty(resolveResults.toList())
+    }
+
     private fun assertResolves(body: String) = assertNotEmpty(resolveInjected(body).toList())
 
     private fun assertDoesNotResolve(body: String) = assertEmpty(resolveInjected(body).toList())

--- a/tests/org/elixir_lang/reference/callable/UsingDestructuredBindingTest.kt
+++ b/tests/org/elixir_lang/reference/callable/UsingDestructuredBindingTest.kt
@@ -1,0 +1,90 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.ResolveResult
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * The two places `Using` reads a `__using__` body's value and used to stop at a container: a fragment in the list a
+ * `__using__` returns, and the value of a match that is the body's last statement.
+ */
+class UsingDestructuredBindingTest : PlatformTestCase() {
+    /** A fragment resolving to a name bound by destructuring, rather than by a bare `name = value`. */
+    fun testFragmentBoundByDestructuringResolves() = assertResolves(
+        "{imports, _} = {$QUOTE, :other}\n\n    [imports]"
+    )
+
+    /** The list of fragments a `__using__` already returns, so the test above is read as being about the binding. */
+    fun testFragmentBoundDirectlyResolves() = assertResolves("imports = $QUOTE\n\n    [imports]")
+
+    /** The body's last statement is a match whose value is the list of fragments, so the list has to be entered. */
+    fun testLastStatementMatchingAListResolves() = assertResolves("[x] = [$QUOTE]")
+
+    /**
+     * A fragment reached through the list a match binds resolves the same way as one reached through the list the body
+     * ends with - the parity the two branches claim.
+     */
+    fun testFragmentBoundInsideAMatchedListResolves() =
+        assertResolves("imports = $QUOTE\n\n    fragments = [imports]")
+
+    /**
+     * A two-element tuple is a quoted literal, so the compiler expands both elements and splices what they define,
+     * exactly as it does for a list. `{_x, _} = {quote ... end, :other}` really does define `injected/0` in the caller.
+     */
+    fun testLastStatementMatchingATwoTupleResolves() = assertResolves("{_x, _} = {$QUOTE, :other}")
+
+    /**
+     * Three elements is a call node, `{name, meta, args}`, and `:other` where the metadata belongs is not a valid
+     * quoted expression, so the caller gets a compile error rather than a definition.
+     */
+    fun testLastStatementMatchingAThreeTupleDoesNotResolve() =
+        assertDoesNotResolve("{_x, _, _} = {$QUOTE, :other, :another}")
+
+    /**
+     * Rebinding a name to a list holding itself is ordinary Elixir, and the returned `[[quote ... end]]` splices. This
+     * does not exercise the visited guard - the inner read resolves to the *earlier* binding, so the container is
+     * never re-entered - and is kept as a guard against that resolver rule changing, not as evidence for the walk.
+     */
+    fun testAListBoundToItselfTerminates() =
+        assertResolves("imports = $QUOTE\n\n    imports = [imports]\n\n    [imports]")
+
+    /**
+     * A nested container is an `accessExpression`, which `unmatchedExpressionList` omits, so reading the returned list
+     * any other way than a list reached as a value breaks the parity
+     * [testFragmentBoundInsideAMatchedListResolves] claims.
+     */
+    fun testNestedListOfFragmentsResolves() = assertResolves("[[$QUOTE]]")
+
+    /**
+     * The same tuple returned bare rather than through a match. Without a branch of its own it falls to the dispatch's
+     * `else`, which - the statements being in reverse - reads an earlier statement as the return value.
+     */
+    fun testLastStatementBareTwoTupleResolves() = assertResolves("{$QUOTE, :other}")
+
+    private fun assertResolves(body: String) = assertNotEmpty(resolveInjected(body).toList())
+
+    private fun assertDoesNotResolve(body: String) = assertEmpty(resolveInjected(body).toList())
+
+    /** Resolves `injected()` in a module that `use`s an injector whose `__using__` has [body]. */
+    private fun resolveInjected(body: String): Array<out ResolveResult> {
+        myFixture.configureByText(
+            "injector.ex",
+            "defmodule Injector do\n  defmacro __using__(_opts) do\n    $body\n  end\nend\n"
+        )
+        myFixture.configureByText(
+            "user.ex",
+            "defmodule User do\n  use Injector\n  def call, do: <caret>injected()\nend\n"
+        )
+        val reference = myFixture.file.findReferenceAt(myFixture.caretOffset)!! as PsiPolyVariantReference
+
+        val (resolveResults, errors) = captureLoggedErrors { reference.multiResolve(false) }
+
+        assertEmpty(errors)
+
+        return resolveResults
+    }
+
+    companion object {
+        private const val QUOTE = "quote do\n      def injected(), do: :ok\n    end"
+    }
+}


### PR DESCRIPTION
Fixes #4025.

`Unquote.treeWalkUpUnquotedVariable` climbs from an unquoted variable to the `=` that binds it, then follows the value so the definitions inside a quote are injected at the `unquote` site. It reassigned its element on every hop, so at the match it compared the whole left-hand pattern, and then handed the whole right-hand side to a value walk that only entered a `Call`. A quote destructured out of a tuple, list or map was reached and then dropped.

New `Destructure` threads the original declaration through the walk unchanged and pairs it with the value at its own position, descending both operands together — by index for a tuple or list, by key for a map, one level at a time, so nesting needs no separate handling. `Using` had the same blind spot twice over, resolving a returned fragment to its binding through a single parent hop and reading a match's value only when that value was a call; both now go through the same helper.

One shape-table column changes: `ElixirKeywordPair`'s `unquote` bucket goes from `STOP` to `RECURSE`, so a `%{key: name}` pattern reaches its match at all. Pairing is what makes that safe — a `do:` block reaches no match, and a pattern that cannot line up with its value now binds nothing rather than claiming the whole right-hand side.

`UnquoteDestructuredBindingTest` asserted only that no error was logged, so it stayed green whether or not the walk descended. It now asserts the reference resolves, and carries three controls that fail a fix which descends the value without pairing: a name bound beside the quote, a tuple of a different length, and a map key the value does not carry. Every positive test in both new classes fails against this branch's base; the controls pass.

Rebased onto `main` now that #4020 has merged, so the diff is only this change: two commits over eight files. Full suite green at 7479 tests.

