### PR TITLE
fix(resolution): bound the transitive alias fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@
   - **A struct or exception in the Structure View is named after its module instead of part of the
     file path.** Fixes [#4069](https://github.com/KronicDeth/intellij-elixir/issues/4069).
 
+- [#4063](https://github.com/KronicDeth/intellij-elixir/pull/4063) [@sh41](https://github.com/sh41)
+  - **An `alias` naming a module that does not exist no longer crashes the IDE with a
+    `StackOverflowError`.** Fixes [#3978](https://github.com/KronicDeth/intellij-elixir/issues/3978).
+
 - [#4039](https://github.com/KronicDeth/intellij-elixir/pull/4039) [@sh41](https://github.com/sh41)
   - **Go To Declaration, autocomplete and Quick Documentation now work for functions declared with
     `defdelegate`, including delegations into compiled modules such as `Map.values/1`.** Fixes

--- a/src/org/elixir_lang/errorreport/Logger.kt
+++ b/src/org/elixir_lang/errorreport/Logger.kt
@@ -19,10 +19,11 @@ object Logger {
      * @param klass   Class whose logger to use
      * @param title   Title of error stored in [Throwable].
      * @param element element responsible for the error
+     * @param cause   omitting it leaves the report carrying a synthetic trace built from the title
      */
     @JvmStatic
-    fun error(klass: Class<*>, title: String, element: PsiElement) {
-        error(Logger.getInstance(klass), title, element)
+    fun error(klass: Class<*>, title: String, element: PsiElement, cause: Throwable? = null) {
+        error(Logger.getInstance(klass), title, element, cause)
     }
 
     fun error(klass: Class<*>, title: String, term: OtpErlangObject) {
@@ -36,13 +37,15 @@ object Logger {
      * @param logger  logger to which to log an error.
      * @param title   Title of error stored in [Throwable].
      * @param element element responsible for the error
+     * @param cause   omitting it leaves the report carrying a synthetic trace built from the title
      */
     fun error(
         logger: Logger,
         title: String,
-        element: PsiElement
+        element: PsiElement,
+        cause: Throwable? = null
     ) {
-        val throwable = Throwable(title)
+        val throwable = Throwable(title, cause)
         val containingFile = element.containingFile
         val message = message(containingFile, element)
         val virtualFile = containingFile.virtualFile

--- a/src/org/elixir_lang/injection/markdown/Injector.kt
+++ b/src/org/elixir_lang/injection/markdown/Injector.kt
@@ -155,8 +155,13 @@ class Injector : MultiHostInjector {
 
                 try {
                     registrar.addPlace(null, null, documentation, textRangeInQuote)
-                } catch (_: RuntimeExceptionWithAttachments) {
-                    Logger.error(javaClass, "Cannot inject markdown in Heredoc", documentation)
+                } catch (runtimeExceptionWithAttachments: RuntimeExceptionWithAttachments) {
+                    Logger.error(
+                        javaClass,
+                        "Cannot inject markdown in Heredoc",
+                        documentation,
+                        runtimeExceptionWithAttachments
+                    )
                 }
             }
         }

--- a/src/org/elixir_lang/psi/impl/call/CallImpl.kt
+++ b/src/org/elixir_lang/psi/impl/call/CallImpl.kt
@@ -173,8 +173,13 @@ fun Call.finalArity(): Int? = secondaryArity() ?: primaryArity()
 @RequiresReadLock
 fun Call.finalArguments(): Array<PsiElement>? = try {
     (secondaryArguments() ?: primaryArguments())?.map { it!! }?.toTypedArray()
-} catch (_: NullPointerException) {
-    Logger.error(this.javaClass, "NullPointerException getting Call.finalArguments()", this)
+} catch (nullPointerException: NullPointerException) {
+    Logger.error(
+        this.javaClass,
+        "NullPointerException getting Call.finalArguments()",
+        this,
+        nullPointerException
+    )
     null
 }
 

--- a/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/psi/scope/CallDefinitionClause.kt
@@ -145,11 +145,12 @@ abstract class CallDefinitionClause : PsiScopeProcessor {
                     Import.treeWalkUp(element, state) { call, accResolveState ->
                         execute(call, accResolveState)
                     }
-                } catch (_: StackOverflowError) {
+                } catch (stackOverflowError: StackOverflowError) {
                     Logger.error(
                         CallDefinitionClause::class.java,
                         "StackOverflowError while processing import",
-                        element
+                        element,
+                        stackOverflowError
                     )
                 }
 

--- a/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
+++ b/src/org/elixir_lang/psi/scope/module/MultiResolve.kt
@@ -1,6 +1,7 @@
 package org.elixir_lang.psi.scope.module
 
 import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.util.RecursionManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
 import com.intellij.psi.ResolveState
@@ -125,26 +126,43 @@ class MultiResolve internal constructor(private val name: String, private val in
 
             // Transitive alias fallback: if stub lookup found nothing and match is a QualifiableAlias,
             // resolve it through the module scope to follow alias chains
-            // (e.g., `alias MyNamespace.Referenced; alias Referenced, as: Refd` — resolving `Refd` needs
+            // (e.g., `alias MyNamespace.Referenced; alias Referenced, as: Refd` - resolving `Refd` needs
             // to follow Referenced → MyNamespace.Referenced transitively)
             if (!found && match is QualifiableAlias) {
-                val transitiveResults = resolveResults(match.fullyQualifiedName(), incompleteCode, match)
-                for (result in transitiveResults) {
-                    val resolvedElement = result.element
-                    if (resolvedElement is NamedElement) {
-                        resolveResultOrderedSet.add(
-                            resolvedElement,
-                            resolvedElement.name ?: unaliasedName,
-                            result.isValidResult,
-                            visitedElementSet + result.visitedElementSet
-                        )
-                    }
+                addTransitiveResults(match, unaliasedName, visitedElementSet)
+            }
+        }
+    }
+
+    /**
+     * `memoize` is false because results accumulate into [resolveResultOrderedSet] as a side effect
+     * rather than being returned.
+     */
+    private fun addTransitiveResults(match: QualifiableAlias,
+                                     unaliasedName: String,
+                                     visitedElementSet: Set<PsiElement>) {
+        val searchedName = match.fullyQualifiedName()
+
+        RECURSION_GUARD.doPreventingRecursion(searchedName, false) {
+            for (result in resolveResults(searchedName, incompleteCode, match)) {
+                val resolvedElement = result.element
+
+                if (resolvedElement is NamedElement) {
+                    resolveResultOrderedSet.add(
+                        resolvedElement,
+                        resolvedElement.name ?: unaliasedName,
+                        result.isValidResult,
+                        visitedElementSet + result.visitedElementSet
+                    )
                 }
             }
         }
     }
 
     companion object {
+        private val RECURSION_GUARD =
+                RecursionManager.createGuard<String>("org.elixir_lang.psi.scope.module.MultiResolve")
+
         fun resolveResults(name: String,
                            incompleteCode: Boolean,
                            entrance: PsiElement): List<VisitedElementSetResolveResult> =

--- a/src/org/elixir_lang/reference.kt
+++ b/src/org/elixir_lang/reference.kt
@@ -15,7 +15,12 @@ fun safeMultiResolve(reference: PsiPolyVariantReference, incompleteCode: Boolean
     try {
         reference.multiResolve(incompleteCode)
     } catch (stackOverflowError: StackOverflowError) {
-        Logger.error(PsiPolyVariantReference::class.java, "StackOverflow resolving reference", reference.element)
+        Logger.error(
+            PsiPolyVariantReference::class.java,
+            "StackOverflow resolving reference",
+            reference.element,
+            stackOverflowError
+        )
 
         emptyArray()
     }

--- a/src/org/elixir_lang/reference/resolver/Callable.kt
+++ b/src/org/elixir_lang/reference/resolver/Callable.kt
@@ -123,8 +123,13 @@ object Callable : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Cal
                 } else {
                     resolveUnqualified(element, name, resolvedPrimaryArity, incompleteCode)
                 }
-            } catch (_: StackOverflowError) {
-                Logger.error(Callable::class.java, "StackOverflowError when annotating Call", element)
+            } catch (stackOverflowError: StackOverflowError) {
+                Logger.error(
+                    Callable::class.java,
+                    "StackOverflowError when annotating Call",
+                    element,
+                    stackOverflowError
+                )
 
                 emptyList()
             }

--- a/src/org/elixir_lang/reference/resolver/Module.kt
+++ b/src/org/elixir_lang/reference/resolver/Module.kt
@@ -2,11 +2,14 @@ package org.elixir_lang.reference.resolver
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.diagnostic.ControlFlowException
+import kotlinx.coroutines.CancellationException
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.impl.source.resolve.ResolveCache
 import com.intellij.psi.stubs.StubIndex
+import org.elixir_lang.errorreport.Logger
 import org.elixir_lang.psi.Alias
 import org.elixir_lang.psi.NamedElement
 import org.elixir_lang.psi.Require
@@ -84,9 +87,34 @@ object Module : ResolveCache.PolyVariantResolver<org.elixir_lang.reference.Modul
     }
 
     private fun resolveAll(element: PsiElement, name: String, incompleteCode: Boolean) =
-        resolveInScope(element, name, incompleteCode)
-            .takeIf { set -> set.any(ResolveResult::isValidResult) }
-            ?: multiResolveProject(element, name)
+        try {
+            resolveInScope(element, name, incompleteCode)
+                .takeIf { set -> set.any(ResolveResult::isValidResult) }
+                ?: multiResolveProject(element, name)
+        } catch (stackOverflowError: StackOverflowError) {
+            Logger.error(Module::class.java, "StackOverflowError when resolving Alias", element, stackOverflowError)
+
+            emptyList()
+        } catch (runtimeException: RuntimeException) {
+            // `RecursionManager` rewraps anything raised in its own unwinding, so an overflow can
+            // arrive with its cause nested. Cancellation is excluded per `tryCatchUtils.kt`.
+            if (runtimeException is ControlFlowException ||
+                runtimeException is CancellationException ||
+                generateSequence<Throwable>(runtimeException) { it.cause }
+                    .none { it is StackOverflowError }
+            ) {
+                throw runtimeException
+            }
+
+            Logger.error(
+                Module::class.java,
+                "StackOverflowError unwinding alias resolution",
+                element,
+                runtimeException
+            )
+
+            emptyList()
+        }
 
     private fun resolveInScope(element: PsiElement, name: String, incompleteCode: Boolean) =
         MultiResolve.resolveResults(name, incompleteCode, element)

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/cycle_a.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/cycle_a.ex
@@ -1,0 +1,9 @@
+defmodule CycleA do
+  use CycleB
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Missing
+    end
+  end
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/cycle_b.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/cycle_b.ex
@@ -1,0 +1,9 @@
+defmodule CycleB do
+  use CycleA
+
+  defmacro __using__(_opts) do
+    quote do
+      alias Missing
+    end
+  end
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/deep_chain.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/deep_chain.ex
@@ -1,0 +1,10 @@
+defmodule DeepChain do
+  alias MyNamespace.Referenced
+  alias Referenced, as: L1
+  alias L1, as: L2
+  alias L2, as: L3
+
+  L<caret>3
+
+  @a 1
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/mutual_use.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/mutual_use.ex
@@ -1,0 +1,8 @@
+defmodule MutualUse do
+  use CycleA
+  use CycleB
+
+  Miss<caret>ing
+
+  @a 1
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/referenced.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/referenced.ex
@@ -1,0 +1,2 @@
+defmodule MyNamespace.Referenced do
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/repeated_alias.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/repeated_alias.ex
@@ -1,0 +1,22 @@
+defmodule RepeatedAlias do
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+  alias Missing
+
+  Miss<caret>ing
+
+  @a 1
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/self_referential.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/self_referential.ex
@@ -1,0 +1,7 @@
+defmodule Cyclic.Usage do
+  alias Missing
+
+  Miss<caret>ing
+
+  @a 1
+end

--- a/testData/org/elixir_lang/reference/module/cyclic_alias/transitive.ex
+++ b/testData/org/elixir_lang/reference/module/cyclic_alias/transitive.ex
@@ -1,0 +1,8 @@
+defmodule Transitive.Usage do
+  alias MyNamespace.Referenced
+  alias Referenced, as: Refd
+
+  Re<caret>fd
+
+  @a 1
+end

--- a/tests/org/elixir_lang/reference/module/CyclicAliasTest.kt
+++ b/tests/org/elixir_lang/reference/module/CyclicAliasTest.kt
@@ -1,0 +1,96 @@
+package org.elixir_lang.reference.module
+
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.ResolveResult
+import com.intellij.testFramework.PlatformTestUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirAlias
+
+/**
+ * `resolver/Module.resolveAll` catches the overflow and logs it, so empty results alone would pass
+ * whether the walk terminated or overflowed - hence the assertions on logged errors.
+ */
+class CyclicAliasTest : PlatformTestCase() {
+    /** A single-segment `alias` of a module that does not exist re-enters the fallback on itself. */
+    fun testSelfReferentialAlias() {
+        val reference = aliasReferenceAtCaret("self_referential.ex")
+
+        val (resolveResults, loggedErrors) = captureLoggedErrors { reference.multiResolve(false) }
+
+        assertEmpty(
+            "resolving an alias of a module that does not exist logged an error",
+            loggedErrors
+        )
+        assertEmpty(resolveResults)
+    }
+
+    /** Two turns rather than one, through the `__using__` quotes of two mutually `use`d modules. */
+    fun testMutuallyUsedAlias() {
+        val reference = aliasReferenceAtCaret("mutual_use.ex", "cycle_a.ex", "cycle_b.ex")
+
+        val (resolveResults, loggedErrors) = captureLoggedErrors { reference.multiResolve(false) }
+
+        assertEmpty(
+            "resolving an alias through mutually `use`d modules logged an error",
+            loggedErrors
+        )
+        assertEmpty(resolveResults)
+    }
+
+    /** Every `alias Missing` asks the same question; keying on the name answers it once. */
+    fun testRepeatedUnresolvableAliasesTerminatePromptly() {
+        val reference = aliasReferenceAtCaret("repeated_alias.ex")
+        lateinit var resolveResults: Array<ResolveResult>
+        lateinit var loggedErrors: List<LoggedError>
+
+        PlatformTestUtil.assertTiming("the same name is being resolved more than once", 6_000, 4) {
+            // Each attempt must do the work: `ResolveCache` would serve the first result to the rest.
+            PsiManager.getInstance(project).dropResolveCaches()
+            val captured = captureLoggedErrors { reference.multiResolve(false) }
+            resolveResults = captured.first
+            loggedErrors = captured.second
+        }
+
+        assertEmpty("resolving repeated unresolvable aliases logged an error", loggedErrors)
+        assertEmpty(resolveResults)
+    }
+
+    /** A rename chain, which the name-keyed guard must not cut short. */
+    fun testDeepChainStillResolves() {
+        val resolveResults = aliasReferenceAtCaret("deep_chain.ex", "referenced.ex").multiResolve(false)
+
+        assertContainsElements(
+            resolveResults.map { it.element!!.text },
+            "defmodule MyNamespace.Referenced do\nend"
+        )
+    }
+
+    /** The control: the chain the fallback exists for, which a guard that over-fires would break. */
+    fun testTransitiveAlias() {
+        val resolveResults = aliasReferenceAtCaret("transitive.ex", "referenced.ex").multiResolve(false)
+
+        assertEquals(
+            listOf(
+                // only the fallback can reach this one, by following Refd -> Referenced ->
+                // MyNamespace.Referenced
+                "defmodule MyNamespace.Referenced do\nend",
+                "alias Referenced, as: Refd",
+                "alias MyNamespace.Referenced"
+            ),
+            resolveResults.map { it.element!!.text }
+        )
+    }
+
+    /** Returns the reference unresolved, so a caller can time or capture the resolve itself. */
+    private fun aliasReferenceAtCaret(vararg fileNames: String): PsiPolyVariantReference {
+        myFixture.configureByFiles(*fileNames)
+
+        val alias = myFixture.file.findElementAt(myFixture.caretOffset)!!.parent
+        assertInstanceOf(alias, ElixirAlias::class.java)
+
+        return assertInstanceOf(alias.reference, PsiPolyVariantReference::class.java)
+    }
+
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/reference/module/cyclic_alias"
+}


### PR DESCRIPTION
Fixes #3978.

## The defect

An `alias` naming a module the stub index cannot find sends module resolution into unbounded recursion. `MultiResolve.addUnaliasedNamedElementsToResolveResultList`'s transitive alias fallback follows the chain by re-entering the companion `resolveResults(name, incompleteCode, entrance)` overload, which starts from `ResolveState.initial()`. Nothing a walker records survives to the next turn, so the walk returns to an alias it is already following and recurses until the stack runs out.

No cyclic chain is needed - `defmodule Cyclic.Usage do alias Missing; Missing end` is enough. The cycling branch needs `aliasedName == targetName`, and `aliasedName` is the alias's last segment while the re-entered target is `match.fullyQualifiedName()`; those are equal only for a single-segment alias, so `alias Foo.Bar` terminates. That is why there is one Marketplace report rather than thousands.

The overflow escaped uncaught: the module resolver had neither the `RecursionManager` wrap nor the `catch (StackOverflowError)` that its callable sibling `reference/resolver/Callable.resolveInScope` has, and nothing above it caught either - `reference/Module.multiResolve` goes through `ResolveCache`, and `safeMultiResolve` is used only by the annotator and by `reference.kt`.

Introduced by 60a838698 and shipping since [v23.2.0](https://github.com/KronicDeth/intellij-elixir/releases/tag/v23.2.0).

## Two commits

**1. `report a module resolution overflow instead of crashing`** — gives the module resolver the net its callable sibling has, so an unbounded module walk degrades to an unresolved reference plus a logged error rather than an IDE crash. Independent of the fix below and revertible on its own.

The catch is around `resolveAll` rather than the scope walk alone so the project-wide fallback is skipped too: after an overflow, `multiResolveProject` would build a stub tree on a stack that has barely unwound. A second clause covers the wrapped form, because `RecursionManager` rethrows anything raised in its own unwinding inside a `RuntimeException`; it excludes `ControlFlowException` and `CancellationException` first, matching the never-swallow idiom in `platform/core-api/src/com/intellij/openapi/util/tryCatchUtils.kt`.

A census rather than an assumption, since grepping for `fun resolveInScope` finds only two of the four (the other two do not use that name). Of the four `ResolveCache.PolyVariantResolver` implementations, this accounts for every one that needs a net: `Callable` already had one, `CaptureNameArity` delegates its whole body to `Callable.resolve`, and `CallDefinitionClause` recurses only downward through `For.treeWalkDown` on a finite tree.

**2. `bound the transitive alias fallback`** — the fix itself, plus the tests.

## The fix

Guard the fallback with `RecursionManager`, **keyed on the name being searched rather than on the matched element**:

```kotlin
val searchedName = match.fullyQualifiedName()

RECURSION_GUARD.doPreventingRecursion(searchedName, false) { ... }
```

The key is the whole fix. Every `alias` sharing a name asks the same question — the fallback always re-enters on `match.fullyQualifiedName()` — so an element-keyed guard treats N aliases of one name as N unrelated computations and re-asks the same question once per alias. Instrumented on a file with sixteen `alias Missing` lines: **3212 nested walks, every one searching `Missing`**, taking 9.7s. Keyed on the name it is ~0.1s, and stays flat out to 48 aliases.

`memoize` is `false` because results accumulate into `resolveResultOrderedSet` as a side effect rather than being returned.

## Verification

`CyclicAliasTest` was written before the fix and proven red on unmodified `main`. Each mutation below was run, not reasoned about.

| Mutation | Result |
|---|---|
| unmodified `main` | RED - `testSelfReferentialAlias` throws a raw `java.lang.StackOverflowError` out of `multiResolve` |
| as shipped | GREEN - 25 targeted tests, including `Issue463Test`, `Issue480Test`, `Issue3405Test` and `CyclicUseTest` |
| guard removed | RED - `testSelfReferentialAlias`, `testMutuallyUsedAlias` and `testRepeatedUnresolvableAliasesTerminatePromptly`, all on the logged overflow |
| guard keyed on the element instead of the name | RED - the timing assertion alone, 9700ms against a 630ms budget |

That last row is why the timing assertion exists: it is the only thing that catches a regression to element-keying, which terminates correctly but does the work N times over.

`testTransitiveAlias` and `testDeepChainStillResolves` are the controls — the two-link chain the fallback exists for, and a four-link rename chain — so a guard that over-fires and switches the fallback off reddens rather than passing quietly.

## Known limitation

A caught `StackOverflowError` yields an empty array that `ResolveCache` keeps until the next PSI change, so one unlucky resolve leaves that reference unresolved for the rest of the epoch. This is not fixable from `MultiResolve`: `RecursionGuard.prohibitResultCaching` only stamps frames after its own `loopStart`, and `ResolveCache` opens its frame before any of this guard's, so no prohibition raised here can reach the outermost stamp. Verified by measurement — a repeat resolve returns the identical array — with `needToPreventRecursion` both `false` and `true`.

## Coarseness of the name key

Keying on the name is coarser than keying on the element: it prevents re-entry for a name already being resolved anywhere up the thread's stack, so two genuinely different resolutions of one name nesting would return nothing for the inner one. No failing case was found. Five candidate shapes were built and all resolved identically under both keys, including a cross-file `use` descent where a provider's `__using__` quotes the same alias name the consumer already has.

Better than that, because failing to imagine a case proves little: instrumenting every prevention across the `reference.*` and `psi.*` suites — 306 tests — recorded 141 preventions, **every one inside a cyclic fixture added by this PR** (`repeated_alias.ex`, `cycle_a.ex`, `cycle_b.ex`, `self_referential.ex`), and none in any pre-existing fixture. The guard only fires on the shapes it was written for.

That is a corpus result, not a proof: a shape nobody wrote a test for stays untested.

Generated with [Claude Code](https://claude.com/claude-code)


