### PR TITLE
fix: offer remote completion when another qualified call follows the caret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,13 @@
   - **An `alias` naming a module that does not exist no longer crashes the IDE with a
     `StackOverflowError`.** Fixes [#3978](https://github.com/KronicDeth/intellij-elixir/issues/3978).
 
+- [#4042](https://github.com/KronicDeth/intellij-elixir/pull/4042) [@sh41](https://github.com/sh41)
+  - **Completing after `Mod.` now offers the module's functions where another qualified call follows the
+    caret, in a struct's field value, and for declarations written below a bare `Mod.` in the same module,
+    and no longer offers them in the first argument of an `alias`, `import`, `require`, `use`,
+    `defmodule`, `defimpl` or `defprotocol`.** Fixes
+    [#4041](https://github.com/KronicDeth/intellij-elixir/issues/4041).
+
 - [#4039](https://github.com/KronicDeth/intellij-elixir/pull/4039) [@sh41](https://github.com/sh41)
   - **Go To Declaration, autocomplete and Quick Documentation now work for functions declared with
     `defdelegate`, including delegations into compiled modules such as `Map.values/1`.** Fixes

--- a/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
+++ b/src/org/elixir_lang/code_insight/completion/ModuleFunctionLookupElements.kt
@@ -1,8 +1,10 @@
 package org.elixir_lang.code_insight.completion
 
+import com.intellij.codeInsight.completion.CompletionUtil
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import org.elixir_lang.beam.psi.Module as BeamModule
 import org.elixir_lang.code_insight.preferFunctionHeads
 import org.elixir_lang.psi.call.Call
@@ -105,7 +107,7 @@ private fun delegationLookupElements(
         .distinctBy { (name, _) -> name }
         .map { (name, delegation) ->
             LookupElementBuilder
-                .createWithSmartPointer(name, delegation)
+                .createWithSmartPointer(name, delegation.inOriginalFile())
                 .withRenderer(DelegationRenderer(name))
                 .let { if (appendParentheses) it.withInsertHandler(CallDefinitionClauseInsertHandler.INSTANCE) else it }
         }
@@ -119,10 +121,38 @@ private fun callDefinitionClauseLookupElements(moduleImpl: BeamModule, appendPar
         }
 
 private fun lookupElement(name: String, element: PsiElement, appendParentheses: Boolean): LookupElement =
-    if (appendParentheses) {
-        CallDefinitionClauseLookupElement.createWithSmartPointer(name, element)
-    } else {
-        LookupElementBuilder
-            .createWithSmartPointer(name, element)
-            .withRenderer(CallDefinitionClauseRenderer(name))
+    element.inOriginalFile().let { originalElement ->
+        if (appendParentheses) {
+            CallDefinitionClauseLookupElement.createWithSmartPointer(name, originalElement)
+        } else {
+            LookupElementBuilder
+                .createWithSmartPointer(name, originalElement)
+                .withRenderer(CallDefinitionClauseRenderer(name))
+        }
     }
+
+/**
+ * [CompletionUtil.getOriginalOrSelf] hands back the copy rather than null when it cannot map, so a lookup
+ * element built from its result silently pins the throwaway file. It fails two ways here: the declaration
+ * enclosing the caret has a same-class node that runs past the translated end, and one the trailing dot
+ * swallowed has no node of its own at all.
+ */
+private fun PsiElement.inOriginalFile(): PsiElement {
+    val mapped = CompletionUtil.getOriginalOrSelf(this)
+    val copyFile = mapped.containingFile ?: return mapped
+
+    if (copyFile.isPhysical) return mapped
+
+    val startOffset = mapped.textRange?.startOffset ?: return mapped
+    val originalLeaf = copyFile.findElementAt(startOffset)
+        ?.let(CompletionUtil::getOriginalOrSelf)
+        ?.takeIf { it.containingFile?.isPhysical == true }
+        ?: return mapped
+    val originalOffset = originalLeaf.textRange.startOffset
+
+    val sameClass = generateSequence(originalLeaf) { it.parent }
+        .takeWhile { it !is PsiFile }
+        .firstOrNull { mapped.javaClass.isInstance(it) && it.textRange?.startOffset == originalOffset }
+
+    return sameClass ?: originalLeaf
+}

--- a/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/code_insight/completion/provider/CallDefinitionClause.kt
@@ -4,42 +4,64 @@ import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 import org.elixir_lang.code_insight.completion.callDefinitionClauseLookupElements
-import org.elixir_lang.psi.ElixirTypes
+import org.elixir_lang.psi.ElixirStructOperation
+import org.elixir_lang.psi.QualifiableAlias
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.call.name.Function
+import org.elixir_lang.psi.call.name.Module
+import org.elixir_lang.psi.qualifier
 import org.elixir_lang.psi.impl.maybeModularNameToModulars
 
 class CallDefinitionClause : CompletionProvider<CompletionParameters>() {
+    /** The copy is read first: its dummy identifier terminates the qualified name. */
     private fun maybeModularName(parameters: CompletionParameters): PsiElement? =
-        parameters.originalPosition?.let { originalPosition ->
-            originalPosition.parent?.let { originalParent ->
-                val grandParent = originalParent.parent
+        (maybeModularNameAt(parameters.position) ?: maybeModularNameAt(parameters.originalPosition))
+            ?.takeIf(::callIsValidAt)
 
-                if (grandParent is org.elixir_lang.psi.qualification.Qualified) {
-                    grandParent.qualifier()
-                } else if (originalPosition is PsiWhiteSpace) {
-                    val originalPositionOffset = originalPosition.textOffset
-
-                    if (originalPositionOffset > 0) {
-                        val previousElement = parameters.originalFile.findElementAt(originalPositionOffset - 1)
-
-                        if (previousElement != null && previousElement.node.elementType === ElixirTypes.DOT_OPERATOR) {
-                            // A trailing dot has no grammar production, so error recovery only wraps it in a
-                            // dotInfixOperator when what follows can complete the call. When a sibling statement
-                            // follows instead, the dot stays a loose leaf beside its qualifier.
-                            previousElement.prevSibling ?: previousElement.parent.prevSibling
-                        } else {
-                            null
-                        }
-                    } else {
-                        null
-                    }
-                } else {
-                    null
-                }
+    private fun maybeModularNameAt(position: PsiElement?): PsiElement? =
+        position?.parent?.parent?.let { qualifiedName ->
+            // Bare, the copy's dummy makes `Mod.` a qualified alias; with a prefix typed it is a call.
+            when (qualifiedName) {
+                is org.elixir_lang.psi.qualification.Qualified -> qualifiedName.qualifier()
+                is QualifiableAlias -> qualifiedName.qualifier()
+                else -> null
             }
         }
+
+    private fun callIsValidAt(qualifiedAlias: PsiElement): Boolean =
+        generateSequence(qualifiedAlias.parent) { it.parent }
+            .takeWhile { it !is PsiFile }
+            .none { ancestor ->
+                when (ancestor) {
+                    is ElixirStructOperation -> !isInsideStructArguments(ancestor, qualifiedAlias)
+                    is Call -> namesModuleDirective(ancestor, qualifiedAlias)
+                    else -> false
+                }
+            }
+
+    /**
+     * `structOperation ::= mapPrefixOperator mapExpression eolStar mapArguments`, so a field value has the
+     * struct operation as an ancestor too and only the name part must be refused.
+     */
+    private fun isInsideStructArguments(
+        structOperation: ElixirStructOperation,
+        qualifiedAlias: PsiElement
+    ): Boolean = PsiTreeUtil.isAncestor(structOperation.mapArguments, qualifiedAlias, false)
+
+    /**
+     * `defmodule` needs listing even though `QualifiableAliasImpl.isDefmoduleDeclarationName` nulls the
+     * reference for one: that recognises a `defmodule` by its `do` block, which a name still being typed
+     * has not got yet.
+     */
+    private fun namesModuleDirective(call: Call, qualifiedAlias: PsiElement): Boolean =
+        call.functionName() in MODULE_NAMING_FUNCTION_NAMES &&
+            call.resolvedModuleName() == Module.KERNEL &&
+            call.primaryArguments()?.firstOrNull()
+                ?.let { PsiTreeUtil.isAncestor(it, qualifiedAlias, false) } == true
 
     override fun addCompletions(
         parameters: CompletionParameters,
@@ -65,5 +87,23 @@ class CallDefinitionClause : CompletionProvider<CompletionParameters>() {
                 )
             }
         }
+    }
+
+    companion object {
+        /**
+         * `Kernel` calls whose first argument is a module name rather than an expression.
+         *
+         * The other module-name positions this does not reach are listed in
+         * [#4051](https://github.com/KronicDeth/intellij-elixir/issues/4051).
+         */
+        private val MODULE_NAMING_FUNCTION_NAMES = setOf(
+            Function.ALIAS,
+            Function.DEFIMPL,
+            Function.DEFMODULE,
+            Function.DEFPROTOCOL,
+            Function.IMPORT,
+            Function.REQUIRE,
+            Function.USE
+        )
     }
 }

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/alias_directive_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/alias_directive_usage.ex
@@ -1,0 +1,3 @@
+defmodule Prefix.AliasDirectiveUsage do
+  alias Prefix.PublicFunctionDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/atom_call_follows_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/atom_call_follows_usage.ex
@@ -1,0 +1,8 @@
+defmodule Prefix.AtomCallFollowsUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  def run do
+    PublicFunctionDeclaration.<caret>
+    :maps.values(%{})
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defimpl_name_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defimpl_name_usage.ex
@@ -1,0 +1,2 @@
+defimpl Prefix.PublicFunctionDeclaration.<caret> do
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defmodule_name_do_block_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defmodule_name_do_block_usage.ex
@@ -1,0 +1,2 @@
+defmodule Prefix.PublicFunctionDeclaration.<caret> do
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defmodule_name_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defmodule_name_usage.ex
@@ -1,0 +1,1 @@
+defmodule Prefix.PublicFunctionDeclaration.<caret>

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defprotocol_name_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/defprotocol_name_usage.ex
@@ -1,0 +1,2 @@
+defprotocol Prefix.PublicFunctionDeclaration.<caret> do
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/existing_call_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/existing_call_usage.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.ExistingCallUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  def run(n) do
+    PublicFunctionDeclaration.<caret>public_function1(n)
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/import_directive_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/import_directive_usage.ex
@@ -1,0 +1,3 @@
+defmodule Prefix.ImportDirectiveUsage do
+  import Prefix.PublicFunctionDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/nested_qualifier_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/nested_qualifier_usage.ex
@@ -1,0 +1,6 @@
+defmodule Prefix.NestedQualifierUsage do
+  def run do
+    Prefix.PublicFunctionDeclaration.<caret>
+    Prefix.PublicFunctionDeclaration.public_function1()
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/require_directive_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/require_directive_usage.ex
@@ -1,0 +1,3 @@
+defmodule Prefix.RequireDirectiveUsage do
+  require Prefix.PublicFunctionDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_enclosing_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_enclosing_usage.ex
@@ -1,0 +1,11 @@
+defmodule Outer do
+  def before_function(a), do: a
+
+  def run do
+    Outer.<caret>
+  end
+
+  def after_function(a), do: a
+
+  defdelegate delegated(a), to: Enum
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_nested_after_caret_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_nested_after_caret_usage.ex
@@ -1,0 +1,9 @@
+defmodule Outer do
+  def run do
+    Inner.<caret>
+  end
+
+  defmodule Inner do
+    def inner_function(a), do: a
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_nested_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_nested_usage.ex
@@ -1,0 +1,10 @@
+defmodule Outer do
+  defmodule Inner do
+    def inner_function(a), do: a
+  end
+
+  def run do
+    Inner.<caret>
+    Inner.inner_function(1)
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_shifted_sibling_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/same_file_shifted_sibling_usage.ex
@@ -1,0 +1,5 @@
+defmodule Outer do
+  def run, do: Outer.<caret>
+  def abc(x), do: x
+  def b(x), do: x
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/sibling_qualified_call_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/sibling_qualified_call_usage.ex
@@ -1,0 +1,8 @@
+defmodule Prefix.SiblingQualifiedCallUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  def run do
+    PublicFunctionDeclaration.<caret>
+    PublicFunctionDeclaration.public_function1()
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_field_existing_call_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_field_existing_call_usage.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.StructFieldExistingCallUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  def run(n) do
+    %SomeStruct{name: PublicFunctionDeclaration.<caret>public_function1(n)}
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_field_value_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_field_value_usage.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.StructFieldValueUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  def run do
+    %SomeStruct{name: PublicFunctionDeclaration.<caret>}
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_literal_no_braces_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_literal_no_braces_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.StructLiteralNoBracesUsage do
+  def run do
+    %Prefix.PublicFunctionDeclaration.<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_literal_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/struct_literal_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.StructLiteralUsage do
+  def run do
+    %Prefix.PublicFunctionDeclaration.<caret>{}
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_directive_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_directive_usage.ex
@@ -1,0 +1,3 @@
+defmodule Prefix.UseDirectiveUsage do
+  use Prefix.PublicFunctionDeclaration.<caret>
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_do_block_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_do_block_usage.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.UseDoBlockUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  use Prefix.SomeBehaviour do
+    PublicFunctionDeclaration.<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_no_arguments_do_block_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_no_arguments_do_block_usage.ex
@@ -1,0 +1,7 @@
+defmodule Prefix.UseNoArgumentsDoBlockUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  use do
+    PublicFunctionDeclaration.<caret>
+  end
+end

--- a/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_option_value_usage.ex
+++ b/testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause/use_option_value_usage.ex
@@ -1,0 +1,5 @@
+defmodule Prefix.UseOptionValueUsage do
+  alias Prefix.PublicFunctionDeclaration
+
+  use Prefix.SomeBehaviour, adapter: PublicFunctionDeclaration.<caret>
+end

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CallDefinitionClauseTest.java
@@ -203,6 +203,32 @@ public class CallDefinitionClauseTest extends PlatformTestCase {
         assertCompletionOffersExactly(myFixture.getLookupElementStrings(), "public_function1", "public_function2");
     }
 
+    public void testQualifiedFunctionOfferedWhenAQualifiedCallFollows() {
+        myFixture.configureByFiles("sibling_qualified_call_usage.ex", "public_function_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        assertCompletionOffersExactly(myFixture.getLookupElementStrings(), "public_function1", "public_function2");
+    }
+
+    /**
+     * A trailing dot binds to a following *alias*, but not to a following atom: Elixir rejects
+     * {@code "Enum.\n:maps.values(%{})"} outright, so the original file's tree comes from error recovery
+     * rather than from the two statements being joined.
+     */
+    public void testQualifiedFunctionOfferedWhenAnAtomQualifiedCallFollows() {
+        myFixture.configureByFiles("atom_call_follows_usage.ex", "public_function_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        assertCompletionOffersExactly(myFixture.getLookupElementStrings(), "public_function1", "public_function2");
+    }
+
+    public void testQualifiedFunctionOfferedForANestedQualifierWhenAQualifiedCallFollows() {
+        myFixture.configureByFiles("nested_qualifier_usage.ex", "public_function_declaration.ex");
+        myFixture.complete(CompletionType.BASIC, 1);
+
+        assertCompletionOffersExactly(myFixture.getLookupElementStrings(), "public_function1", "public_function2");
+    }
+
     public void testQualifiedFunctionOfferedWhenAnotherStatementFollowsInBlock() {
         myFixture.configureByFiles("following_statement_usage.ex", "following_statement_declaration.ex");
         myFixture.complete(CompletionType.BASIC, 1);

--- a/tests/org/elixir_lang/code_insight/completion/contributor/CompletionCopyLeakTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/CompletionCopyLeakTest.kt
@@ -1,0 +1,128 @@
+package org.elixir_lang.code_insight.completion.contributor
+
+import com.intellij.codeInsight.completion.CompletionType
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.call.Call
+
+/**
+ * A lookup element must point at the user's file, never at the completion copy.
+ *
+ * A modular in another file resolves through the stub index and cannot leak. A same-file sibling is mapped
+ * by `getOriginalOrSelf` alone; only the enclosing and swallowed declarations need more than that.
+ * Assert on `isPhysical`: a copy's `virtualFile` is null, not a `LightVirtualFile`, so the obvious check
+ * passes on a leaked copy.
+ */
+class CompletionCopyLeakTest : PlatformTestCase() {
+    fun testLookupElementPointsAtTheRealFileForASameFileModular() {
+        myFixture.configureByFiles("same_file_nested_usage.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val element = myFixture.lookupElements.orEmpty().firstOrNull { it.lookupString == "inner_function" }
+
+        assertNotNull(
+            "Completion should offer inner_function from the same file, got: ${myFixture.lookupElementStrings}",
+            element
+        )
+
+        val containingFile = element!!.psiElement?.containingFile
+
+        assertNotNull("Lookup element lost its PSI element", containingFile)
+        assertTrue(
+            "Lookup element points at the throwaway completion copy rather than the user's file " +
+                "(isPhysical=${containingFile!!.isPhysical}, virtualFile=${containingFile.virtualFile})",
+            containingFile.isPhysical
+        )
+    }
+
+    fun testLookupElementPointsAtTheRealFileForASameFileModularBelowTheCaret() {
+        myFixture.configureByFiles("same_file_nested_after_caret_usage.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val element = myFixture.lookupElements.orEmpty().firstOrNull { it.lookupString == "inner_function" }
+
+        assertNotNull(
+            "Completion should offer inner_function from the same file, got: ${myFixture.lookupElementStrings}",
+            element
+        )
+
+        val containingFile = element!!.psiElement?.containingFile
+
+        assertNotNull("Lookup element lost its PSI element", containingFile)
+        assertTrue(
+            "Lookup element points at the throwaway completion copy rather than the user's file " +
+                "(isPhysical=${containingFile!!.isPhysical}, virtualFile=${containingFile.virtualFile})",
+            containingFile.isPhysical
+        )
+    }
+
+    /** The enclosing modular, whose range spans the dummy identifier, unlike the two sibling cases above. */
+    fun testLookupElementPointsAtTheRealFileForTheEnclosingModular() {
+        myFixture.configureByFiles("same_file_enclosing_usage.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val offered = myFixture.lookupElementStrings.orEmpty()
+
+        assertTrue(
+            "Every function of the enclosing module should be offered, got: $offered",
+            offered.containsAll(listOf("before_function", "run", "after_function", "delegated"))
+        )
+
+        myFixture.lookupElements.orEmpty().forEach { element ->
+            val containingFile = element.psiElement?.containingFile
+
+            assertNotNull("Lookup element ${element.lookupString} lost its PSI element", containingFile)
+            assertTrue(
+                "Lookup element ${element.lookupString} points at the throwaway completion copy rather " +
+                    "than the user's file (isPhysical=${containingFile!!.isPhysical}, " +
+                    "virtualFile=${containingFile.virtualFile})",
+                containingFile.isPhysical
+            )
+        }
+
+        // `run` encloses the caret, so it is the one that needs mapping rather than an early return. It
+        // must come back as its clause, which is what the renderer and Quick Documentation read; the leaf
+        // at the same offset would be physical too and tell us nothing.
+        val enclosing = myFixture.lookupElements.orEmpty().first { it.lookupString == "run" }
+
+        assertTrue(
+            "run points at ${enclosing.psiElement?.javaClass?.simpleName}, not its declaration",
+            (enclosing.psiElement as? Call)?.let { org.elixir_lang.psi.CallDefinitionClause.`is`(it) } == true
+        )
+    }
+
+    /**
+     * A declaration the trailing dot swallowed still points at its own position in the user's file.
+     *
+     * There is no clause node for it in the original tree, so the assertion is on where the element sits,
+     * not what it is. `def abc` starts exactly one dummy identifier before `def b`, so an untranslated
+     * copy offset lands on `b` and reports it as `abc`.
+     */
+    fun testLookupElementPointsAtTheSwallowedDeclarationsOwnPosition() {
+        myFixture.configureByFiles("same_file_shifted_sibling_usage.ex")
+        myFixture.complete(CompletionType.BASIC, 1)
+
+        val element = myFixture.lookupElements.orEmpty().firstOrNull { it.lookupString == "abc" }
+
+        assertNotNull("Completion should offer abc, got: ${myFixture.lookupElementStrings}", element)
+
+        val target = element!!.psiElement
+
+        assertNotNull("Lookup element lost its PSI element", target)
+        assertTrue(
+            "Lookup element for abc points at the throwaway completion copy " +
+                "(isPhysical=${target!!.containingFile.isPhysical})",
+            target.containingFile.isPhysical
+        )
+
+        val offset = target.textRange.startOffset
+
+        assertTrue(
+            "Lookup element for abc points at offset $offset, which is " +
+                "\"${myFixture.file.text.drop(offset).take(16)}\"",
+            myFixture.file.text.startsWith("def abc", offset)
+        )
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause"
+}

--- a/tests/org/elixir_lang/code_insight/completion/contributor/ErlangModuleCompletionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/ErlangModuleCompletionTest.kt
@@ -83,6 +83,37 @@ class ErlangModuleCompletionTest : BeamLibraryTestCase() {
     }
 
     /**
+     * `:math.<caret>` with nothing typed after the dot offers `sqrt` too.
+     *
+     * Distinct from the prefixed case above: the completion copy inserts an alias-shaped dummy
+     * identifier, and an atom followed by an alias is a syntax error in Elixir - `Code.string_to_quoted`
+     * rejects it with "atom cannot be followed by an alias". This grammar is more permissive than the
+     * language: `matchedQualifiedAlias ::= matchedExpression dotInfixOperator alias`
+     * and an atom is a `matchedExpression`, so `:math.<dummy>` still reduces to a qualified *alias* and is
+     * answered by the same branch as `Mod.<caret>`. `:math.s<caret>` reaches the qualified-call branch
+     * instead, because a lowercase dummy continues a call.
+     */
+    fun testErlangModuleFunctionsAreOfferedAfterABareAtomQualifier() {
+        myFixture.configureByText(
+            "test.ex",
+            """
+                defmodule Test do
+                  def run do
+                    :math.<caret>
+                  end
+                end
+            """.trimIndent()
+        )
+
+        val strings = myFixture.completionStringsAtCaret()
+        assertNotNull("No completion popup after the bare Erlang atom qualifier `:math.`", strings)
+        assertTrue(
+            "Expected `sqrt` among the completions after `:math.`, got: ${strings!!.sorted()}",
+            strings.contains("sqrt")
+        )
+    }
+
+    /**
      * `{:math, :s<caret>, 1}` offers `sqrt` - the MFA-tuple function atom against a BEAM module.
      * `ErlangMfaTupleReferenceTest` pins that this resolves; this pins that it completes.
      */

--- a/tests/org/elixir_lang/code_insight/completion/contributor/QualifiedAliasPositionTest.kt
+++ b/tests/org/elixir_lang/code_insight/completion/contributor/QualifiedAliasPositionTest.kt
@@ -1,0 +1,142 @@
+package org.elixir_lang.code_insight.completion.contributor
+
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.code_insight.completionAttemptAtCaret
+import org.elixir_lang.code_insight.completionStringsAtCaret
+
+/**
+ * Where a qualified name may and may not be completed as a function.
+ *
+ * The contributor's pattern is only `afterLeaf(".")`, so an expression, a directive, a definer's name
+ * and a struct literal all arrive identically. Only the module being named is off limits; what these
+ * constructs contain is ordinary code.
+ */
+class QualifiedAliasPositionTest : PlatformTestCase() {
+    fun testFunctionsNotOfferedInAnAliasDirective() {
+        assertNoFunctionsOfferedIn("alias_directive_usage.ex")
+    }
+
+    fun testFunctionsNotOfferedInAnImportDirective() {
+        assertNoFunctionsOfferedIn("import_directive_usage.ex")
+    }
+
+    fun testFunctionsNotOfferedInARequireDirective() {
+        assertNoFunctionsOfferedIn("require_directive_usage.ex")
+    }
+
+    fun testFunctionsNotOfferedInAUseDirective() {
+        assertNoFunctionsOfferedIn("use_directive_usage.ex")
+    }
+
+    fun testFunctionsNotOfferedInAStructName() {
+        assertNoFunctionsOfferedIn("struct_literal_usage.ex")
+    }
+
+    /**
+     * `%Prefix.Mod.<caret>` before the braces offers nothing because no qualified name is found at all, not
+     * because the struct guard refused it: `structOperation` needs its `mapArguments`, so without the
+     * braces there is no `ElixirStructOperation` ancestor for the guard to see.
+     */
+    fun testFunctionsNotOfferedInAStructNameWithoutBraces() {
+        assertNoFunctionsOfferedIn("struct_literal_no_braces_usage.ex")
+    }
+
+    /**
+     * `isDefmoduleDeclarationName` recognises a `defmodule` by its `do` block, which a name still being
+     * typed has not got yet.
+     */
+    fun testFunctionsNotOfferedInADefmoduleName() {
+        assertNoFunctionsOfferedIn("defmodule_name_usage.ex")
+    }
+
+    /**
+     * With the `do` block written, `isDefmoduleDeclarationName` nulls the reference, so resolution finds
+     * nothing even with the guard removed. The refusal is over-determined and this cannot distinguish the
+     * two; [testFunctionsNotOfferedInADefmoduleName] is what pins the guard.
+     */
+    fun testFunctionsNotOfferedInADefmoduleNameWithADoBlock() {
+        assertNoFunctionsOfferedIn("defmodule_name_do_block_usage.ex")
+    }
+
+    fun testFunctionsNotOfferedInADefprotocolName() {
+        assertNoFunctionsOfferedIn("defprotocol_name_usage.ex")
+    }
+
+    fun testFunctionsNotOfferedInADefimplName() {
+        assertNoFunctionsOfferedIn("defimpl_name_usage.ex")
+    }
+
+    fun testFunctionsOfferedInADirectiveOptionValue() {
+        assertFunctionsOfferedIn("use_option_value_usage.ex")
+    }
+
+    /** A struct's field value is ordinary code, unlike its name. */
+    fun testFunctionsOfferedInAStructFieldValue() {
+        assertFunctionsOfferedIn("struct_field_value_usage.ex")
+    }
+
+    fun testFunctionsOfferedInsideAnExistingCall() {
+        assertFunctionsOfferedIn("existing_call_usage.ex")
+    }
+
+    /**
+     * Between the braces an alias-shaped dummy cannot be called, so recovery flattens the copy and no
+     * qualified name survives in it to read - the one shape needing the original file.
+     */
+    fun testFunctionsOfferedInsideAnExistingCallInAStructFieldValue() {
+        assertFunctionsOfferedIn("struct_field_existing_call_usage.ex")
+    }
+
+    /** A directive's `do` block is ordinary code, unlike the module it names. */
+    fun testFunctionsOfferedInsideAUseDoBlock() {
+        assertFunctionsOfferedIn("use_do_block_usage.ex")
+    }
+
+    /** `primaryArguments()` is `null` for the `None`-arity call `use do … end`, so nothing is refused. */
+    fun testFunctionsOfferedInsideAnArgumentlessUseDoBlock() {
+        assertFunctionsOfferedIn("use_no_arguments_do_block_usage.ex")
+    }
+
+    private fun assertFunctionsOfferedIn(usageFile: String) {
+        configure(usageFile)
+
+        val offered = myFixture.completionStringsAtCaret().orEmpty()
+
+        assertTrue(
+            "Expected the module's functions where a call is valid, got: $offered",
+            offered.containsAll(FUNCTION_NAMES)
+        )
+    }
+
+    /**
+     * The candidates are `null` both when nothing was offered and when a lone candidate auto-inserted, so
+     * the document is checked too or a silent rewrite would pass.
+     */
+    private fun assertNoFunctionsOfferedIn(usageFile: String) {
+        configure(usageFile)
+
+        val before = myFixture.file.text
+        val (candidates, text) = myFixture.completionAttemptAtCaret()
+
+        assertFalse(
+            "A function name was offered where only a module name is valid, got: $candidates",
+            candidates.orEmpty().any { it in FUNCTION_NAMES }
+        )
+        assertEquals(
+            "Completion rewrote the document where only a module name is valid",
+            before,
+            text
+        )
+    }
+
+    private fun configure(usageFile: String) {
+        myFixture.configureByFiles(usageFile, "public_function_declaration.ex")
+    }
+
+    override fun getTestDataPath(): String =
+        "testData/org/elixir_lang/code_insight/completion/contributor/call_definition_clause"
+
+    companion object {
+        private val FUNCTION_NAMES = listOf("public_function1", "public_function2")
+    }
+}


### PR DESCRIPTION
Fixes #4041.

Completing `Mod.` offered nothing when another qualified call followed the caret:

```elixir
def broken do
  Enum.<caret>
  Enum.any?([])
end
```

The parse is right and matches the compiler: a trailing dot binds to a following alias, so `Code.string_to_quoted("Enum.\nEnum.any?([])")` reads that as the single expression `Enum.Enum.any?([])`. The user's file therefore yields the wrong qualifier, and it resolves to nothing.

**The completion copy is read first.** There the dummy identifier terminates the qualified name and the following call is its own statement again, so the copy describes the edit in progress. The dot's parent is then a qualified *alias* rather than a qualified call, which had no branch.

**The user's file is still read second, for the one shape the copy cannot express** — a caret parked inside an existing call in a struct's field value, `%User{name: Mod.<caret>upcase(n)}`. The dummy is alias-shaped and an alias cannot be called, so between the braces the copy is a syntax error that recovery flattens, leaving no qualified name to read.

**Both readings refuse the module being named.** The contributor's pattern is only `afterLeaf(".")`, so an expression, a directive, a definer's name and a struct literal all arrive identically. Newly refused: the first argument of `alias`, `import`, `require`, `use`, `defimpl` or `defprotocol`, and a `defmodule` whose `do` block is written. A `defmodule` name still being typed, and a struct's name, are refused on `main` already — but the copy-first reading would have started offering in both, so the guard covers them too.

What those constructs *contain* is ordinary code — a directive's `do` block and its option list complete as before, and a struct's field value now completes where it previously offered nothing.

## Declarations are mapped back to the user's file

This is also what makes a declaration written *below* the caret appear at all: a bare trailing dot leaves the rest of the file unparseable, so on `main` completion sees only what precedes it. A modular declared in the same file resolves inside the copy, so its declarations come back as copy PSI. Left alone that sends navigation and Quick Documentation to a throwaway file, and logs an error at the user once the copy is invalidated.

Mapping happens **per declaration, as each lookup element is built** rather than on the modular they were found in, because the copy is the only tree where a swallowed declaration is still a child of its module.

`CompletionUtil.getOriginalOrSelf` does most of it, but it needs a same-class node starting at the translated start and ending no later than the translated end, and it returns the copy rather than `null` when it cannot find one. Two cases defeat it: the declaration *enclosing* the caret has such a node but it runs past the translated end, and a *swallowed* declaration has none at that offset at all. Both are handled by mapping the declaration's first leaf, which the platform's own translator can place, and taking the element at that position.

## Known limitations

A declaration the dot swallowed is offered, and navigates correctly, but renders without its icon or `(params)` and has no Quick Documentation — the renderer and `generateDoc` both need a `Call`, and the user's file has none there until the dot is completed:

```elixir
defmodule Outer do
  def run, do: Outer.<caret>
  def abc(x), do: x # offered, but as a bare name
  def b(x), do: x   # same
end
```

Module-name positions that are not a first argument — `defimpl`'s `for:`, `alias`/`require`'s `as:`, `defdelegate`'s `to:`, `@behaviour`, `@impl`, a `@type` right-hand side — still offer functions, unchanged from `main`.

Both are recorded in #4051, which proposes the unification that fixes them properly: a position check knows argument positions, not what a module name is.

## Tests

`QualifiedAliasPositionTest` (16) covers both sides of the position rule, including the two shapes that pass for a reason other than the guard beside them — a `defmodule` whose `do` block already nulls the reference, and a struct name before its braces exist, where no `structOperation` is reduced at all.

`CompletionCopyLeakTest` (4) asserts a lookup element points into the user's file: for a modular declared above the caret, below it, and enclosing it, and that a swallowed declaration lands on its own position rather than on a later declaration at the untranslated offset. It asserts `isPhysical` rather than the virtual file, since a copy's virtual file is `null` and the obvious check passes on a leaked copy.

`CallDefinitionClauseTest` (19) and `ErlangModuleCompletionTest` (5) add the following-call shapes. Of these, only `sibling_qualified_call_usage.ex` reproduces #4041 on `main` (`same_file_nested_usage.ex` does too, in `CompletionCopyLeakTest`); the multi-segment, atom-qualified and bare `:math.<caret>` cases are non-regression coverage for shapes the copy-first reading could have broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






