### PR TITLE
ci(qodana): run static analysis on pull requests

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -46,6 +46,14 @@ inputs:
     description: 'Remove Docker images during disk space cleanup. Set to false when later steps use Docker container actions.'
     required: false
     default: 'true'
+  cache-read-only:
+    description: |
+      Pass 'true' to restore the Gradle User Home cache without ever writing it. Worth setting for a
+      caller that resolves dependencies the rest of CI does not, so it cannot mint cache entries the
+      test matrix will never restore. The default reproduces gradle/actions' own expression, so a
+      caller that leaves this unset behaves exactly as before.
+    required: false
+    default: ${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}
   gradle-encryption-key:
     description: |
       Base64 AES key (`openssl rand -base64 16`, stored as the GRADLE_ENCRYPTION_KEY secret) without
@@ -157,14 +165,16 @@ runs:
     # provider deduplicates dependency entries across jobs, so it is one copy per IDE version and OS.
     # caches/*/transforms (the extracted IDE) is not deduplicated and restores no faster than
     # re-extracting, so it stays excluded. Excludes filter the Gradle User Home only; they cannot
-    # affect the configuration-cache data that cache-encryption-key covers. cache-read-only keeps
-    # its default (write from the default branch only): a pull request's writes are scoped to its
-    # merge ref and nothing else can restore them.
+    # affect the configuration-cache data that cache-encryption-key covers. cache-read-only defaults
+    # to gradle/actions' own rule (write from the default branch only), so a pull request's writes
+    # are scoped to its merge ref and nothing else can restore them; a caller that resolves
+    # dependencies the rest of CI does not can force it read-only.
     - name: Setup Gradle
       id: setup-gradle
       uses: gradle/actions/setup-gradle@v6
       with:
         cache-disabled: false
