### PR TITLE
fix: resolve, complete and document defdelegate declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@
 
 ### Bug Fixes
 
+- [#4039](https://github.com/KronicDeth/intellij-elixir/pull/4039) [@sh41](https://github.com/sh41)
+  - **Go To Declaration, autocomplete and Quick Documentation now work for functions declared with
+    `defdelegate`, including delegations into compiled modules such as `Map.values/1`.** Fixes
+    [#1613](https://github.com/KronicDeth/intellij-elixir/issues/1613).
+
 - [#4020](https://github.com/KronicDeth/intellij-elixir/pull/4020) [@sh41](https://github.com/sh41)
   - **Variable resolution, Find Usages and rename no longer report errors or miss bindings for code
     shapes they did not model.** Fixes [#4019](https://github.com/KronicDeth/intellij-elixir/issues/4019).

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,8 +27,9 @@ changelogGroups=Breaking changes,Enhancements,Bug Fixes,Threading / Platform Hyg
 # Breaking changes belongs here: it is the entry a reader most needs, and a version whose only group
 # is unpublished renders empty and is dropped from the panel entirely.
 changelogPublishedGroups=Breaking changes,Enhancements,Bug Fixes
-# How many versions the "What's New" lists: the one being built plus the five before it.
-changelogPublishedVersions=5
+# How many versions the "What's New" lists, counting the one being built - so it plus the three before
+# it. Lowered from five because the rendered change notes outgrew what the build accepts.
+changelogPublishedVersions=4
 
 # Set to True to skip building searchable options, if developing this drastically speeds up build times.
 # See https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin-faq.html#how-to-disable-building-searchable-options

--- a/src/org/elixir_lang/code_insight/ParameterInfo.kt
+++ b/src/org/elixir_lang/code_insight/ParameterInfo.kt
@@ -106,14 +106,12 @@ class ParameterInfo : ParameterInfoHandler<Arguments, Any> {
 
                                 disabled = finalArguments.size <= currentParameterIndex
                             }
-                        } else {
-                            TODO()
                         }
                     }
                 }
-            } else {
-                TODO()
             }
