### PR TITLE
Bump the minimum supported IDE from 2025.3 (253) to 2026.1 (build 261)

### DIFF
--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -39,10 +39,9 @@
     "    backlog."
   ],
   "idea": {
-    "minimumSupported": { "version": "2025.3.6", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
+    "minimumSupported": { "version": "2026.1.5", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
     "additionalToTest": [
-      { "version": "2026.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] },
-      { "version": "2026.1.4", "java": "21", "verify": [ "ideaIU", "rubymine" ] }
+      { "version": "2026.2.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] }
     ]
   },
   "beam": {

--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -41,7 +41,7 @@
   "idea": {
     "minimumSupported": { "version": "2026.1.5", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
     "additionalToTest": [
-      { "version": "2026.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] }
+      { "version": "2026.2.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] }
     ]
   },
   "beam": {

--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -41,7 +41,7 @@
   "idea": {
     "minimumSupported": { "version": "2026.1.5", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
     "additionalToTest": [
-      { "version": "2026.2.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] }
+      { "version": "2026.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] }
     ]
   },
   "beam": {

--- a/.github/internal-api-usages-allowlist.txt
+++ b/.github/internal-api-usages-allowlist.txt
@@ -25,8 +25,8 @@ Internal class com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl
 Internal method com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl.setCodeInsightContext(com.intellij.psi.FileViewProvider, com.intellij.codeInsight.multiverse.CodeInsightContext) : void is invoked in org.elixir_lang.beam.psi.BeamFileImpl.propagateCodeInsightContextTo(PsiFile) : void
 
 # --- Awaiting the JPS project model before changing module or SDK configuration --------------------
-# The replacement is itself internal and absent from build 253, so migrating would relocate the finding,
-# not remove it. Five entries for one call site: a Kotlin Companion access compiles to a field read, an
+# The replacement is itself internal, so migrating would relocate the finding, not remove it. Five
+# entries for one call site: a Kotlin Companion access compiles to a field read, an
 # interface reference and the call. Watch IJPL-249625 and IJPL-241069; see the KDoc on
 # awaitJpsProjectLoaded, the single place to change.
 Internal interface com.intellij.workspaceModel.ide.JpsProjectLoadingManager is referenced in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object

--- a/.github/workflows/shared-verify.yml
+++ b/.github/workflows/shared-verify.yml
@@ -41,7 +41,7 @@ on:
           - mps
         default: ideaIU
       version:
-        description: 'Marketing version, e.g. 2026.2 or 2025.3.6.'
+        description: 'Marketing version, e.g. 2026.2 or 2026.1.5.'
         required: true
         type: string
       plugin:
@@ -167,8 +167,8 @@ jobs:
   verify:
     # The word `verify` is deliberately absent: the check name for a reusable workflow is
     # `<caller job name> / <callee job name>`, the caller job has no name: so its id `verify` is used,
-    # and the checks graph truncates around 24-27 characters - `verify / verify (ideaIU, 2025...` spent
-    # its whole budget saying verify twice. `verify / ideaIU 2025.3.6` fits.
+    # and the checks graph truncates around 24-27 characters - `verify / verify (ideaIU, 2026...` spent
+    # its whole budget saying verify twice. `verify / ideaIU 2026.1.5` fits.
     name: ${{ matrix.product }} ${{ matrix.version }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Breaking changes
 
+- **The minimum supported IDE is now 2026.1 (build 261.22158.277), raised from 2025.3.** The plugin
+  ships against 2026.1.5 and supports 2026.1 through 2026.2. Update to a 2026.1 or newer IDE to keep
+  receiving plugin updates.
+
+  > 2026.1 was released in March 2026, 2026.2 was released in July 2026.
+
+  This allows us to integrate with Mise plugin directly for example, which is only available in 2026.1 (261) and later.
+
 ### Enhancements
 
 - [#3983](https://github.com/KronicDeth/intellij-elixir/pull/3983) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,6 +325,14 @@
 
 ### Build / CI
 
+- [#4034](https://github.com/KronicDeth/intellij-elixir/pull/4034) [@sh41](https://github.com/sh41)
+  - **The test matrix runs against 2026.2.2 again, with `com.intellij.modules.ultimate` off the test
+    classpath.** In IU-262.10315.125 that bundled plugin's classes are obfuscated into a package
+    `lib/product-backend.jar` already occupies, and a test classpath is flat, so its
+    `postStartupActivity` resolved to an unrelated interface and every test that opened a project
+    failed. Obfuscated names are re-rolled per build, so the exclusion is permanent rather than
+    version-gated.
+
 - [#4006](https://github.com/KronicDeth/intellij-elixir/pull/4006) [@sh41](https://github.com/sh41)
   - **CI is faster: Gradle's build and configuration caches are kept, Elixir is no longer rebuilt from
     source on the Windows leg, and the runners no longer reclaim disk space they were not short of.**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ val actualPlatformVersion: String = if (useDynamicEapVersion) {
     project.property("platformVersion").toString()
 }
 
-// IntelliJ Platform 262 (2026.2) ships JARs compiled for Java 25, and 253/261 are Java 21.
+// IntelliJ Platform 262 (2026.2) ships JARs compiled for Java 25, and 261 is Java 21.
 // `javac --release` validates the class-file version of everything on the compile classpath,
 // so the Java level must follow the platform being built against -- a fixed level cannot
 // serve both 261 and 262.
@@ -156,7 +156,7 @@ val platformBuildNumber: Int = actualPlatformVersion
     .let { parts ->
         val major = parts[0].toIntOrNull() ?: 0
         when {
-            // Marketing version, e.g. "2026.2" or "2025.3.6" -> 262, 253
+            // Marketing version, e.g. "2026.2" or "2026.1.5" -> 262, 261
             major >= 2000 -> (major - 2000) * 10 + (parts.getOrNull(1)?.toIntOrNull() ?: 0)
             // Already a build number, e.g. "262.8665.258"
             else -> major
@@ -644,10 +644,10 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget = JvmTarget.valueOf("JVM_$javaVersionStr")
         freeCompilerArgs.add("-jvm-default=enable")
-        // Restricts stdlib references to what 2025.3 (minimumSupported) bundles, independent of
+        // Restricts stdlib references to what 2026.1 (minimumSupported) bundles, independent of
         // the newer compiler in gradle/libs.versions.toml's kotlin entry. Doesn't cover
         // jps-shared - a separate project, its own tasks.withType block needed there too.
-        apiVersion = KotlinVersion.KOTLIN_2_2
+        apiVersion = KotlinVersion.KOTLIN_2_3
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -127,6 +127,13 @@ ideaAutoReload=false
 #   org.jetbrains.plugins.docker.gateway - SLF4J provider fails to instantiate in headless JVM
 #   com.intellij.platform.daemon        - competing SLF4J provider (Slf4jToDaemonServiceProvider)
 #   JavaScript                          - JSPluginPathManager cannot find jsLanguageServicesImpl resources
+# The last one is the only ERROR-level exclusion, and the only one that changes test results:
+#   com.intellij.modules.ultimate  - obfuscated to a package lib/product-backend.jar already occupies
+# A test classpath is flat, with no per-plugin classloader, so on IU-262.10315.125 that plugin's
+# postStartupActivity resolves to an unrelated interface in product-backend.jar and every project open
+# fails. Obfuscated names are re-rolled per build (262.8665.258 and 262.9437.185 do not collide), so the
+# exclusion is permanent rather than version-gated. Nothing here depends on Ultimate: the plugin ships one
+# licensing activity, and this plugin's plugin.xml declares no Ultimate module.
 org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes=\
   com.intellij.openRewrite,\
   com.intellij.ja,\
@@ -137,7 +144,8 @@ org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes=\
   com.jetbrains.remoteDevelopment,\
   org.jetbrains.plugins.docker.gateway,\
   com.intellij.platform.daemon,\
-  JavaScript
+  JavaScript,\
+  com.intellij.modules.ultimate
 
 # --- Gradle Performance & Memory ---
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion=25.0.0
 pluginRepositoryUrl=https://github.com/KronicDeth/intellij-elixir/
 vendorName=Kadie Enheduanna Inanna
 vendorEmail=Kronic.Deth@gmail.com
-pluginSinceBuild=253.28294.1
+pluginSinceBuild=261.22158.277
 publishChannels=canary
 
 # --- Changelog ---
@@ -40,21 +40,21 @@ platformType=IU
 # pluginSinceBuild below), not the newest - buildPlugin takes no -PplatformVersion override, so
 # whatever this is set to is what actually ships. Override per-invocation for local dev against a
 # newer IDE (-PplatformVersion=<version>).
-platformVersion=2025.3.6
+platformVersion=2026.1.5
 # Enable this to pull in the latest EAP version.
 useDynamicEapVersion=false
 
 # --- IDE Run Configuration Versions ---
 enableEAPIDEs=true
 
-# Stable Versions (2025.3)
-platformVersionIntellijIdea=2026.1.4
-platformVersionRubyMine=2026.1.4
-platformVersionPyCharm=2026.1.4
-platformVersionWebStorm=2026.1.4
+# Stable Versions (2026.1)
+platformVersionIntellijIdea=2026.1.5
+platformVersionRubyMine=2026.1.5
+platformVersionPyCharm=2026.1.5
+platformVersionWebStorm=2026.1.5
 platformVersionRustRover=2026.1.1
 platformVersionCLion=2026.1.1
-platformVersionGoLand=2026.1.4
+platformVersionGoLand=2026.1.5
 platformVersionPhpStorm=2026.1.1
 
 # EAP Versions
@@ -70,7 +70,7 @@ platformVersionPhpStormEAP=262-EAP-SNAPSHOT
 # --- Plugin Verification ---
 # Comma-separated list of IDE types to verify against
 pluginVerifierIdeTypes=IntellijIdea,PyCharm,RubyMine,WebStorm
-pluginVerifierVersion=2025.3.6
+pluginVerifierVersion=2026.1.5
 pluginVerifierChannels=RELEASE,EAP,RC,PREVIEW
 
 # --- Tooling Versions ---

--- a/jps-shared/build.gradle.kts
+++ b/jps-shared/build.gradle.kts
@@ -14,11 +14,11 @@ tasks.testClasses {
     enabled = false
 }
 
-// Restricts stdlib references to what 2025.3 (minimumSupported) bundles - the root project's
+// Restricts stdlib references to what 2026.1 (minimumSupported) bundles - the root project's
 // own copy of this (build.gradle.kts) doesn't reach this separate project.
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
-        apiVersion = KotlinVersion.KOTLIN_2_2
+        apiVersion = KotlinVersion.KOTLIN_2_3
     }
 }
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <vendor email="Kronic.Deth@gmail.com">Kadie Enheduanna Inanna</vendor>
 
     <!-- please see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html for description -->
-    <idea-version since-build="253.28294.1"/>
+    <idea-version since-build="261.22158.277"/>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->

--- a/src/org/elixir_lang/debugger/Runner.kt
+++ b/src/org/elixir_lang/debugger/Runner.kt
@@ -30,18 +30,17 @@ import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 
 class Runner : GenericProgramRunner<RunnerSettings>() {
-    override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor =
+    override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor? =
             XDebuggerManager
                     .getInstance(environment.project)
-                    // Keep startSession() for 253 compatibility; XDebugSessionBuilder is not
-                    // available across our supported baseline yet.
-                    .startSession(
-                            environment,
+                    .newSessionBuilder(
                             object : XDebugProcessStarter() {
                                 override fun start(session: XDebugSession): com.intellij.xdebugger.XDebugProcess =
                                         Process(session, environment)
                             }
                     )
+                    .environment(environment)
+                    .startSession()
                     .runContentDescriptor
 
     override fun getRunnerId(): String = ELIXIR_DEBUG_RUNNER_ID

--- a/src/org/elixir_lang/distillery/State.kt
+++ b/src/org/elixir_lang/distillery/State.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.terminal.TerminalExecutionConsoleBuilder
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.ElixirProcessHandler
 import org.elixir_lang.run.WslSafeCommandLineState
@@ -22,9 +22,8 @@ class State(environment: ExecutionEnvironment, configuration: Configuration) :
 
         return if (configuration.pty) {
             val processHandler = startProcess()
-            // Keep direct TerminalExecutionConsole constructor for 253 compatibility;
-            // TerminalExecutionConsoleBuilder is not available across our supported baseline yet.
-            val console = TerminalExecutionConsole(project, processHandler)
+            val console = TerminalExecutionConsoleBuilder(project).build()
+            console.attachToProcess(processHandler)
             processHandler.startNotify()
 
             DefaultExecutionResult(console, processHandler)

--- a/src/org/elixir_lang/formatter/settings/LanguageCodeStyleSettingsProvider.kt
+++ b/src/org/elixir_lang/formatter/settings/LanguageCodeStyleSettingsProvider.kt
@@ -5,7 +5,6 @@ import com.intellij.application.options.CodeStyleAbstractPanel
 import com.intellij.application.options.IndentOptionsEditor
 import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.lang.Language
-import com.intellij.openapi.util.BuildNumber
 import com.intellij.psi.codeStyle.*
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.*

--- a/src/org/elixir_lang/iex/State.kt
+++ b/src/org/elixir_lang/iex/State.kt
@@ -7,7 +7,7 @@ import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.terminal.TerminalExecutionConsoleBuilder
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.WslSafeCommandLineState
 
@@ -18,9 +18,8 @@ class State(environment: ExecutionEnvironment, configuration: Configuration) :
         val project = configuration.project
 
         val processHandler = startProcess()
-        // Keep direct TerminalExecutionConsole constructor for 253 compatibility;
-        // TerminalExecutionConsoleBuilder is not available across our supported baseline yet.
-        val console = TerminalExecutionConsole(project, processHandler)
+        val console = TerminalExecutionConsoleBuilder(project).build()
+        console.attachToProcess(processHandler)
         processHandler.startNotify()
 
         return DefaultExecutionResult(console, processHandler)

--- a/src/org/elixir_lang/iex/mix/State.kt
+++ b/src/org/elixir_lang/iex/mix/State.kt
@@ -7,7 +7,7 @@ import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.terminal.TerminalExecutionConsoleBuilder
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.WslSafeCommandLineState
 
@@ -18,9 +18,8 @@ class State(environment: ExecutionEnvironment, configuration: Configuration) :
         val project = configuration.project
 
         val processHandler = startProcess()
-        // Keep direct TerminalExecutionConsole constructor for 253 compatibility;
-        // TerminalExecutionConsoleBuilder is not available across our supported baseline yet.
-        val console = TerminalExecutionConsole(project, processHandler)
+        val console = TerminalExecutionConsoleBuilder(project).build()
+        console.attachToProcess(processHandler)
         processHandler.startNotify()
 
         return DefaultExecutionResult(console, processHandler)

--- a/src/org/elixir_lang/mix/project/OpenProcessor.kt
+++ b/src/org/elixir_lang/mix/project/OpenProcessor.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.mix.project
 
 import com.intellij.ide.util.projectWizard.WizardContext
-import com.intellij.openapi.application.EDT
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.coroutineToIndicator
 import com.intellij.openapi.vfs.VirtualFile
@@ -51,13 +50,11 @@ class OpenProcessor : ProjectOpenProcessorBase<Builder>() {
         // Store pre-scanned results in the builder
         builder.setPreScannedApps(projectRoot, foundApps)
 
-        // Ensure EDT context for runBlockingModalWithRawProgressReporter in IntelliJ 2025.3
-        // We need .EDT here..
-        // See: https://github.com/JetBrains/intellij-community/commit/59da423bd3fef56a7929838fb9bfeee5beae8785
-        @Suppress("ObsoleteDispatchersEdt")
-        return withContext(Dispatchers.EDT) {
-            super.openProjectAsync(virtualFile, projectToClose, forceOpenInNewFrame)
-        }
+        // The platform's ProjectOpenProcessorBase.openProjectAsync dispatches to the EDT itself on
+        // 2026.1+ (it wraps its EDT-bound work in withContext(Dispatchers.EDT) and uses
+        // withRawProgressReporter), so the old caller-side EDT hop for 2025.3's
+        // runBlockingModalWithRawProgressReporter is no longer needed.
+        return super.openProjectAsync(virtualFile, projectToClose, forceOpenInNewFrame)
     }
 
     override fun doQuickImport(file: VirtualFile, wizardContext: WizardContext): Boolean {

--- a/tests/org/elixir_lang/sdk/erlang/TypeSourcePathsTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang/TypeSourcePathsTest.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.sdk.erlang
 
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.io.File
 
@@ -45,7 +46,7 @@ class TypeSourcePathsTest : BasePlatformTestCase() {
 
     /** A home with no `lib` at all is not an error - an SDK can be pointed anywhere. */
     fun testTakesNothingFromAHomeWithoutLib() {
-        val home = createTempDir("erlang-home-empty").absolutePath
+        val home = FileUtil.createTempDirectory("erlang-home-empty", null).absolutePath
 
         assertEmpty(Type.sourcePaths(home))
     }
@@ -55,7 +56,7 @@ class TypeSourcePathsTest : BasePlatformTestCase() {
      * `src` beside its `ebin`.
      */
     private fun erlangHome(vararg applications: Pair<String, Boolean>): String {
-        val home = createTempDir("erlang-home")
+        val home = FileUtil.createTempDirectory("erlang-home", null)
 
         for ((application, hasSrc) in applications) {
             val applicationDirectory = File(home, "lib${File.separator}$application")


### PR DESCRIPTION
Fixes #4032.

Bumps the plugin's minimum version from 2025.3 (253.x) to 2026.1 (261.x).

As discussed, I believe 2026.1 is a good move, as it unblocks the work we want to do that needs 261.x, without also needing to bump the JDK to 25.

### What changed

Version pins:

- `pluginSinceBuild` and plugin.xml `since-build` -> `261.22158.277` (IntelliJ IDEA's 2026.1 GA build; `until-build` stays open-ended).
- `platformVersion` and `pluginVerifierVersion` -> `2026.1.5` (newest 2026.1 patch). `platformVersion` tracks the newest patch of the minimum line and is what actually ships; `since-build` is the GA build, so the plugin still installs on any 2026.1.x.
- Kotlin `apiVersion` stays `KOTLIN_2_2`; the Java level stays 21.

CI matrix (`.github/ci-versions.json`):

Dropping the 253 minimum version also now lets four 2025.3-only compatibility shims go (yay).

Each replacement was checked against both 2026.1 GA and 2026.2 source before switching, and confirmed to exist as far back as the `idea/2026.1` GA tag, so a GA `since-build` is safe:

- `TerminalExecutionConsole(project, handler)` (deprecated in 261) -> `TerminalExecutionConsoleBuilder(project).build()` + `attachToProcess(handler)`, in the distillery, `iex` and `iex/mix` run states. Platform source (261.27258): [deprecated ctor](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution-impl/src/com/intellij/terminal/TerminalExecutionConsole.java#L91), [`TerminalExecutionConsoleBuilder`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution-impl/src/com/intellij/terminal/TerminalExecutionConsoleBuilder.kt#L8), [`attachToProcess`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution-impl/src/com/intellij/terminal/TerminalExecutionConsole.java#L340).
- `XDebuggerManager.startSession(env, starter)` (deprecated in 261) -> `newSessionBuilder(starter).environment(env).startSession()`. The debug runner's `doExecute` return is now nullable to match the platform's (`GenericProgramRunner.doExecute` is nullable). Platform source (261.27258): [deprecated `startSession`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/xdebugger-api/src/com/intellij/xdebugger/XDebuggerManager.java#L66), [`newSessionBuilder`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/xdebugger-api/src/com/intellij/xdebugger/XDebuggerManager.java#L54), [`XDebugSessionBuilder`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/xdebugger-api/src/com/intellij/xdebugger/XDebugSessionBuilder.kt#L32), [`GenericProgramRunner.doExecute`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution/src/com/intellij/execution/runners/GenericProgramRunner.kt#L29).
- The caller-side `withContext(Dispatchers.EDT)` hop in the Mix `OpenProcessor`, which is no longer needed: the platform's `ProjectOpenProcessorBase.openProjectAsync` dispatches to the EDT itself on 261+ (it wraps its EDT-bound work and uses `withRawProgressReporter`, not the old `runBlockingModalWithRawProgressReporter`). Platform source (261.27258): [`openProjectAsync`](https://github.com/JetBrains/intellij-community/blob/261.27258/java/idea-ui/src/com/intellij/projectImport/ProjectOpenProcessorBase.kt#L82), [`withRawProgressReporter`](https://github.com/JetBrains/intellij-community/blob/261.27258/java/idea-ui/src/com/intellij/projectImport/ProjectOpenProcessorBase.kt#L164).
- An unused `BuildNumber` import in the formatter settings provider.