### PR TITLE
Bump the minimum supported IDE from 2025.3 to 2026.1

### DIFF
--- a/.github/ci-versions.json
+++ b/.github/ci-versions.json
@@ -39,10 +39,9 @@
     "    backlog."
   ],
   "idea": {
-    "minimumSupported": { "version": "2025.3.6", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
+    "minimumSupported": { "version": "2026.1.5", "java": "21", "verify": [ "ideaIU", "rubymine" ] },
     "additionalToTest": [
-      { "version": "2026.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] },
-      { "version": "2026.1.4", "java": "21", "verify": [ "ideaIU", "rubymine" ] }
+      { "version": "2026.2.2", "java": "25", "verify": [ "ideaIU", "rubymine" ] }
     ]
   },
   "beam": {

--- a/.github/internal-api-usages-allowlist.txt
+++ b/.github/internal-api-usages-allowlist.txt
@@ -25,8 +25,8 @@ Internal class com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl
 Internal method com.intellij.codeInsight.multiverse.CodeInsightContextManagerImpl.setCodeInsightContext(com.intellij.psi.FileViewProvider, com.intellij.codeInsight.multiverse.CodeInsightContext) : void is invoked in org.elixir_lang.beam.psi.BeamFileImpl.propagateCodeInsightContextTo(PsiFile) : void
 
 # --- Awaiting the JPS project model before changing module or SDK configuration --------------------
-# The replacement is itself internal and absent from build 253, so migrating would relocate the finding,
-# not remove it. Five entries for one call site: a Kotlin Companion access compiles to a field read, an
+# The replacement is itself internal, so migrating would relocate the finding, not remove it. Five
+# entries for one call site: a Kotlin Companion access compiles to a field read, an
 # interface reference and the call. Watch IJPL-249625 and IJPL-241069; see the KDoc on
 # awaitJpsProjectLoaded, the single place to change.
 Internal interface com.intellij.workspaceModel.ide.JpsProjectLoadingManager is referenced in org.elixir_lang.util.JpsProjectModelKt.awaitJpsProjectLoaded(Project, Continuation) : Object

--- a/.github/workflows/shared-verify.yml
+++ b/.github/workflows/shared-verify.yml
@@ -41,7 +41,7 @@ on:
           - mps
         default: ideaIU
       version:
-        description: 'Marketing version, e.g. 2026.2 or 2025.3.6.'
+        description: 'Marketing version, e.g. 2026.2 or 2026.1.5.'
         required: true
         type: string
       plugin:
@@ -167,8 +167,8 @@ jobs:
   verify:
     # The word `verify` is deliberately absent: the check name for a reusable workflow is
     # `<caller job name> / <callee job name>`, the caller job has no name: so its id `verify` is used,
-    # and the checks graph truncates around 24-27 characters - `verify / verify (ideaIU, 2025...` spent
-    # its whole budget saying verify twice. `verify / ideaIU 2025.3.6` fits.
+    # and the checks graph truncates around 24-27 characters - `verify / verify (ideaIU, 2026...` spent
+    # its whole budget saying verify twice. `verify / ideaIU 2026.1.5` fits.
     name: ${{ matrix.product }} ${{ matrix.version }}
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Breaking changes
 
+- **The minimum supported IDE is now 2026.1 (build 261.22158.277), raised from 2025.3.** The plugin
+  ships against 2026.1.5 and supports 2026.1 through 2026.2. Update to a 2026.1 or newer IDE to keep
+  receiving plugin updates.
+
+  > 2026.1 was released in March 2026, 2026.2 was released in July 2026.
+
+  This allows us to integrate with Mise plugin directly for example, which is only available in 2026.1 (261) and later.
+
 ### Enhancements
 
 - [#3983](https://github.com/KronicDeth/intellij-elixir/pull/3983) [@sh41](https://github.com/sh41)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ### Breaking changes
 
-- **The minimum supported IDE is now 2026.1 (build 261.22158.277), raised from 2025.3.** The plugin
-  ships against 2026.1.5 and supports 2026.1 through 2026.2. Update to a 2026.1 or newer IDE to keep
-  receiving plugin updates.
+- [#4038](https://github.com/KronicDeth/intellij-elixir/pull/4038) [@joshuataylor](https://github.com/joshuataylor)
+  - **The minimum supported IDE is now 2026.1 (build 261.22158.277), raised from 2025.3.** The plugin
+    ships against 2026.1.5 and supports 2026.1 through 2026.2. Update to a 2026.1 or newer IDE to keep
+    receiving plugin updates.
 
-  > 2026.1 was released in March 2026, 2026.2 was released in July 2026.
+    > 2026.1 was released in March 2026, 2026.2 was released in July 2026.
 
-  This allows us to integrate with Mise plugin directly for example, which is only available in 2026.1 (261) and later.
+    This allows us to integrate with Mise plugin directly for example, which is only available in 2026.1 (261) and later.
 
 ### Enhancements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ listed above yourself.
 - **Erlang/OTP** and **Elixir**: **required for running tests** (not just building), at the versions
   [above](#elixir-and-erlang). Install both with `mise install`, or install them yourself and put
   `erl`/`erl.exe` and `elixir` on `PATH`, or point `ERLANG_SDK_HOME`/`ELIXIR_SDK_HOME` at them.
-- **JetBrains Runtime**: **21** for IDEA 2025.3 and 2026.1, **25** for 2026.2 and later.
+- **JetBrains Runtime**: **21** for IDEA 2026.1, **25** for 2026.2 and later.
   `build.gradle.kts` picks the bytecode level from the platform build number (262+ → 25), and
   `javac --release` validates the platform JARs against it, so the wrong JDK fails the compile rather
   than producing a bad build. `mise install` provisions the pinned JBR.
@@ -375,6 +375,11 @@ JBR level each needs and the products to verify them against) and the Elixir/OTP
 Edit that one file to add or bump a version: the test legs, the plugin verifier's IDE lists, and the
 release build's default platform are all derived from it.
 
+Three places in this document quote that data rather than deriving it - the JBR levels under
+[Windows Development Setup](#prerequisites), and the worked check names under
+[Reading a leg in the checks list](#reading-a-leg-in-the-checks-list). Nothing keeps them in sync, so
+update them in the same commit as `.github/ci-versions.json`.
+
 Tests always run against IntelliJ IDEA. The legs are every declared IDEA version on Ubuntu with
 `beam.baseline`, plus one leg per `beam.additional` pair on the minimum supported IDEA, plus
 `beam.baseline` on Windows.
@@ -433,14 +438,14 @@ the phase it died in, so you can tell those apart.
 ##### Reading a leg in the checks list
 
 Each leg is named after the axis its group varies, so the part that distinguishes it survives the
-checks list's truncation: `test (IDEA 2026.2)`, `test (1.19.5+28.1)` (Elixir + OTP),
-`test (Win25, IDEA 2025.3.6)`. The same name is used for the leg's `Test Results (...)` check, so a
+checks list's truncation: `test (IDEA 2026.2.2)`, `test (1.19.5+28.4)` (Elixir + OTP),
+`test (Win25, IDEA 2026.1.5)`. The same name is used for the leg's `Test Results (...)` check, so a
 row in one list maps to the other without translating.
 
 A leg that stopped **before its tests ran** says so in the name:
 
 ```
-Test Results (1.19.5+28.1, INCOMPLETE - failed at compile)
+Test Results (1.19.5+28.4, INCOMPLETE - failed at compile)
 ```
 
 That matters because the check's own title only ever describes the result files it found - a leg that

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ val actualPlatformVersion: String = if (useDynamicEapVersion) {
     project.property("platformVersion").toString()
 }
 
-// IntelliJ Platform 262 (2026.2) ships JARs compiled for Java 25, and 253/261 are Java 21.
+// IntelliJ Platform 262 (2026.2) ships JARs compiled for Java 25, and 261 is Java 21.
 // `javac --release` validates the class-file version of everything on the compile classpath,
 // so the Java level must follow the platform being built against -- a fixed level cannot
 // serve both 261 and 262.
@@ -156,7 +156,7 @@ val platformBuildNumber: Int = actualPlatformVersion
     .let { parts ->
         val major = parts[0].toIntOrNull() ?: 0
         when {
-            // Marketing version, e.g. "2026.2" or "2025.3.6" -> 262, 253
+            // Marketing version, e.g. "2026.2" or "2026.1.5" -> 262, 261
             major >= 2000 -> (major - 2000) * 10 + (parts.getOrNull(1)?.toIntOrNull() ?: 0)
             // Already a build number, e.g. "262.8665.258"
             else -> major
@@ -644,10 +644,10 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget = JvmTarget.valueOf("JVM_$javaVersionStr")
         freeCompilerArgs.add("-jvm-default=enable")
-        // Restricts stdlib references to what 2025.3 (minimumSupported) bundles, independent of
+        // Restricts stdlib references to what 2026.1 (minimumSupported) bundles, independent of
         // the newer compiler in gradle/libs.versions.toml's kotlin entry. Doesn't cover
         // jps-shared - a separate project, its own tasks.withType block needed there too.
-        apiVersion = KotlinVersion.KOTLIN_2_2
+        apiVersion = KotlinVersion.KOTLIN_2_3
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -127,6 +127,13 @@ ideaAutoReload=false
 #   org.jetbrains.plugins.docker.gateway - SLF4J provider fails to instantiate in headless JVM
 #   com.intellij.platform.daemon        - competing SLF4J provider (Slf4jToDaemonServiceProvider)
 #   JavaScript                          - JSPluginPathManager cannot find jsLanguageServicesImpl resources
+# The last one is the only ERROR-level exclusion, and the only one that changes test results:
+#   com.intellij.modules.ultimate  - obfuscated to a package lib/product-backend.jar already occupies
+# A test classpath is flat, with no per-plugin classloader, so on IU-262.10315.125 that plugin's
+# postStartupActivity resolves to an unrelated interface in product-backend.jar and every project open
+# fails. Obfuscated names are re-rolled per build (262.8665.258 and 262.9437.185 do not collide), so the
+# exclusion is permanent rather than version-gated. Nothing here depends on Ultimate: the plugin ships one
+# licensing activity, and this plugin's plugin.xml declares no Ultimate module.
 org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes=\
   com.intellij.openRewrite,\
   com.intellij.ja,\
@@ -137,7 +144,8 @@ org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes=\
   com.jetbrains.remoteDevelopment,\
   org.jetbrains.plugins.docker.gateway,\
   com.intellij.platform.daemon,\
-  JavaScript
+  JavaScript,\
+  com.intellij.modules.ultimate
 
 # --- Gradle Performance & Memory ---
 org.gradle.jvmargs=-Xmx4096m

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion=25.0.0
 pluginRepositoryUrl=https://github.com/KronicDeth/intellij-elixir/
 vendorName=Kadie Enheduanna Inanna
 vendorEmail=Kronic.Deth@gmail.com
-pluginSinceBuild=253.28294.1
+pluginSinceBuild=261.22158.277
 publishChannels=canary
 
 # --- Changelog ---
@@ -40,21 +40,21 @@ platformType=IU
 # pluginSinceBuild below), not the newest - buildPlugin takes no -PplatformVersion override, so
 # whatever this is set to is what actually ships. Override per-invocation for local dev against a
 # newer IDE (-PplatformVersion=<version>).
-platformVersion=2025.3.6
+platformVersion=2026.1.5
 # Enable this to pull in the latest EAP version.
 useDynamicEapVersion=false
 
 # --- IDE Run Configuration Versions ---
 enableEAPIDEs=true
 
-# Stable Versions (2025.3)
-platformVersionIntellijIdea=2026.1.4
-platformVersionRubyMine=2026.1.4
-platformVersionPyCharm=2026.1.4
-platformVersionWebStorm=2026.1.4
+# Stable Versions (2026.1)
+platformVersionIntellijIdea=2026.1.5
+platformVersionRubyMine=2026.1.5
+platformVersionPyCharm=2026.1.5
+platformVersionWebStorm=2026.1.5
 platformVersionRustRover=2026.1.1
 platformVersionCLion=2026.1.1
-platformVersionGoLand=2026.1.4
+platformVersionGoLand=2026.1.5
 platformVersionPhpStorm=2026.1.1
 
 # EAP Versions
@@ -70,7 +70,7 @@ platformVersionPhpStormEAP=262-EAP-SNAPSHOT
 # --- Plugin Verification ---
 # Comma-separated list of IDE types to verify against
 pluginVerifierIdeTypes=IntellijIdea,PyCharm,RubyMine,WebStorm
-pluginVerifierVersion=2025.3.6
+pluginVerifierVersion=2026.1.5
 pluginVerifierChannels=RELEASE,EAP,RC,PREVIEW
 
 # --- Tooling Versions ---

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,8 @@
 # minimumSupported floor - this compiler must be able to emit whatever JVM bytecode target the
 # newest tested platform needs (compileKotlin's javaVersionStr can reach "25", and
 # JvmTarget.JVM_25 doesn't exist before Kotlin 2.3.20). Stdlib compliance with the floor is a
-# separate concern, held by apiVersion = KotlinVersion.KOTLIN_2_2 in build.gradle.kts (and
-# jps-shared's own copy of it), independent of which compiler/stdlib artifact this pin resolves.
+# separate concern, held by the apiVersion pin in build.gradle.kts (and jps-shared's own copy of
+# it), independent of which compiler/stdlib artifact this pin resolves.
 # kotlin.stdlib.default.dependency = false must be set in gradle.properties
 kotlin = "2.4.0"
 

--- a/jps-shared/build.gradle.kts
+++ b/jps-shared/build.gradle.kts
@@ -14,11 +14,11 @@ tasks.testClasses {
     enabled = false
 }
 
-// Restricts stdlib references to what 2025.3 (minimumSupported) bundles - the root project's
+// Restricts stdlib references to what 2026.1 (minimumSupported) bundles - the root project's
 // own copy of this (build.gradle.kts) doesn't reach this separate project.
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
-        apiVersion = KotlinVersion.KOTLIN_2_2
+        apiVersion = KotlinVersion.KOTLIN_2_3
     }
 }
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
     <vendor email="Kronic.Deth@gmail.com">Kadie Enheduanna Inanna</vendor>
 
     <!-- please see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html for description -->
-    <idea-version since-build="253.28294.1"/>
+    <idea-version since-build="261.22158.277"/>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->

--- a/src/org/elixir_lang/debugger/Runner.kt
+++ b/src/org/elixir_lang/debugger/Runner.kt
@@ -30,18 +30,20 @@ import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 
 class Runner : GenericProgramRunner<RunnerSettings>() {
-    override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor =
+    // XDebugSessionBuilder and XSessionStartedResult are experimental; they are the non-deprecated
+    // way to start a session since 261, and there is no stable alternative.
+    @Suppress("UnstableApiUsage")
+    override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor? =
             XDebuggerManager
                     .getInstance(environment.project)
-                    // Keep startSession() for 253 compatibility; XDebugSessionBuilder is not
-                    // available across our supported baseline yet.
-                    .startSession(
-                            environment,
+                    .newSessionBuilder(
                             object : XDebugProcessStarter() {
                                 override fun start(session: XDebugSession): com.intellij.xdebugger.XDebugProcess =
                                         Process(session, environment)
                             }
                     )
+                    .environment(environment)
+                    .startSession()
                     .runContentDescriptor
 
     override fun getRunnerId(): String = ELIXIR_DEBUG_RUNNER_ID

--- a/src/org/elixir_lang/distillery/State.kt
+++ b/src/org/elixir_lang/distillery/State.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.terminal.TerminalExecutionConsoleBuilder
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.ElixirProcessHandler
 import org.elixir_lang.run.WslSafeCommandLineState
@@ -22,9 +22,8 @@ class State(environment: ExecutionEnvironment, configuration: Configuration) :
 
         return if (configuration.pty) {
             val processHandler = startProcess()
-            // Keep direct TerminalExecutionConsole constructor for 253 compatibility;
-            // TerminalExecutionConsoleBuilder is not available across our supported baseline yet.
-            val console = TerminalExecutionConsole(project, processHandler)
+            val console = TerminalExecutionConsoleBuilder(project).build()
+            console.attachToProcess(processHandler)
             processHandler.startNotify()
 
             DefaultExecutionResult(console, processHandler)

--- a/src/org/elixir_lang/formatter/settings/CodeGenerationPanel.kt
+++ b/src/org/elixir_lang/formatter/settings/CodeGenerationPanel.kt
@@ -73,7 +73,7 @@ class CodeGenerationPanel(settings: CodeStyleSettings) : CodeStyleAbstractPanel(
     override fun createHighlighter(colors: EditorColorsScheme): EditorHighlighter {
         // EditorHighlighterFactory rather than FileTypeEditorHighlighterProviders.forFileType():
         // 2026.2 added a covariant forFileType override declared on the class itself, so bytecode
-        // compiled against 2026.2 references a method that does not exist on 2025.3/2026.1
+        // compiled against 2026.2 references a method that does not exist on 2026.1
         // (NoSuchMethodError). EditorHighlighterFactory has the same signature in all supported
         // builds and routes through the same provider EP.
         return EditorHighlighterFactory.getInstance().createEditorHighlighter(getFileType(), colors, null)

--- a/src/org/elixir_lang/formatter/settings/LanguageCodeStyleSettingsProvider.kt
+++ b/src/org/elixir_lang/formatter/settings/LanguageCodeStyleSettingsProvider.kt
@@ -5,7 +5,6 @@ import com.intellij.application.options.CodeStyleAbstractPanel
 import com.intellij.application.options.IndentOptionsEditor
 import com.intellij.application.options.SmartIndentOptionsEditor
 import com.intellij.lang.Language
-import com.intellij.openapi.util.BuildNumber
 import com.intellij.psi.codeStyle.*
 import com.intellij.psi.codeStyle.LanguageCodeStyleSettingsProvider
 import com.intellij.psi.codeStyle.CodeStyleSettingsCustomizable.*

--- a/src/org/elixir_lang/iex/State.kt
+++ b/src/org/elixir_lang/iex/State.kt
@@ -7,7 +7,7 @@ import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.terminal.TerminalExecutionConsoleBuilder
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.WslSafeCommandLineState
 
@@ -18,9 +18,8 @@ class State(environment: ExecutionEnvironment, configuration: Configuration) :
         val project = configuration.project
 
         val processHandler = startProcess()
-        // Keep direct TerminalExecutionConsole constructor for 253 compatibility;
-        // TerminalExecutionConsoleBuilder is not available across our supported baseline yet.
-        val console = TerminalExecutionConsole(project, processHandler)
+        val console = TerminalExecutionConsoleBuilder(project).build()
+        console.attachToProcess(processHandler)
         processHandler.startNotify()
 
         return DefaultExecutionResult(console, processHandler)

--- a/src/org/elixir_lang/iex/mix/State.kt
+++ b/src/org/elixir_lang/iex/mix/State.kt
@@ -7,7 +7,7 @@ import com.intellij.execution.Executor
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.terminal.TerminalExecutionConsole
+import com.intellij.terminal.TerminalExecutionConsoleBuilder
 import org.elixir_lang.notification.setup_sdk.Notifier
 import org.elixir_lang.run.WslSafeCommandLineState
 
@@ -18,9 +18,8 @@ class State(environment: ExecutionEnvironment, configuration: Configuration) :
         val project = configuration.project
 
         val processHandler = startProcess()
-        // Keep direct TerminalExecutionConsole constructor for 253 compatibility;
-        // TerminalExecutionConsoleBuilder is not available across our supported baseline yet.
-        val console = TerminalExecutionConsole(project, processHandler)
+        val console = TerminalExecutionConsoleBuilder(project).build()
+        console.attachToProcess(processHandler)
         processHandler.startNotify()
 
         return DefaultExecutionResult(console, processHandler)

--- a/src/org/elixir_lang/mix/project/OpenProcessor.kt
+++ b/src/org/elixir_lang/mix/project/OpenProcessor.kt
@@ -1,7 +1,6 @@
 package org.elixir_lang.mix.project
 
 import com.intellij.ide.util.projectWizard.WizardContext
-import com.intellij.openapi.application.EDT
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.coroutineToIndicator
 import com.intellij.openapi.vfs.VirtualFile
@@ -51,13 +50,11 @@ class OpenProcessor : ProjectOpenProcessorBase<Builder>() {
         // Store pre-scanned results in the builder
         builder.setPreScannedApps(projectRoot, foundApps)
 
-        // Ensure EDT context for runBlockingModalWithRawProgressReporter in IntelliJ 2025.3
-        // We need .EDT here..
-        // See: https://github.com/JetBrains/intellij-community/commit/59da423bd3fef56a7929838fb9bfeee5beae8785
-        @Suppress("ObsoleteDispatchersEdt")
-        return withContext(Dispatchers.EDT) {
-            super.openProjectAsync(virtualFile, projectToClose, forceOpenInNewFrame)
-        }
+        // The platform's ProjectOpenProcessorBase.openProjectAsync dispatches to the EDT itself on
+        // 2026.1+ (it wraps its EDT-bound work in withContext(Dispatchers.EDT) and uses
+        // withRawProgressReporter), so the old caller-side EDT hop for 2025.3's
+        // runBlockingModalWithRawProgressReporter is no longer needed.
+        return super.openProjectAsync(virtualFile, projectToClose, forceOpenInNewFrame)
     }
 
     override fun doQuickImport(file: VirtualFile, wizardContext: WizardContext): Boolean {

--- a/src/org/elixir_lang/sdk/SdkEnvironment.kt
+++ b/src/org/elixir_lang/sdk/SdkEnvironment.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.roots.ui.configuration.projectRoot.ProjectSdksModel
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.platform.eel.EelDescriptor
 import com.intellij.platform.eel.provider.getEelDescriptor
+import com.intellij.platform.eel.provider.getResolvedEelMachine
 import org.elixir_lang.sdk.wsl.wslCompat
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.InvalidPathException
@@ -25,12 +26,13 @@ import java.nio.file.Path
  * from the wizard's directory with the public (experimental) Path.getEelDescriptor(), and
  * matching SDKs are re-added via the public ProjectSdksModel.addSdk() in [syncTargetSdks].
  *
- * Environments are compared by [EelDescriptor] equality rather than by EelMachine, because no
- * machine API spans the supported builds (EelDescriptor.machine exists only in 2025.3,
- * getResolvedEelMachine() only in 2026.1+) while Path.getEelDescriptor() is binary-stable across
- * all of them. WSL descriptor equality includes the UNC root, so the path is normalized with
- * WslCompatService.canonicalizeWslPrefix first to make `\\wsl$\<distro>` and
- * `\\wsl.localhost\<distro>` resolve to the same descriptor.
+ * Environments are compared by EelMachine, resolved from the descriptor with
+ * getResolvedEelMachine(), because that is what the internal syncSdks(EelMachine) this replicates
+ * keys on. Descriptor equality is finer: it includes the UNC root, so `\\wsl$\<distro>` and
+ * `\\wsl.localhost\<distro>` are different descriptors but one machine. The path is still
+ * normalized with WslCompatService.canonicalizeWslPrefix first, because Path.of needs it to parse
+ * the UNC form at all. Comparison is permissive when either machine cannot be resolved, so SDK
+ * validation stays the deciding factor.
  */
 @Suppress("UnstableApiUsage")
 object SdkEnvironment {
@@ -69,10 +71,10 @@ object SdkEnvironment {
      * either environment cannot be determined, so SDK validation stays the deciding factor.
      */
     fun sdkVisibleFor(targetDescriptor: EelDescriptor?, sdk: Sdk): Boolean {
-        if (targetDescriptor == null) return true
-        val descriptor = sdkDescriptor(sdk) ?: return true
+        val targetMachine = targetDescriptor?.getResolvedEelMachine() ?: return true
+        val machine = sdkDescriptor(sdk)?.getResolvedEelMachine() ?: return true
 
-        return descriptor == targetDescriptor
+        return machine == targetMachine
     }
 
     /**
@@ -82,13 +84,13 @@ object SdkEnvironment {
      * and apply() treats SDKs already present in ProjectJdkTable as updates, not additions.
      */
     fun syncTargetSdks(sdksModel: ProjectSdksModel, targetDescriptor: EelDescriptor?) {
-        if (targetDescriptor == null) return
+        val targetMachine = targetDescriptor?.getResolvedEelMachine() ?: return
         val projectSdks = sdksModel.projectSdks
 
         for (sdk in ProjectJdkTable.getInstance().allJdks) {
             if (projectSdks.containsKey(sdk) || projectSdks.containsValue(sdk)) continue
 
-            if (sdkDescriptor(sdk) == targetDescriptor) {
+            if (sdkDescriptor(sdk)?.getResolvedEelMachine() == targetMachine) {
                 sdksModel.addSdk(sdk)
             }
         }

--- a/src/org/elixir_lang/util/JpsProjectModel.kt
+++ b/src/org/elixir_lang/util/JpsProjectModel.kt
@@ -14,20 +14,22 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  * assigning a missing Elixir SDK - is overwritten when the sync applies the persisted state. Callers that read or
  * mutate authoritative module/SDK configuration from an automated startup activity must await this gate first.
  *
- * ## Why the deprecated, internal [JpsProjectLoadingManager]?
+ * ## Why the internal [JpsProjectLoadingManager]?
  *
- * [JpsProjectLoadingManager] is `@ApiStatus.Internal` **and** `@Deprecated` in favour of
- * `com.intellij.platform.backend.workspace.impl.WorkspaceModelInternal.awaitSynchronizationWithJpsModel`. We do not
- * migrate, because for a Marketplace plugin the replacement is no better:
+ * [JpsProjectLoadingManager] is `@ApiStatus.Internal` across the supported range, and on 262 it is additionally
+ * `@Deprecated` in favour of
+ * `com.intellij.platform.backend.workspace.impl.WorkspaceModelInternal.awaitSynchronizationWithJpsModel` - hence the
+ * `DEPRECATION` suppression below, which 261 does not need but 262 does. We do not migrate, because for a
+ * Marketplace plugin the replacement is no better:
  *
  * - It is `@ApiStatus.Experimental` declared on the `@ApiStatus.Internal WorkspaceModelInternal` interface, so it is
  *   itself an internal API - switching would relocate the plugin-verifier internal-API violation, not remove it.
  * - It requires a `(workspaceModel as WorkspaceModelInternal)` cast (the platform confirms the cast is safe, but it
  *   is still internal surface).
- * - It is absent from our minimum supported build 253 (verified against tag `idea/253.28294.334`); calling it there
- *   throws `NoSuchMethodError`.
+ * - It is absent from our minimum supported build 261: it was introduced by IJPL-240839 after the 261 branch cut
+ *   and first ships in 262 (verified against tag `idea/261.22158.277`). Calling it there throws `NoSuchMethodError`.
  *
- * [JpsProjectLoadingManager] works across the whole supported range (253 → 261+) and is the mechanism the platform
+ * [JpsProjectLoadingManager] works across the whole supported range (261 → 262) and is the mechanism the platform
  * itself endorses for the "automated startup activity that may change project configuration" case - which is exactly
  * this one (see the IJPL-249625 discussion). The JetBrains PyCharm plugin uses it for the same purpose.
  *

--- a/tests/org/elixir_lang/elixir_flex_lexer/Issue1888Test.java
+++ b/tests/org/elixir_lang/elixir_flex_lexer/Issue1888Test.java
@@ -4,11 +4,19 @@ import com.intellij.lexer.Lexer;
 import com.intellij.testFramework.LexerTestCase;
 import org.elixir_lang.ElixirLexer;
 
+/**
+ * {@code checkCorrectRestart} is called explicitly because {@code doTest} only performs it
+ * implicitly on platform 262 - see the KDoc on
+ * {@link org.elixir_lang.heex.lexer.RestartabilityTest}. Without it this class's effective
+ * coverage would differ across the CI legs in .github/ci-versions.json.
+ */
 public class Issue1888Test extends LexerTestCase {
     public void testAtom() {
-        doTest("defmodule MyModule do\n" +
-                        "  def my_function([:list_atom], :argument_atom)\n" +
-                        "end\n",
+        String text = "defmodule MyModule do\n" +
+                "  def my_function([:list_atom], :argument_atom)\n" +
+                "end\n";
+
+        doTest(text,
                 "identifier ('defmodule')\n" +
                         "WHITE_SPACE (' ')\n" +
                         "Alias ('MyModule')\n" +
@@ -32,12 +40,15 @@ public class Issue1888Test extends LexerTestCase {
                         "WHITE_SPACE ('\\n')\n" +
                         "end ('end')\n" +
                         "\\\\n, \\\\r\\\\n ('\\n')");
+        checkCorrectRestart(text);
     }
 
     public void testColumn() {
-        doTest("defmodule MyModule do\n" +
-                        "  def my_function([:list_atom], :)\n" +
-                        "end\n",
+        String text = "defmodule MyModule do\n" +
+                "  def my_function([:list_atom], :)\n" +
+                "end\n";
+
+        doTest(text,
                         "identifier ('defmodule')\n" +
                         "WHITE_SPACE (' ')\n" +
                         "Alias ('MyModule')\n" +
@@ -60,6 +71,7 @@ public class Issue1888Test extends LexerTestCase {
                         "WHITE_SPACE ('\\n')\n" +
                         "end ('end')\n" +
                         "\\\\n, \\\\r\\\\n ('\\n')");
+        checkCorrectRestart(text);
     }
 
     @Override

--- a/tests/org/elixir_lang/heex/lexer/RestartabilityTest.java
+++ b/tests/org/elixir_lang/heex/lexer/RestartabilityTest.java
@@ -10,41 +10,48 @@ import com.intellij.testFramework.LexerTestCase;
  * start. Only this outer lexer is covered; {@link org.elixir_lang.heex.html.HeexHTMLLexerTest}
  * covers the inner HTML lexer's offsets.
  *
- * {@code checkCorrectRestartUsingPosition} is NOT used here - it does not exist on this plugin's
- * minimum supported platform (2025.3.6 / build 253); it was added in 261.
+ * {@link LexerTestCase#checkCorrectRestartUsingPosition} is stronger and now also runs: it captures a
+ * {@code LexerPosition} at every token and asserts the {@code getCurrentPosition()}/{@code restore()}
+ * round-trip from each, so it reaches offsets state-based restart never does. Both run via
+ * {@link #checkRestarts}.
  *
- * {@code doTest(text, expected)} is deliberately not used either - on platform 262 it silently
+ * {@code doTest(text, expected)} is deliberately not used - on platform 262 it silently
  * grows an implicit {@code checkCorrectRestart} call, so relying on it would make this class's
- * effective coverage differ across the CI legs in .github/ci-versions.json. Calling
- * {@code checkCorrectRestart} explicitly keeps behaviour identical on every leg.
+ * effective coverage differ across the CI legs in .github/ci-versions.json. Calling the checks
+ * explicitly keeps behaviour identical on every leg.
  */
 public class RestartabilityTest extends LexerTestCase {
     public void testNestedBraces() {
-        checkCorrectRestart("before {%{a: 1, b: [2, 3]}} after");
+        checkRestarts("before {%{a: 1, b: [2, 3]}} after");
     }
 
     public void testMidScript() {
-        checkCorrectRestart("<script>\n  var x = 1;\n</script>");
+        checkRestarts("<script>\n  var x = 1;\n</script>");
     }
 
     public void testMidTag() {
-        checkCorrectRestart("<div class=\"a\"><%= @x %></div>");
+        checkRestarts("<div class=\"a\"><%= @x %></div>");
     }
 
     public void testTagSpanningMultipleTags() {
-        checkCorrectRestart("<%= if @ok do %><p>yes</p><% else %><p>no</p><% end %>");
+        checkRestarts("<%= if @ok do %><p>yes</p><% else %><p>no</p><% end %>");
     }
 
     public void testComment() {
-        checkCorrectRestart("before <%# a comment %> after");
+        checkRestarts("before <%# a comment %> after");
     }
 
     public void testLongComment() {
-        checkCorrectRestart("before <%!-- a %> comment --%> after");
+        checkRestarts("before <%!-- a %> comment --%> after");
     }
 
     public void testEscapedOpening() {
-        checkCorrectRestart("before <%% literal %> after");
+        checkRestarts("before <%% literal %> after");
+    }
+
+    private void checkRestarts(String text) {
+        checkCorrectRestart(text);
+        checkCorrectRestartUsingPosition(text);
     }
 
     @Override

--- a/tests/org/elixir_lang/heex/parser/HeexParsingTestCase.kt
+++ b/tests/org/elixir_lang/heex/parser/HeexParsingTestCase.kt
@@ -25,8 +25,8 @@ import org.elixir_lang.psi.EexDataAstFactory
 /**
  * Multi-root parsing tests for HEEx (`.html.heex`, three PSI roots: HEEx, HTML, Elixir).
  * Registration recipe copied from `MarkdownParsingTestCase` - the platform's own in-repo example
- * of a template language + HTML data root ParsingTestCase (verified byte-identical on this
- * plugin's minimum supported platform, 2025.3.6 / build 253, and on master).
+ * of a template language + HTML data root ParsingTestCase (verified byte-identical against build
+ * 253 and on master).
  *
  * `checkAllPsiRoots()` defaults to `true` on the platform base class, so `checkResult` writes one
  * expected tree per `provider.getLanguages()` entry, named `<testName>.<LanguageID>.txt`.

--- a/tests/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStepTest.kt
+++ b/tests/org/elixir_lang/mix/project/_import/step/ElixirSdkForModuleStepTest.kt
@@ -179,8 +179,8 @@ class ElixirSdkForModuleStepTest : PlatformTestCase() {
 
     fun testSdkDescriptorIsNullForUnparseableHomePath() {
         // A NUL character is rejected by Path.of() on every platform. The SDK is mocked rather
-        // than registered because on 2025.3 ProjectJdkTable.addJdk() itself parses the home path
-        // and rejects the NUL before sdkDescriptor() could ever see it.
+        // than registered because ProjectJdkTable.addJdk() itself parses the home path and
+        // rejects the NUL before sdkDescriptor() could ever see it.
         val sdk = Mockito.mock(Sdk::class.java)
         Mockito.`when`(sdk.homePath).thenReturn("\u0000invalid")
 

--- a/tests/org/elixir_lang/sdk/erlang/TypeSourcePathsTest.kt
+++ b/tests/org/elixir_lang/sdk/erlang/TypeSourcePathsTest.kt
@@ -1,5 +1,6 @@
 package org.elixir_lang.sdk.erlang
 
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.io.File
 
@@ -45,7 +46,7 @@ class TypeSourcePathsTest : BasePlatformTestCase() {
 
     /** A home with no `lib` at all is not an error - an SDK can be pointed anywhere. */
     fun testTakesNothingFromAHomeWithoutLib() {
-        val home = createTempDir("erlang-home-empty").absolutePath
+        val home = FileUtil.createTempDirectory("erlang-home-empty", null).absolutePath
 
         assertEmpty(Type.sourcePaths(home))
     }
@@ -55,7 +56,7 @@ class TypeSourcePathsTest : BasePlatformTestCase() {
      * `src` beside its `ebin`.
      */
     private fun erlangHome(vararg applications: Pair<String, Boolean>): String {
-        val home = createTempDir("erlang-home")
+        val home = FileUtil.createTempDirectory("erlang-home", null)
 
         for ((application, hasSrc) in applications) {
             val applicationDirectory = File(home, "lib${File.separator}$application")


### PR DESCRIPTION
Supersedes #4034 by @joshuataylor, whose commits are carried over unchanged. That PR was opened from a fork with "Allow edits by maintainers" turned off, so the follow-up commits could not be pushed to its branch; this one lives on the main repository instead. The original description follows.

---

Fixes #4032.

Bumps the plugin's minimum version from 2025.3 (253.x) to 2026.1 (261.x).

As discussed, I believe 2026.1 is a good move, as it unblocks the work we want to do that needs 261.x, without also needing to bump the JDK to 25.

### What changed

Version pins:

- `pluginSinceBuild` and plugin.xml `since-build` -> `261.22158.277` (IntelliJ IDEA's 2026.1 GA build; `until-build` stays open-ended).
- `platformVersion` and `pluginVerifierVersion` -> `2026.1.5` (newest 2026.1 patch). `platformVersion` tracks the newest patch of the minimum line and is what actually ships; `since-build` is the GA build, so the plugin still installs on any 2026.1.x.
- Kotlin `apiVersion` stays `KOTLIN_2_2`; the Java level stays 21.

CI matrix (`.github/ci-versions.json`):

Dropping the 253 minimum version also now lets four 2025.3-only compatibility shims go (yay).

Each replacement was checked against both 2026.1 GA and 2026.2 source before switching, and confirmed to exist as far back as the `idea/2026.1` GA tag, so a GA `since-build` is safe:

- `TerminalExecutionConsole(project, handler)` (deprecated in 261) -> `TerminalExecutionConsoleBuilder(project).build()` + `attachToProcess(handler)`, in the distillery, `iex` and `iex/mix` run states. Platform source (261.27258): [deprecated ctor](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution-impl/src/com/intellij/terminal/TerminalExecutionConsole.java#L91), [`TerminalExecutionConsoleBuilder`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution-impl/src/com/intellij/terminal/TerminalExecutionConsoleBuilder.kt#L8), [`attachToProcess`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution-impl/src/com/intellij/terminal/TerminalExecutionConsole.java#L340).
- `XDebuggerManager.startSession(env, starter)` (deprecated in 261) -> `newSessionBuilder(starter).environment(env).startSession()`. The debug runner's `doExecute` return is now nullable to match the platform's (`GenericProgramRunner.doExecute` is nullable). Platform source (261.27258): [deprecated `startSession`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/xdebugger-api/src/com/intellij/xdebugger/XDebuggerManager.java#L66), [`newSessionBuilder`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/xdebugger-api/src/com/intellij/xdebugger/XDebuggerManager.java#L54), [`XDebugSessionBuilder`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/xdebugger-api/src/com/intellij/xdebugger/XDebugSessionBuilder.kt#L32), [`GenericProgramRunner.doExecute`](https://github.com/JetBrains/intellij-community/blob/261.27258/platform/execution/src/com/intellij/execution/runners/GenericProgramRunner.kt#L29).
- The caller-side `withContext(Dispatchers.EDT)` hop in the Mix `OpenProcessor`, which is no longer needed: the platform's `ProjectOpenProcessorBase.openProjectAsync` dispatches to the EDT itself on 261+ (it wraps its EDT-bound work and uses `withRawProgressReporter`, not the old `runBlockingModalWithRawProgressReporter`). Platform source (261.27258): [`openProjectAsync`](https://github.com/JetBrains/intellij-community/blob/261.27258/java/idea-ui/src/com/intellij/projectImport/ProjectOpenProcessorBase.kt#L82), [`withRawProgressReporter`](https://github.com/JetBrains/intellij-community/blob/261.27258/java/idea-ui/src/com/intellij/projectImport/ProjectOpenProcessorBase.kt#L164).
- An unused `BuildNumber` import in the formatter settings provider.

---

### Changed since #4034 was opened

- Kotlin `apiVersion` moves `KOTLIN_2_2` -> `KOTLIN_2_3` after all, to match 2026.1's bundled stdlib (2.3.20), in both the root and jps-shared compile blocks. This supersedes the "stays `KOTLIN_2_2`" line above.
- `TypeSourcePathsTest` swaps `kotlin.io.createTempDir` for `FileUtil.createTempDirectory`, since apiVersion 2.3 raises that deprecation from a warning to an error.
- The CI matrix takes 2026.1.5 as its minimum and 2026.2.2 as the additional leg, with `com.intellij.modules.ultimate` excluded from the test classpath: on IU-262.10315.125 its classes are obfuscated into a package `lib/product-backend.jar` already occupies, and a test classpath is flat, so its `postStartupActivity` resolved to an unrelated interface and every test that opened a project failed.
- The CHANGELOG entry carries its PR link and attribution, and the Kotlin pin comment in `gradle/libs.versions.toml` now names the `apiVersion` pin rather than its current value.