+        cache-read-only: ${{ inputs.cache-read-only }}
         # `caches/<gradle-version>/transforms` on Gradle 9, not `caches/transforms-*`.
         gradle-home-cache-excludes: |
           caches/*/transforms

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -58,6 +58,9 @@ jobs:
           # Qodana imports the Gradle project; it never runs the quoter, so the BEAM toolchain is
           # dead weight here.
           setup-elixir: 'false'
+          # Qodana's headless import resolves configurations the test matrix does not, so it must
+          # never write cache entries no other job can restore.
+          cache-read-only: 'true'
 
       - name: Qodana Scan
         id: qodana

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,0 +1,91 @@
+name: Qodana
+
+# Static analysis on pull requests. Two choices are load-bearing here:
+#
+#   1. Native mode (--within-docker false). The container form gives Qodana its own Gradle home, a
+#      second multi-GB copy of a tree CI already caches. This repository is over GitHub's 10 GB
+#      Actions cache quota, so that second copy would evict the test matrix's gradle-dependencies
+#      entries. Native mode reuses the Gradle home setup-env warms, and skips a 4.15 GB image pull.
+#      It requires qodana.yml's `linter:` to be a linter NAME - an image value takes a legacy code
+#      path that forces a container regardless of this flag.
+#   2. Advisory only. The project has ~1300 findings, so any absolute quality gate fails on day one
+#      and a permanently red check gets ignored. continue-on-error keeps the signal without the
+#      false alarm; add failThreshold or a baseline to qodana.yml when the numbers justify it.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # the action's PR summary comment
+  pull-requests: write
+  # inline annotations on the diff
+  checks: write
+  # SARIF upload to code scanning
+  security-events: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  qodana:
+    name: Qodana
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Qodana analyses the PR head rather than the merge commit, and pr-mode diffs against the
+          # base, so it needs the full history.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Build Environment
+        id: setup-env
+        uses: ./.github/actions/setup-env
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # Qodana imports the Gradle project; it never runs the quoter, so the BEAM toolchain is
+          # dead weight here.
+          setup-elixir: 'false'
+
+      - name: Qodana Scan
+        id: qodana
+        # Advisory: findings must never fail the check. See the header.
+        continue-on-error: true
+        uses: JetBrains/qodana-action@10be11607eb323a180e2b76b26c9c5cdceac3e77 # v2026.2.1
+        with:
+          args: "--linter qodana-jvm-community --within-docker false"
+          # Only the files the PR touches, which is the whole reason this is affordable per-PR.
+          pr-mode: true
+          # Deliberately off: Qodana's cache is multi-GB and the repository is already over the
+          # 10 GB Actions quota. The cost is re-downloading the IDE distribution each run.
+          use-caches: false
+          upload-result: true
+          artifact-name: qodana-report
+          post-pr-comment: true
+          use-annotations: true
+          push-fixes: 'none'
+
+      - name: Upload SARIF to code scanning
+        id: upload-sarif
+        # Attempted for fork PRs too, rather than skipped. upload-sarif is documented to reach an
+        # endpoint that does not require `security-events: write`, but that is not something this
+        # repository has exercised - so try the upload and let it fail harmlessly if the token is
+        # too weak, instead of guessing and reporting nothing.
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+          category: qodana

--- a/.qodana/qodana.profile.yaml
+++ b/.qodana/qodana.profile.yaml
@@ -1,0 +1,18 @@
+# Project inspection profile for Qodana.
+#
+# qodana.yml can enable an inspection but cannot configure one, and ThreadingConcurrency reports
+# nothing at all until its options are set - which is why a deliberately unannotated caller of a
+# @RequiresReadLock method passed CI while the IDE flagged it as an error. The options below match
+# .idea/inspectionProfiles/Project_Default.xml, which is gitignored and so was never shared with
+# CI or with other contributors.
+baseProfile: qodana.recommended
+
+inspections:
+  - inspection: ThreadingConcurrency
+    enabled: true
+    options:
+      requiresReadLockInsideRequiresEdt: true
+      requiresWriteLockInsideRequiresEdt: true
+      # The one that matters: off by default, and the only thing that reports a public method
+      # missing an annotation its callees require.
+      checkMissingAnnotations: true

--- a/qodana.yml
+++ b/qodana.yml
@@ -6,7 +6,7 @@ version: "1.0"
 linter: qodana-jvm-community
 projectJDK: "21"
 profile:
-  name: qodana.recommended
+  path: .qodana/qodana.profile.yaml
 # qodana.recommended disables every inspection outside a 23-category allowlist, and "Plugin DevKit"
 # is not on it - so the inspections that matter most for a plugin have to be named one by one.
 include:
@@ -22,6 +22,13 @@ include:
   - name: CancellationCheckInLoops
   - name: LightServiceMustBeFinal
   - name: NonDefaultConstructor
+  - name: ObsoleteDispatchersEdt
+  - name: CanBeDumbAware
+  - name: CallingMethodShouldBeRequiresBlockingContext
+  - name: ExtensionClassShouldBeFinalAndNonPublic
+  - name: OptionalDependencyViaDependsTag
+  - name: PathAnnotationInspection
+  - name: SerializableCtor
 exclude:
   - name: All
     paths:

--- a/qodana.yml
+++ b/qodana.yml
@@ -1,13 +1,31 @@
 # Qodana configuration:
 # https://www.jetbrains.com/help/qodana/qodana-yaml.html
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2026.2
+# Linter NAME, not a docker image: the image form is the pre-2025.2 legacy syntax and forces a
+# container, which would make CI unable to run in native mode.
+linter: qodana-jvm-community
 projectJDK: "21"
 profile:
   name: qodana.recommended
+# qodana.recommended disables every inspection outside a 23-category allowlist, and "Plugin DevKit"
+# is not on it - so the inspections that matter most for a plugin have to be named one by one.
+include:
+  - name: ThreadingConcurrency
+  - name: MissingRecentApi
+  - name: PluginXmlValidity
+  - name: IncorrectServiceRetrieving
+  - name: PotentialDeadlockInServiceInitialization
+  - name: IncorrectCancellationExceptionHandling
+  - name: ComponentNotRegistered
+  - name: IncorrectParentDisposable
+  - name: ApplicationServiceAsStaticFinalFieldOrProperty
+  - name: CancellationCheckInLoops
+  - name: LightServiceMustBeFinal
+  - name: NonDefaultConstructor
 exclude:
   - name: All
     paths:
       - .qodana
       - cache
       - testData
+      - gen


### PR DESCRIPTION
Adds a Qodana job on `pull_request`, plus the configuration that makes it report anything useful. All four changed files are configuration; no production code is touched.

### Native mode, not a container

`linter:` is a linter *name* rather than a docker image. The image form takes a legacy code path in the CLI (`GuessAnalyzerByLinterParam`) that returns a container analyzer before `--within-docker` is even read, so native mode is unreachable while an image value is set. That matters because a container gives Qodana its own multi-GB Gradle home — a second copy of a tree CI already caches — and this repository sits at roughly 10 GB against GitHub's 10 GB Actions cache quota, so the copy would evict the test matrix's `gradle-dependencies-v2` entries. Native mode instead reuses the Gradle home `setup-env` already warms, and skips a 4.15 GB image pull. Measured cost of a PR-scoped run: 8m57s end to end, of which 25s is downloading the IDE distribution.

`setup-env` gains a `cache-read-only` input so this job can never write cache entries the rest of CI would not restore. Its default reproduces `gradle/actions`' own expression, so the eleven existing callers behave exactly as before.

### Enabling DevKit is not enough; it has to be configured

`qodana.recommended` disables every inspection outside a 23-category allowlist, and "Plugin DevKit" is not on it, so every plugin-specific inspection was silently off. Naming them under `include:` fixes that — but an inspection can be enabled and still report nothing. `ThreadingConcurrency` needs `checkMissingAnnotations`, which is off by default, before it reports a public method whose callees require a read lock. Verified against a deliberately unannotated caller: with the inspection merely enabled, CI reported only the orphaned import; with the option set, it reports `Threading and concurrency problems — Critical`.

`qodana.yml` can enable an inspection but cannot configure one, so the options move into `.qodana/qodana.profile.yaml`, which inherits `qodana.recommended` and therefore keeps the category allowlist intact. They previously lived only in a gitignored `.idea` profile, so neither CI nor any other contributor ever had them.

An audit of DevKit's 108 inspection registrations found 11 that ship `enabledByDefault="false"`. Seven that apply to this plugin are now enabled: `ObsoleteDispatchersEdt`, `CanBeDumbAware`, `CallingMethodShouldBeRequiresBlockingContext`, `ExtensionClassShouldBeFinalAndNonPublic`, `OptionalDependencyViaDependsTag`, `PathAnnotationInspection`, `SerializableCtor`. `StatisticsCollectorNotRegistered` is left out as it targets JetBrains' internal FUS collectors.

### Job shape

Advisory only — `continue-on-error`, so findings never fail the check. A full-project run currently reports 1105 problems, so any absolute gate would fail on day one and be ignored within a week; a baseline or `failThreshold` is the right way to add teeth later. `pr-mode: true` limits each run to the files the PR touches. Results go to code scanning, PR annotations, and a `qodana-report` artifact.

The SARIF upload runs with `continue-on-error` rather than being skipped for forks. That was a deliberate experiment and it succeeded: this PR is from a fork with a read-only token, and the upload still produced a code scanning analysis against `refs/pull/4033/head`. Qodana's own PR comment and inline annotations remain unavailable on fork PRs, as their token cannot write checks or pull requests.

### Known gaps

A full-project scan on `main` would create roughly 1105 code scanning alerts in one go. Nothing here triggers that — the workflow runs on `pull_request` only, with no `push` or schedule — but it is worth a deliberate decision before adding either.

The seven newly enabled inspections have not been run against the whole tree; `pr-mode` only ever shows the diff. The last full-project run predates them and found 18 `PluginXmlValidity` (Critical) and 11 `CancellationCheckInLoops` findings, none of which are addressed here.