+            // Any other item kind leaves the builder empty and renders as "<no parameters>" below; a
+            // hint is not worth a crash.
 
             if (stringBuilder.isEmpty()) {
                 stringBuilder.append("<no parameters>")

--- a/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
+++ b/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
@@ -9,7 +9,12 @@ import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.macroChildCalls
 import org.elixir_lang.code_insight.lookup.element.CallDefinitionClause as CallDefinitionClauseLookupElement
 import org.elixir_lang.code_insight.lookup.element_renderer.CallDefinitionClause as CallDefinitionClauseRenderer
+import com.intellij.psi.ResolveState
+import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.structure_view.element.CallDefinitionHead
+import org.elixir_lang.structure_view.element.Delegation
 import org.elixir_lang.psi.CallDefinitionClause as CallDefinitionClausePsi
+import org.elixir_lang.code_insight.lookup.element_renderer.Delegation as DelegationRenderer
 
 /**
  * The function-name [LookupElement]s a modular ([scope]) offers when completing a **remote**
@@ -55,15 +60,49 @@ fun callDefinitionClauseLookupElements(
 }
 
 private fun callDefinitionClauseLookupElements(scope: Call, appendParentheses: Boolean): Iterable<LookupElement> {
-    val publicClauses = scope
-        .macroChildCalls()
+    val childCalls = scope.macroChildCalls()
+
+    val publicClauses = childCalls
         .filter { CallDefinitionClausePsi.`is`(it) }
         .filter { CallDefinitionClausePsi.isPublic(it) }
 
-    return preferFunctionHeads(publicClauses).map { (name, bestClause) ->
-        lookupElement(name, bestClause, appendParentheses)
+    val clauseLookupElements = preferFunctionHeads(publicClauses).map { (name, bestClause) ->
+        name to lookupElement(name, bestClause, appendParentheses)
     }
+    val clauseNames = clauseLookupElements.map { (name, _) -> name }.toSet()
+
+    return clauseLookupElements.map { (_, lookupElement) -> lookupElement } +
+        delegationLookupElements(childCalls, clauseNames)
 }
+
+/**
+ * The [LookupElement]s for functions this module declares only with `defdelegate`.
+ *
+ * `Delegation.is` and `CallDefinitionClause.is` are disjoint, so delegates need their own pass or they
+ * are never offered. Names already in [clauseNames] are skipped so a `def` keeps its richer
+ * presentation; visibility is not filtered because there is no `defdelegatep`.
+ */
+private fun delegationLookupElements(
+    childCalls: Array<Call>,
+    clauseNames: Set<String>
+): List<LookupElement> =
+    childCalls
+        .filter { Delegation.`is`(it) }
+        .mapNotNull { delegation ->
+            delegation
+                .finalArguments()
+                ?.takeIf { it.size == 2 }
+                ?.let { arguments -> CallDefinitionHead.nameArityInterval(arguments[0], ResolveState.initial()) }
+                ?.name
+                ?.takeIf { it !in clauseNames }
+                ?.let { name -> name to delegation }
+        }
+        .distinctBy { (name, _) -> name }
+        .map { (name, delegation) ->
+            LookupElementBuilder
+                .createWithSmartPointer(name, delegation)
+                .withRenderer(DelegationRenderer(name))
+        }
 
 private fun callDefinitionClauseLookupElements(moduleImpl: BeamModule, appendParentheses: Boolean): Iterable<LookupElement> =
     moduleImpl.callDefinitions()

--- a/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
+++ b/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
@@ -15,6 +15,7 @@ import org.elixir_lang.structure_view.element.CallDefinitionHead
 import org.elixir_lang.structure_view.element.Delegation
 import org.elixir_lang.psi.CallDefinitionClause as CallDefinitionClausePsi
 import org.elixir_lang.code_insight.lookup.element_renderer.Delegation as DelegationRenderer
+import org.elixir_lang.code_insight.completion.insert_handler.CallDefinitionClause as CallDefinitionClauseInsertHandler
 
 /**
  * The function-name [LookupElement]s a modular ([scope]) offers when completing a **remote**
@@ -72,7 +73,7 @@ private fun callDefinitionClauseLookupElements(scope: Call, appendParentheses: B
     val clauseNames = clauseLookupElements.map { (name, _) -> name }.toSet()
 
     return clauseLookupElements.map { (_, lookupElement) -> lookupElement } +
-        delegationLookupElements(childCalls, clauseNames)
+        delegationLookupElements(childCalls, clauseNames, appendParentheses)
 }
 
 /**
@@ -81,10 +82,14 @@ private fun callDefinitionClauseLookupElements(scope: Call, appendParentheses: B
  * `Delegation.is` and `CallDefinitionClause.is` are disjoint, so delegates need their own pass or they
  * are never offered. Names already in [clauseNames] are skipped so a `def` keeps its richer
  * presentation; visibility is not filtered because there is no `defdelegatep`.
+ *
+ * [appendParentheses] is threaded through so a delegate inserts `Mod.values()` and opens parameter
+ * info like a `def`, and stays a bare name for an MFA atom, where a name is not a call.
  */
 private fun delegationLookupElements(
     childCalls: Array<Call>,
-    clauseNames: Set<String>
+    clauseNames: Set<String>,
+    appendParentheses: Boolean
 ): List<LookupElement> =
     childCalls
         .filter { Delegation.`is`(it) }
@@ -102,6 +107,7 @@ private fun delegationLookupElements(
             LookupElementBuilder
                 .createWithSmartPointer(name, delegation)
                 .withRenderer(DelegationRenderer(name))
+                .let { if (appendParentheses) it.withInsertHandler(CallDefinitionClauseInsertHandler.INSTANCE) else it }
         }
 
 private fun callDefinitionClauseLookupElements(moduleImpl: BeamModule, appendParentheses: Boolean): Iterable<LookupElement> =

--- a/src/org/elixir_lang/code_insight/lookup/element_renderer/Delegation.kt
+++ b/src/org/elixir_lang/code_insight/lookup/element_renderer/Delegation.kt
@@ -4,14 +4,50 @@ import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementPresentation
 import com.intellij.codeInsight.lookup.LookupElementRenderer
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.call.finalArguments
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 
-class Delegation(val name: String) : LookupElementRenderer<LookupElement>() {
+/**
+ * Renders a `defdelegate` like an ordinary clause: name, head parameters, then where it is declared.
+ *
+ * Its own item presentation reads `defdelegate append_first: false, to: Mod`, which yields no tail and
+ * so reads as a missing signature. Parameters come from the head, named whether or not `to:` resolves.
+ */
+class Delegation(private val name: String) : LookupElementRenderer<LookupElement>() {
     override fun renderElement(element: LookupElement, lookupElementPresentation: LookupElementPresentation) {
         lookupElementPresentation.itemText = name
         lookupElementPresentation.isItemTextBold = true
 
-        element.psiElement?.let { it as? Call }?.let { org.elixir_lang.structure_view.element.Delegation.fromCall(it) }?.presentation?.let { itemPresentation ->
-            lookupElementPresentation.putItemPresentation(itemPresentation)
-        }
+        val delegationCall = element.psiElement as? Call ?: return
+        val itemPresentation = org.elixir_lang.structure_view.element.Delegation
+            .fromCall(delegationCall)
+            ?.presentation
+
+        lookupElementPresentation.icon = itemPresentation?.getIcon(true)
+
+        // Only strip the name when the head actually starts with it. `removePrefix` returns the string
+        // unchanged on a mismatch, which would render the name twice - `values` + `unquote(:values)(map)`
+        // for an unquoted head, or `<>` + `left <> right` for an operator delegate.
+        headText(delegationCall)
+            ?.takeIf { it.startsWith(name) }
+            ?.removePrefix(name)
+            ?.takeIf(String::isNotEmpty)
+            ?.let { lookupElementPresentation.appendTailText(it, true) }
+
+        itemPresentation?.locationString?.let { lookupElementPresentation.appendTailText(" ($it)", false) }
+    }
+
+    /** The head as written, whitespace-normalised, e.g. `values(map)`. */
+    @RequiresReadLock
+    private fun headText(delegationCall: Call): String? =
+        delegationCall
+            .finalArguments()
+            ?.takeIf { it.size == 2 }
+            ?.get(0)
+            ?.text
+            ?.replace(WHITESPACE_RUN, " ")
+
+    companion object {
+        private val WHITESPACE_RUN = Regex("\\s+")
     }
 }

--- a/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
+++ b/src/org/elixir_lang/documentation/ElixirDocumentationProvider.kt
@@ -30,6 +30,7 @@ import org.elixir_lang.psi.stub.type.call.Stub.isModular
 import org.elixir_lang.reference.CaptureNameArity
 import org.elixir_lang.reference.Resolver
 import org.elixir_lang.structure_view.element.Callback
+import org.elixir_lang.structure_view.element.Delegation
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
 import java.util.function.Consumer
@@ -311,9 +312,16 @@ internal class ElixirDocumentationProvider : DocumentationProvider {
                         .filter(ResolveResult::isValidResult)
                         .mapNotNull(ResolveResult::getElement)
 
-                    // Prefer source Call elements (CallDefinitionClause), fall back to BEAM stubs (CallDefinitionImpl)
+                    // A defdelegate carrying its own @doc outranks what it delegates to: the delegating
+                    // module is saying what the function means here, which is why the @doc was written.
+                    // One without its own @doc is skipped so the to: target's documentation shows.
+                    // Otherwise prefer source Call elements (CallDefinitionClause), falling back to BEAM
+                    // stubs (CallDefinitionImpl).
                     fun bestMatch(elements: List<PsiElement>): PsiElement? =
-                        elements.filterIsInstance<Call>().firstOrNull { CallDefinitionClause.`is`(it) }
+                        elements
+                            .filterIsInstance<Call>()
+                            .firstOrNull { Delegation.`is`(it) && SourceFileDocsHelper.fetchDocs(it) != null }
+                            ?: elements.filterIsInstance<Call>().firstOrNull { CallDefinitionClause.`is`(it) }
                             ?: elements.filterIsInstance<BeamCallDefinition>().firstOrNull()
 
                     // If no exact arity match (validResult), fall back to results with an exact name match

--- a/src/org/elixir_lang/documentation/FetchedDocs.kt
+++ b/src/org/elixir_lang/documentation/FetchedDocs.kt
@@ -10,6 +10,7 @@ import org.elixir_lang.beam.chunk.beam_documentation.docs.documented.MarkdownByL
 import org.elixir_lang.beam.term.inspect
 import org.elixir_lang.psi.AtUnqualifiedNoParenthesesCall
 import org.elixir_lang.psi.CallDefinitionClause
+import org.elixir_lang.structure_view.element.Delegation
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.psi.impl.identifierName
@@ -104,7 +105,10 @@ private fun callDefinitionAttributeListByName(callDefinitionCall: Call): Map<Str
     callDefinitionCall
         .prevSiblingSequence()
         .drop(1)
-        .takeWhile { it !is Call || !CallDefinitionClause.`is`(it) }
+        // A defdelegate ends the run of attributes belonging to whatever follows it, exactly as a def
+        // does. Without it the walk runs past any number of delegations and attaches an @doc written
+        // for one of them to a later, undocumented definition.
+        .takeWhile { it !is Call || !(CallDefinitionClause.`is`(it) || Delegation.`is`(it)) }
         .filterIsInstance<AtUnqualifiedNoParenthesesCall<*>>()
         .filter { CALL_DEFINITION_ATTRIBUTE_NAME_SET.contains(it.atIdentifier.identifierName()) }
         .groupBy { it.atIdentifier.identifierName() }

--- a/src/org/elixir_lang/documentation/SourceFileDocsHelper.kt
+++ b/src/org/elixir_lang/documentation/SourceFileDocsHelper.kt
@@ -13,7 +13,10 @@ import org.elixir_lang.psi.impl.call.macroChildCallList
 import org.elixir_lang.psi.impl.identifierName
 import org.elixir_lang.psi.impl.siblingExpressions
 import org.elixir_lang.psi.stub.type.call.Stub
+import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.structure_view.element.CallDefinitionHead
+import org.elixir_lang.structure_view.element.Delegation
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 
 object SourceFileDocsHelper {
     fun fetchDocs(element: PsiElement): FetchedDocs? = when (element) {
@@ -149,6 +152,28 @@ object SourceFileDocsHelper {
                 }
             }
         }
+        Delegation.`is`(call) -> delegationDocs(call)
         else -> null
     }
+
+    /**
+     * The `@doc` written on a `defdelegate` itself, or `null` when it has none.
+     *
+     * A delegation's own `@doc` is the more specific answer, so it replaces the target's. Null rather
+     * than an empty document is what lets the caller fall through to the target.
+     */
+    @RequiresReadLock
+    private fun delegationDocs(call: Call): FetchedDocs? =
+        call
+            .finalArguments()
+            ?.takeIf { it.size == 2 }
+            ?.let { arguments ->
+                enclosingModularMacroCall(call)?.let { modular ->
+                    val module = (modular as? CanonicallyNamed)?.canonicalName().orEmpty()
+
+                    FetchedDocs.FunctionOrMacroDocumentation
+                        .fromCallDefinitionClauseCall(module, call, arguments[0])
+                        .takeIf { it.doc != null }
+                }
+            }
 }

--- a/src/org/elixir_lang/model/psi/function/FunctionCallReference.kt
+++ b/src/org/elixir_lang/model/psi/function/FunctionCallReference.kt
@@ -44,8 +44,9 @@ class FunctionCallReference(
         // Delegate to the legacy Callable scope-walker, which understands qualified calls,
         // unqualified calls within the lexical scope, captures, imports, etc.
         val callArity = call.resolvedFinalArity()
-        val clauses = Callable(call).multiResolve(false)
+        val resolved = Callable(call).multiResolve(false)
             .filter { it.isValidResult }
+        val clauses = resolved
             .mapNotNull { result ->
                 when (val element = result.element) {
                     // A source `def`/`defmacro` clause is already a `Call`, while a decompiled beam function exposes
@@ -69,8 +70,18 @@ class FunctionCallReference(
         // Clauses directly inside a `defprotocol` are owned by ProtocolFunction, not FunctionSymbol
         // (FunctionSymbol.fromClause returns empty for them). A qualified protocol call
         // `Protocol.function(args)` therefore resolves here.
-        return clauses
+        val protocolFunctions = clauses
             .flatMap { ProtocolFunction.fromClause(it) }
+            .filter { it.arity == callArity }
+        if (protocolFunctions.isNotEmpty()) return protocolFunctions
+
+        // Last, the `defdelegate` head itself. It declares a function of that name and arity in its own
+        // module whether or not `to:` resolves, so when nothing else matched - an unresolvable target, or
+        // one whose module is not on the path yet - it is still somewhere to go, and the alternative is a
+        // gesture that silently does nothing. It ranks last so a resolvable target always wins.
+        return resolved
+            .mapNotNull { it.element as? Call }
+            .flatMap { FunctionSymbol.fromDelegation(it) }
             .filter { it.arity == callArity }
     }
 }

--- a/src/org/elixir_lang/model/psi/function/FunctionSymbol.kt
+++ b/src/org/elixir_lang/model/psi/function/FunctionSymbol.kt
@@ -20,6 +20,9 @@ import org.elixir_lang.navigation.ElixirClausePresentation
 import org.elixir_lang.psi.CallDefinitionClause
 import org.elixir_lang.psi.Protocol
 import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.call.finalArguments
+import org.elixir_lang.structure_view.element.CallDefinitionHead
+import org.elixir_lang.structure_view.element.Delegation
 import java.util.*
 
 /**
@@ -141,6 +144,30 @@ class FunctionSymbol(
             val declarationFile = clause.containingFile.originalFile
             return nameArity.arityInterval.closed().map { arity ->
                 FunctionSymbol(declarationFile, nameId.textRange, moduleName, nameArity.name, arity, macro)
+            }
+        }
+
+        /**
+         * The symbols a `defdelegate` declares in its own module.
+         *
+         * A delegation declares a function whether or not `to:` resolves, and [fromClause] cannot
+         * express it because `Delegation.is` and `CallDefinitionClause.is` are disjoint. Never a macro.
+         */
+        @RequiresReadLock
+        fun fromDelegation(delegation: Call): List<FunctionSymbol> {
+            if (!Delegation.`is`(delegation)) return emptyList()
+            val head = delegation.finalArguments()?.takeIf { it.size == 2 }?.get(0) ?: return emptyList()
+            val enclosingModular = CallDefinitionClause.enclosingModularMacroCall(delegation) ?: return emptyList()
+            if (Protocol.`is`(enclosingModular)) return emptyList()
+            val moduleName = runCatching { org.elixir_lang.psi.Module.name(enclosingModular) }
+                .getOrElse { if (it is ProcessCanceledException) throw it else null }
+                ?: return emptyList()
+            val nameArity = CallDefinitionHead.nameArityInterval(head, ResolveState.initial()) ?: return emptyList()
+            val nameId = Delegation.nameIdentifier(delegation) ?: return emptyList()
+            val declarationFile = delegation.containingFile.originalFile
+
+            return nameArity.arityInterval.closed().map { arity ->
+                FunctionSymbol(declarationFile, nameId.textRange, moduleName, nameArity.name, arity, false)
             }
         }
     }

--- a/src/org/elixir_lang/reference/Resolver.kt
+++ b/src/org/elixir_lang/reference/Resolver.kt
@@ -10,6 +10,9 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
 import org.elixir_lang.navigation.isDecompiled
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.structure_view.element.Delegation
+import com.intellij.util.concurrency.annotations.RequiresReadLock
 
 object Resolver {
     fun <T : ResolveResult> preferred(
@@ -56,9 +59,9 @@ object Resolver {
         list: List<T>,
         listElementToPsiElement: (listElement: T) -> U?
     ): List<T> =
-        filterUnderSameModule(elementInModule, list, listElementToPsiElement)
-            .takeIf(List<T>::isNotEmpty)
-            ?: list
+        preferFiltered(list, listElementToPsiElement) {
+            filterUnderSameModule(elementInModule, it, listElementToPsiElement)
+        }
 
     private fun <T : ResolveResult> preferSourceElement(resolveResultList: List<T>): List<T> =
         preferSource(resolveResultList, ResolveResult::getElement)
@@ -70,7 +73,30 @@ object Resolver {
         list: List<T>,
         listElementToPsiElement: (listElement: T) -> U?
     ): List<T> =
-        filterSource(list, listElementToPsiElement).takeIf(List<T>::isNotEmpty) ?: list
+        preferFiltered(list, listElementToPsiElement) { filterSource(it, listElementToPsiElement) }
+
+    /**
+     * Narrows [list] with [filter], keeping the whole list when the narrowed one is empty *or* holds
+     * nothing but `defdelegate` heads.
+     *
+     * A head names a function without defining one, so it must not stand in for the target it points
+     * at - which is what both preferences would otherwise keep when the target is decompiled or lives
+     * outside the calling module.
+     */
+    private fun <T, U : PsiElement> preferFiltered(
+        list: List<T>,
+        listElementToPsiElement: (listElement: T) -> U?,
+        filter: (List<T>) -> List<T>
+    ): List<T> =
+        filter(list)
+            .takeIf { filtered ->
+                filtered.isNotEmpty() && !filtered.all { isDelegation(listElementToPsiElement(it)) }
+            }
+            ?: list
+
+    @RequiresReadLock
+    private fun isDelegation(element: PsiElement?): Boolean =
+        (element as? Call)?.let { Delegation.`is`(it) } ?: false
 
     private fun <T : ResolveResult> filterIsValidResult(resolveResultList: List<T>): List<T> =
         resolveResultList.filter(ResolveResult::isValidResult)

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_declaration.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.DefdelegateDeclaration do
+  def merge(map1, map2, fun), do: {map1, map2, fun}
+  defdelegate merge(map1, map2), to: :maps
+  defdelegate values(map), to: :maps
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_following_statement_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_following_statement_usage.ex
@@ -1,0 +1,8 @@
+defmodule Prefix.DefdelegateFollowingStatementUsage do
+  alias Prefix.DefdelegateDeclaration
+
+  def hello do
+    DefdelegateDeclaration.<caret>
+    :world
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_mfa_atom_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_mfa_atom_usage.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.DefdelegateMfaAtomUsage do
+  alias Prefix.DefdelegateDeclaration
+
+  def call_it(argument) do
+    apply(DefdelegateDeclaration, :<caret>, [argument])
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_source_target_declaration.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_source_target_declaration.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.DefdelegateSourceTarget do
+  def values(map), do: map
+end
+
+defmodule Prefix.DefdelegateSourceTargetDeclaration do
+  defdelegate values(map), to: Prefix.DefdelegateSourceTarget
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_source_target_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_source_target_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.DefdelegateSourceTargetUsage do
+  alias Prefix.DefdelegateSourceTargetDeclaration
+
+  DefdelegateSourceTargetDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defdelegate_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.DefdelegateUsage do
+  alias Prefix.DefdelegateDeclaration
+
+  DefdelegateDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/documentation/defdelegate_quick_doc/delegate_declaration.ex
+++ b/testData/org/elixir_lang/documentation/defdelegate_quick_doc/delegate_declaration.ex
@@ -1,0 +1,12 @@
+defmodule DelegateTarget do
+  @moduledoc "DelegateTarget module."
+  @doc "Merges two maps."
+  def merge(map1, map2) do
+    Map.merge(map1, map2)
+  end
+end
+
+defmodule Delegator do
+  @moduledoc "Delegator module."
+  defdelegate mer<caret>ge(map1, map2), to: DelegateTarget
+end

--- a/testData/org/elixir_lang/documentation/defdelegate_quick_doc/delegated_call.ex
+++ b/testData/org/elixir_lang/documentation/defdelegate_quick_doc/delegated_call.ex
@@ -1,0 +1,18 @@
+defmodule DelegateTarget do
+  @moduledoc "DelegateTarget module."
+  @doc "Merges two maps."
+  def merge(map1, map2) do
+    Map.merge(map1, map2)
+  end
+end
+
+defmodule Delegator do
+  @moduledoc "Delegator module."
+  defdelegate merge(map1, map2), to: DelegateTarget
+end
+
+defmodule Caller do
+  def run do
+    Delegator.mer<caret>ge(%{}, %{})
+  end
+end

--- a/testData/org/elixir_lang/documentation/defdelegate_quick_doc/doc_does_not_leak.ex
+++ b/testData/org/elixir_lang/documentation/defdelegate_quick_doc/doc_does_not_leak.ex
@@ -1,0 +1,22 @@
+defmodule DelegateTarget do
+  @moduledoc "DelegateTarget module."
+  def merge(map1, map2), do: {map1, map2}
+  def values(map), do: map
+end
+
+defmodule Delegator do
+  @moduledoc "Delegator module."
+
+  @doc "Delegator's own account of merging."
+  defdelegate documented(m1, m2), to: DelegateTarget, as: :merge
+
+  defdelegate undocumented(x), to: DelegateTarget, as: :values
+
+  def plain(x), do: x
+end
+
+defmodule Caller do
+  def run do
+    Delegator.undocu<caret>mented(1)
+  end
+end

--- a/testData/org/elixir_lang/documentation/defdelegate_quick_doc/doc_does_not_leak_into_def.ex
+++ b/testData/org/elixir_lang/documentation/defdelegate_quick_doc/doc_does_not_leak_into_def.ex
@@ -1,0 +1,22 @@
+defmodule DelegateTarget do
+  @moduledoc "DelegateTarget module."
+  def merge(map1, map2), do: {map1, map2}
+  def values(map), do: map
+end
+
+defmodule Delegator do
+  @moduledoc "Delegator module."
+
+  @doc "Delegator's own account of merging."
+  defdelegate documented(m1, m2), to: DelegateTarget, as: :merge
+
+  defdelegate undocumented(x), to: DelegateTarget, as: :values
+
+  def plain(x), do: x
+end
+
+defmodule Caller do
+  def run do
+    Delegator.pl<caret>ain(1)
+  end
+end

--- a/testData/org/elixir_lang/documentation/defdelegate_quick_doc/documented_delegate.ex
+++ b/testData/org/elixir_lang/documentation/defdelegate_quick_doc/documented_delegate.ex
@@ -1,0 +1,19 @@
+defmodule DelegateTarget do
+  @moduledoc "DelegateTarget module."
+  @doc "Merges two maps."
+  def merge(map1, map2) do
+    Map.merge(map1, map2)
+  end
+end
+
+defmodule Delegator do
+  @moduledoc "Delegator module."
+  @doc "Delegator's own account of merging."
+  defdelegate merge(map1, map2), to: DelegateTarget
+end
+
+defmodule Caller do
+  def run do
+    Delegator.mer<caret>ge(%{}, %{})
+  end
+end

--- a/testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover/defdelegate_to_beam_hover.ex
+++ b/testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover/defdelegate_to_beam_hover.ex
@@ -1,0 +1,10 @@
+defmodule Delegator do
+  @moduledoc "Delegator module."
+  defdelegate new(), to: :queue
+end
+
+defmodule Caller do
+  def run do
+    Delegator.n<caret>ew()
+  end
+end

--- a/testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover/direct_beam_call_control.ex
+++ b/testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover/direct_beam_call_control.ex
@@ -1,0 +1,5 @@
+defmodule Caller do
+  def run do
+    :queue.n<caret>ew()
+  end
+end

--- a/testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover/documented_delegate_to_beam.ex
+++ b/testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover/documented_delegate_to_beam.ex
@@ -1,0 +1,11 @@
+defmodule Delegator do
+  @moduledoc "Delegator module."
+  @doc "Delegator's own account of queueing."
+  defdelegate new(), to: :queue
+end
+
+defmodule Caller do
+  def run do
+    Delegator.n<caret>ew()
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_1613_declaration_gesture/def_control.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1613_declaration_gesture/def_control.ex
@@ -1,0 +1,7 @@
+defmodule Delegator do
+  def own_<caret>merge(m1, m2), do: {m1, m2}
+
+  def run do
+    own_merge(%{}, %{})
+  end
+end

--- a/testData/org/elixir_lang/reference/callable/issue_1613_unresolvable_target/unresolvable_target.ex
+++ b/testData/org/elixir_lang/reference/callable/issue_1613_unresolvable_target/unresolvable_target.ex
@@ -1,0 +1,9 @@
+defmodule Delegator do
+  defdelegate delegated(x), to: NoSuchModuleAnywhere
+end
+
+defmodule Caller do
+  def run do
+    Delegator.dele<caret>gated(1)
+  end
+end

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -74,12 +74,13 @@ public class CallDefinitionClauseTest extends PlatformTestCase {
         assertNotNull(lookupElements);
         lookupElements[0].renderElement(lookupElementPresentation);
         assertEquals("source", lookupElementPresentation.getItemText());
-        assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
+        // A delegation is presented like any other declaration: head parameters, then location.
+        assertEquals("() (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
 
         lookupElementPresentation = new LookupElementPresentation();
         lookupElements[1].renderElement(lookupElementPresentation);
         assertEquals("source_as", lookupElementPresentation.getItemText());
-        assertEquals(" (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
+        assertEquals("() (defdelegate.ex defmodule Defdelegate)", lookupElementPresentation.getTailText());
 
         lookupElementPresentation = new LookupElementPresentation();
         lookupElements[2].renderElement(lookupElementPresentation);

--- a/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613DelegateInsertionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613DelegateInsertionTest.kt
@@ -1,0 +1,58 @@
+package org.elixir_lang.code_insight.completion.contributor
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.code_insight.completeCandidateAtCaret
+
+/**
+ * Accepting a delegated function from completion must insert what accepting an ordinary `def` inserts.
+ *
+ * [Issue1613RemoteCompletionTest] covers the offer; this covers the insertion, which used to differ
+ * because delegation entries carried no insert handler. The MFA-atom case is why the flag is threaded
+ * rather than the handler simply attached.
+ */
+class Issue1613DelegateInsertionTest : PlatformTestCase() {
+    fun testAcceptingADelegatedFunctionInsertsParentheses() {
+        myFixture.configureByFiles("defdelegate_usage.ex", "defdelegate_declaration.ex")
+
+        val text = myFixture.completeCandidateAtCaret("values")
+
+        assertTrue(
+            "Accepting the delegate `values` should insert `values()`, as accepting a `def` does; got:\n$text",
+            text.contains("DefdelegateDeclaration.values()")
+        )
+    }
+
+    /**
+     * The sibling `def`-backed name, from the same popup, so a failure above cannot be blamed on the
+     * fixture or on the insertion helper.
+     */
+    fun testAcceptingAClauseBackedFunctionInsertsParentheses() {
+        myFixture.configureByFiles("defdelegate_usage.ex", "defdelegate_declaration.ex")
+
+        val text = myFixture.completeCandidateAtCaret("merge")
+
+        assertTrue(
+            "Accepting `merge` should insert `merge()`; got:\n$text",
+            text.contains("DefdelegateDeclaration.merge()")
+        )
+    }
+
+    /** `apply(Mod, :values, args)` names the function; appending `()` there would be wrong. */
+    fun testAcceptingADelegatedFunctionAsAnMfaAtomInsertsNoParentheses() {
+        myFixture.configureByFiles("defdelegate_mfa_atom_usage.ex", "defdelegate_declaration.ex")
+
+        val text = myFixture.completeCandidateAtCaret("values")
+
+        assertFalse(
+            "An MFA atom names a function rather than calling it, so `:values` must not gain `()`; got:\n$text",
+            text.contains(":values()")
+        )
+        assertTrue(
+            "Expected the bare atom `:values` to be inserted; got:\n$text",
+            text.contains(":values")
+        )
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause"
+}

--- a/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613RemoteCompletionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613RemoteCompletionTest.kt
@@ -57,6 +57,27 @@ class Issue1613RemoteCompletionTest : PlatformTestCase() {
         )
     }
 
+    /**
+     * The caret with another statement after it, which the suite already treats as a separate case for
+     * ordinary clauses (`testQualifiedFunctionOfferedWhenAnotherStatementFollowsInBlock`) because the
+     * trailing dot parses differently there.
+     */
+    fun testDelegatedFunctionOfferedWhenAnotherStatementFollowsInBlock() {
+        myFixture.configureByFiles(
+            "defdelegate_following_statement_usage.ex",
+            "defdelegate_declaration.ex"
+        )
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val lookupElementStrings = myFixture.lookupElementStrings
+
+        assertNotNull("Completion lookup not shown", lookupElementStrings)
+        assertTrue(
+            "Remote completion should offer values/1 with a following statement, got: $lookupElementStrings",
+            lookupElementStrings!!.contains("values")
+        )
+    }
+
     override fun getTestDataPath(): String =
         "testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause"
 }

--- a/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613RemoteCompletionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613RemoteCompletionTest.kt
@@ -1,0 +1,62 @@
+package org.elixir_lang.code_insight.completion.contributor
+
+import com.intellij.codeInsight.completion.CompletionType
+import org.elixir_lang.PlatformTestCase
+
+/**
+ * Remote (qualified) completion must offer a function declared only by `defdelegate`.
+ *
+ * `Delegation.is` and `CallDefinitionClause.is` are disjoint predicates - `defdelegate` is not one of
+ * the heads `isFunction`/`isMacro`/`isGuard` test - so the `CallDefinitionClause.is` filter in
+ * `ModuleFunctionLookupElements` drops every delegate. The fixture reproduces the reported contrast:
+ * `merge` is offered anyway because a sibling `def merge/3` clears the filter under the same name,
+ * while `values`, declared only as a delegate, is offered by nothing.
+ *
+ * The `BeamModule` branch has no such filter, but source modulars are preferred over BEAM-decompiled
+ * stubs, so for any module whose source is on disk the unfiltered branch is never the one taken.
+ */
+class Issue1613RemoteCompletionTest : PlatformTestCase() {
+    fun testDelegatedFunctionOfferedInRemoteCompletion() {
+        myFixture.configureByFiles("defdelegate_usage.ex", "defdelegate_declaration.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val lookupElementStrings = myFixture.lookupElementStrings
+
+        assertNotNull("Completion lookup not shown", lookupElementStrings)
+        assertTrue(
+            "Remote completion should offer values/1, declared only by defdelegate, got: $lookupElementStrings",
+            lookupElementStrings!!.contains("values")
+        )
+        assertTrue(
+            "Remote completion should offer merge, got: $lookupElementStrings",
+            lookupElementStrings.contains("merge")
+        )
+    }
+
+    /**
+     * The same gap with a `to:` target that does resolve, to source, in the same project.
+     *
+     * Without this the suite cannot tell the declaration-site filter from a target that simply does
+     * not resolve - `to: :maps` above resolves to nothing in the fixture, so on its own it is
+     * consistent with either cause. The filter never consults `to:`, so this must fail too.
+     */
+    fun testDelegatedFunctionWithResolvableSourceTargetOfferedInRemoteCompletion() {
+        myFixture.configureByFiles(
+            "defdelegate_source_target_usage.ex",
+            "defdelegate_source_target_declaration.ex"
+        )
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val lookupElementStrings = myFixture.lookupElementStrings
+
+        assertNotNull("Completion lookup not shown", lookupElementStrings)
+        assertTrue(
+            "Remote completion should offer values/1 delegated to a resolvable source module, got: " +
+                "$lookupElementStrings",
+            lookupElementStrings!!.contains("values")
+        )
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause"
+}

--- a/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613RemoteCompletionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/Issue1613RemoteCompletionTest.kt
@@ -1,19 +1,15 @@
 package org.elixir_lang.code_insight.completion.contributor
 
 import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementPresentation
 import org.elixir_lang.PlatformTestCase
 
 /**
  * Remote (qualified) completion must offer a function declared only by `defdelegate`.
  *
- * `Delegation.is` and `CallDefinitionClause.is` are disjoint predicates - `defdelegate` is not one of
- * the heads `isFunction`/`isMacro`/`isGuard` test - so the `CallDefinitionClause.is` filter in
+ * `Delegation.is` and `CallDefinitionClause.is` are disjoint, so the clause filter in
  * `ModuleFunctionLookupElements` drops every delegate. The fixture reproduces the reported contrast:
- * `merge` is offered anyway because a sibling `def merge/3` clears the filter under the same name,
- * while `values`, declared only as a delegate, is offered by nothing.
- *
- * The `BeamModule` branch has no such filter, but source modulars are preferred over BEAM-decompiled
- * stubs, so for any module whose source is on disk the unfiltered branch is never the one taken.
+ * `merge` clears the filter via a sibling `def merge/3`, `values` is only ever a delegate.
  */
 class Issue1613RemoteCompletionTest : PlatformTestCase() {
     fun testDelegatedFunctionOfferedInRemoteCompletion() {
@@ -75,6 +71,27 @@ class Issue1613RemoteCompletionTest : PlatformTestCase() {
         assertTrue(
             "Remote completion should offer values/1 with a following statement, got: $lookupElementStrings",
             lookupElementStrings!!.contains("values")
+        )
+    }
+
+    /**
+     * A delegated function must show its signature like any other, or it reads as broken sitting next
+     * to entries that have one. The shared delegation renderer now appends the head's parameters;
+     * `testIssue2122` pins the same shape for local completion.
+     */
+    fun testDelegatedFunctionRendersItsHeadSignature() {
+        myFixture.configureByFiles("defdelegate_usage.ex", "defdelegate_declaration.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val values = myFixture.lookupElements.orEmpty().first { lookupElement ->
+            LookupElementPresentation().also(lookupElement::renderElement).itemText == "values"
+        }
+        val presentation = LookupElementPresentation().also(values::renderElement)
+
+        assertEquals("values", presentation.itemText)
+        assertTrue(
+            "Expected the delegate's parameters in the tail, got: ${presentation.tailText}",
+            presentation.tailText.orEmpty().startsWith("(map)")
         )
     }
 

--- a/tests/org/elixir_lang/documentation/Issue1613BeamDelegateQuickDocumentationTest.kt
+++ b/tests/org/elixir_lang/documentation/Issue1613BeamDelegateQuickDocumentationTest.kt
@@ -1,0 +1,105 @@
+package org.elixir_lang.documentation
+
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import org.elixir_lang.beam.BeamLibraryFixture
+import java.io.File
+
+/**
+ * Quick Documentation for a call to a function declared by `defdelegate` whose `to:` target is a
+ * **compiled** module.
+ *
+ * The reported case: delegating into a module that exists only as `.beam`, the way the standard
+ * library delegates `Map.values/1` to `:maps`. Reuses the `queue.beam` fixture from
+ * [ErlangAtomQualifierHoverDocumentationTest].
+ */
+class Issue1613BeamDelegateQuickDocumentationTest : QuickDocumentationTestCase() {
+    override fun setUp() {
+        super.setUp()
+        addBeamLibrary()
+    }
+
+    override fun tearDown() {
+        try {
+            removeBeamLibrary()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testQuickDocOnCallDelegatedToBeamModule() {
+        myFixture.configureByFiles("defdelegate_to_beam_hover.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull(
+            "Quick Documentation should be shown for a call delegated to a compiled module",
+            documentation
+        )
+        assertFalse(
+            "Expected function documentation, not the delegating module's @moduledoc, got: $documentation",
+            documentation!!.contains("Delegator module.")
+        )
+        assertTrue(
+            "Expected the delegation target :queue in the documentation, got: $documentation",
+            documentation.contains(":queue")
+        )
+    }
+
+    /** The delegate's own `@doc` wins over the compiled target's too, not only over a source target's. */
+    fun testQuickDocPrefersTheDelegatesOwnDocOverTheBeamTargets() {
+        myFixture.configureByFiles("documented_delegate_to_beam.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull("Quick Documentation should be shown for a documented delegate", documentation)
+        assertTrue(
+            "Expected the delegate's own @doc, got: $documentation",
+            documentation!!.contains("Delegator's own account of queueing.")
+        )
+    }
+
+    /**
+     * The control for [testQuickDocOnCallDelegatedToBeamModule]: `:queue.new()` called directly must
+     * already produce documentation, so a null for the delegated call cannot be blamed on the fixture.
+     */
+    fun testQuickDocOnDirectBeamCall() {
+        myFixture.configureByFiles("direct_beam_call_control.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull(
+            "Quick Documentation should be shown for a direct :queue.new() call - without this the " +
+                "delegated-call assertion proves nothing about delegation",
+            documentation
+        )
+        assertTrue(
+            "Expected :queue in the documentation, got: $documentation",
+            documentation!!.contains(":queue")
+        )
+    }
+
+    private fun addBeamLibrary() {
+        val beamFile = File(testDataPath, "queue.beam")
+        assertTrue("queue.beam not found at ${beamFile.absolutePath}", beamFile.exists())
+
+        val beamDir = beamFile.parentFile.absolutePath
+        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, beamDir)
+
+        val beamDirVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(beamDir))
+        assertNotNull("Could not find beam test data directory: $beamDir", beamDirVf)
+
+        BeamLibraryFixture.addLibrary(project, myFixture.module, LIBRARY_NAME, listOf(beamDirVf!!))
+    }
+
+    private fun removeBeamLibrary() {
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, LIBRARY_NAME)
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover"
+
+    companion object {
+        private const val LIBRARY_NAME = "defdelegate_beam_hover_test_lib"
+    }
+}

--- a/tests/org/elixir_lang/documentation/Issue1613QuickDocumentationTest.kt
+++ b/tests/org/elixir_lang/documentation/Issue1613QuickDocumentationTest.kt
@@ -1,0 +1,96 @@
+package org.elixir_lang.documentation
+
+/**
+ * Quick Documentation (Ctrl+Q) through a `defdelegate` whose `to:` target is Elixir **source**.
+ *
+ * The control for [Issue1613BeamDelegateQuickDocumentationTest]. This case works because resolution
+ * chases `to:` first and hands the pipeline the target's own `def`, so the missing `Delegation`
+ * branch is never reached - which is why the gap went unnoticed.
+ */
+class Issue1613QuickDocumentationTest : QuickDocumentationTestCase() {
+    fun testQuickDocOnCallDelegatedToSourceShowsTargetDoc() {
+        myFixture.configureByFiles("delegated_call.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull("Quick Documentation should be shown for a call to a delegated function", documentation)
+        assertTrue(
+            "Expected the delegation target's function head, got: $documentation",
+            documentation!!.contains("merge(map1, map2)")
+        )
+        assertTrue(
+            "Expected the delegation target's @doc, got: $documentation",
+            documentation.contains("Merges two maps.")
+        )
+    }
+
+    fun testQuickDocOnDefdelegateDeclarationShowsTargetDoc() {
+        myFixture.configureByFiles("delegate_declaration.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull("Quick Documentation should be shown for a defdelegate declaration", documentation)
+        assertTrue(
+            "Expected the delegation target's function head, got: $documentation",
+            documentation!!.contains("merge(map1, map2)")
+        )
+        assertTrue(
+            "Expected the delegation target's @doc, got: $documentation",
+            documentation.contains("Merges two maps.")
+        )
+    }
+
+    /**
+     * A `defdelegate` may carry its own `@doc`, and when it does that is the more specific answer - the
+     * delegating module is saying what the function means *here*, which is the reason to write it.
+     * Chasing `to:` regardless would discard it.
+     */
+    fun testQuickDocPrefersTheDelegatesOwnDocOverTheTargets() {
+        myFixture.configureByFiles("documented_delegate.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertNotNull("Quick Documentation should be shown for a documented delegate", documentation)
+        assertTrue(
+            "Expected the delegate's own @doc, got: $documentation",
+            documentation!!.contains("Delegator's own account of merging.")
+        )
+        assertFalse(
+            "Expected the delegate's own @doc to replace the target's, got: $documentation",
+            documentation.contains("Merges two maps.")
+        )
+    }
+
+    /**
+     * A documented `defdelegate` must not lend its `@doc` to a later, undocumented one.
+     *
+     * The attribute walk collecting `@doc` stops at the previous call definition clause, and a
+     * `defdelegate` is not one - so without a delegation boundary it runs straight past any number of
+     * intervening delegations and attaches the wrong module attribute.
+     */
+    fun testDelegateDocDoesNotLeakToALaterDelegate() {
+        myFixture.configureByFiles("doc_does_not_leak.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertFalse(
+            "An undocumented delegate must not show the previous delegate's @doc, got: $documentation",
+            documentation.orEmpty().contains("Delegator's own account of merging.")
+        )
+    }
+
+    /** The same boundary in the other direction: a `def` must not inherit a preceding delegate's `@doc`. */
+    fun testDelegateDocDoesNotLeakToALaterDef() {
+        myFixture.configureByFiles("doc_does_not_leak_into_def.ex")
+
+        val documentation = quickDocumentationAtCaret()
+
+        assertFalse(
+            "A def must not show a preceding delegate's @doc, got: $documentation",
+            documentation.orEmpty().contains("Delegator's own account of merging.")
+        )
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/documentation/defdelegate_quick_doc"
+}

--- a/tests/org/elixir_lang/reference/callable/Issue1613BeamDelegateTest.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue1613BeamDelegateTest.kt
@@ -1,0 +1,107 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.ide.impl.HeadlessDataManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.newvfs.impl.VfsRootAccess
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.beam.BeamLibraryFixture
+import org.elixir_lang.beam.psi.BeamFileImpl
+import org.elixir_lang.code_insight.gotoDeclarationTargetsAtCaret
+import java.io.File
+
+/**
+ * Go To Declaration on a call to a function declared by `defdelegate` whose `to:` target is a
+ * **compiled** module.
+ *
+ * [Issue1613Test] pins the source-to-source case; this is the reported one, where the target exists
+ * only as `.beam` (`queue.beam` stands in for `:maps`). The gesture must reach the compiled target,
+ * not stop at the `defdelegate` head - the head alone would satisfy a non-empty check.
+ */
+class Issue1613BeamDelegateTest : PlatformTestCase() {
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/documentation/erlang_atom_qualifier_hover"
+
+    override fun setUp() {
+        super.setUp()
+        HeadlessDataManager.fallbackToProductionDataManager(myFixture.testRootDisposable)
+        addBeamLibrary()
+    }
+
+    override fun tearDown() {
+        try {
+            removeBeamLibrary()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    /**
+     * The gesture must reach `:queue.new`, not merely reach something.
+     *
+     * Asserting only that a declaration was found does not discriminate the fix: the head fallback in
+     * `FunctionCallReference` makes the result non-empty on its own, so a `Resolver` reverted to main
+     * still passes. Measured - reverting only `Resolver.kt` leaves this class green under the weaker
+     * assertion.
+     */
+    fun testQualifiedUsageOfDefdelegateToBeamModuleReachesTheCompiledTarget() {
+        myFixture.configureByFile("defdelegate_to_beam_hover.ex")
+
+        val declarations = myFixture.gotoDeclarationTargetsAtCaret().orEmpty().mapNotNull { it.destination }
+
+        assertTrue(
+            "Go To Declaration from a usage of a function delegated to a compiled module should " +
+                "reach a declaration, got none",
+            declarations.isNotEmpty()
+        )
+
+        val destinations = declarations.joinToString { "${it.javaClass.simpleName} in ${it.containingFile?.originalFile?.name}" }
+
+        assertTrue(
+            "Go To Declaration should reach the delegation's compiled target in queue.beam, not stop " +
+                "at the defdelegate head. The head alone satisfies a non-empty check, which is why " +
+                "this asserts the destination. Got: $destinations",
+            declarations.any { it.containingFile?.originalFile is BeamFileImpl }
+        )
+    }
+
+    /**
+     * The control for [testQualifiedUsageOfDefdelegateToBeamModuleReachesTheCompiledTarget].
+     *
+     * Calling `:queue.new()` directly must navigate. Without this, an empty result from the delegated
+     * call is equally consistent with the delegation being broken and with `queue.beam` not being
+     * mounted, not exporting `new/0`, or the fixture not resolving at all - and the suite could not
+     * tell a fixed plugin from a fixed fixture.
+     */
+    fun testDirectCallToBeamModuleNavigates() {
+        myFixture.configureByFile("direct_beam_call_control.ex")
+
+        val declarations = myFixture.gotoDeclarationTargetsAtCaret().orEmpty().mapNotNull { it.destination }
+
+        assertTrue(
+            "Go To Declaration on a direct :queue.new() call should reach a declaration, got none - " +
+                "the beam library fixture is not usable and the delegation assertion above proves nothing",
+            declarations.isNotEmpty()
+        )
+    }
+
+    private fun addBeamLibrary() {
+        val beamFile = File(testDataPath, "queue.beam")
+        assertTrue("queue.beam not found at ${beamFile.absolutePath}", beamFile.exists())
+
+        val beamDir = beamFile.parentFile.absolutePath
+        VfsRootAccess.allowRootAccess(myFixture.testRootDisposable, beamDir)
+
+        val beamDirVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(File(beamDir))
+        assertNotNull("Could not find beam test data directory: $beamDir", beamDirVf)
+
+        BeamLibraryFixture.addLibrary(project, myFixture.module, LIBRARY_NAME, listOf(beamDirVf!!))
+    }
+
+    private fun removeBeamLibrary() {
+        BeamLibraryFixture.removeLibrary(project, myFixture.module, LIBRARY_NAME)
+    }
+
+    companion object {
+        private const val LIBRARY_NAME = "defdelegate_beam_goto_test_lib"
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/Issue1613DeclarationGestureTest.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue1613DeclarationGestureTest.kt
@@ -1,0 +1,33 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.ide.impl.HeadlessDataManager
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.code_insight.GtduNavigation
+import org.elixir_lang.code_insight.gtduNavigationAtCaret
+
+/**
+ * Ctrl+Click on the name in a `def` head offers Show Usages, because the name is a declaration.
+ *
+ * A `defdelegate` head navigates to its target instead - it has two references and no declaration, and
+ * the platform prefers a reference. That gap is #4043 and is deliberately not asserted here.
+ */
+class Issue1613DeclarationGestureTest : PlatformTestCase() {
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/reference/callable/issue_1613_declaration_gesture"
+
+    override fun setUp() {
+        super.setUp()
+        HeadlessDataManager.fallbackToProductionDataManager(myFixture.testRootDisposable)
+    }
+
+    fun testCtrlClickOnDefNameShowsUsages() {
+        myFixture.configureByFile("def_control.ex")
+
+        val navigation = myFixture.gtduNavigationAtCaret()
+
+        assertTrue(
+            "Ctrl+Click on a def's own name should offer Show Usages, got: $navigation",
+            navigation is GtduNavigation.ShowUsages
+        )
+    }
+}

--- a/tests/org/elixir_lang/reference/callable/Issue1613UnresolvableTargetTest.kt
+++ b/tests/org/elixir_lang/reference/callable/Issue1613UnresolvableTargetTest.kt
@@ -1,0 +1,33 @@
+package org.elixir_lang.reference.callable
+
+import com.intellij.ide.impl.HeadlessDataManager
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.code_insight.gotoDeclarationTargetsAtCaret
+
+/**
+ * Go To Declaration on a call to a delegated function whose `to:` module does not resolve.
+ *
+ * The head is then the only result, and the symbol layer dropped it for not being a call definition
+ * clause, so the gesture reached nothing. Not only a broken-program case - a module delegating to a
+ * dependency not yet on the path resolves this way.
+ */
+class Issue1613UnresolvableTargetTest : PlatformTestCase() {
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/reference/callable/issue_1613_unresolvable_target"
+
+    override fun setUp() {
+        super.setUp()
+        HeadlessDataManager.fallbackToProductionDataManager(myFixture.testRootDisposable)
+    }
+
+    fun testUsageOfDefdelegateWithUnresolvableTargetNavigatesToTheHead() {
+        myFixture.configureByFile("unresolvable_target.ex")
+
+        val declarations = myFixture.gotoDeclarationTargetsAtCaret().orEmpty().mapNotNull { it.destination }
+
+        assertTrue(
+            "Go To Declaration should fall back to the defdelegate head when to: does not resolve, got none",
+            declarations.isNotEmpty()
+        )
+    }
+}


### PR DESCRIPTION
Fixes #1613.

Three symptoms, reported against `Map.values/1` and `Map.merge/2`, with two causes.

**Go To Declaration and Quick Documentation** reached nothing when `to:` named a compiled module. `executeOnDelegation` produces both the `defdelegate` head and the target, but the head satisfied both of `Resolver`'s preferences — source-over-decompiled, and same-module — so it discarded the target it delegates to.

**Remote completion** never offered a delegate-only function: `ModuleFunctionLookupElements` filters on `CallDefinitionClause.is`, which is disjoint from `Delegation.is`. Hence `merge` (also an ordinary `def merge/3`) being offered while `values`, only ever a delegate, was not.

**Completing a delegate now inserts `()`**, as completing a `def` already did — delegation entries were built without the insert handler that clause entries get. `appendParentheses` is threaded through so the MFA-atom case, where a name is not a call, stays correct by intent. Note the parentheses do not bring a parameter hint with them when `to:` names a compiled module; see the known gap below.

Also here: a `defdelegate` with its own `@doc` shows it in preference to the target's; Go To Declaration falls back to the head when `to:` does not resolve; and two `TODO()` arms in `ParameterInfo.updateUI` that threw on an unrecognised item now degrade to `<no parameters>` (unrelated latent crash, own commit).

`CallDefinitionClause.is` is deliberately not widened — `Import`, the scope dispatcher and `PsiNameIdentifierOwnerImpl` test it before `Delegation.is`, so widening would shadow live delegation branches.

## Tests

Six new classes. Run against the commit before this branch, **14 of their 22 tests fail** — `Issue1613RemoteCompletionTest` 4/4, `Issue1613BeamDelegateQuickDocumentationTest` 3/3, `Issue1613BeamDelegateTest` 2/2, `Issue1613QuickDocumentationTest` 2/5, `Issue1613DelegateInsertionTest` 2/3, `Issue1613UnresolvableTargetTest` 1/1. The eight that pass on the base are deliberate controls, and they carry as much weight as the failures: they establish that navigation and docs turn on whether `to:` resolves to source or to a compiled module, while completion failed either way, and that a direct `:queue.new()` already navigates and hovers in the same fixture — so a red spec cannot be blamed on the beam library not being mounted. `Issue1613DeclarationGestureTest` is green on the base by design: it pins that Ctrl+Click on a `def` name shows usages, as the comparison for #4043.

Full suite: 7491 tests, 0 failures.

## Known gap

`defdelegate [foo(a), bar(b)], to: Target` remains invisible to resolution, completion and imports — `CallDefinitionHead.nameArityInterval` returns nil for a list. Pre-existing, filed as #4040.

**Parameter hints still do not appear for `Map.values(`, or for any other function defined in a `.beam`.** `ParameterInfo` keeps only resolve results satisfying `(it is Call) && CallDefinitionClause.is(it)`, and a decompiled definition is a `BeamCallDefinition`, which is not a `Call` — so every compiled function is dropped before anything else runs. This is long-standing and unrelated to `defdelegate`: `:lists.reverse(`, `:queue.new(` and `:maps.merge(` show nothing either. It is not caused or fixed here, but this PR makes it easier to reach, because a delegate that was never offered in completion now is. Being filed separately.


