### PR TITLE
fix(structure view): drive the tree and caret sync from one list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@
 
 ### Bug Fixes
 
+- [#4065](https://github.com/KronicDeth/intellij-elixir/pull/4065) [@sh41](https://github.com/sh41)
+  - **A module's Structure View tree and its caret sync now come from one list, so an ExUnit `test`
+    written outside a `describe` gets its own node and an `EEx.function_from_*` node follows the
+    caret.** Fixes [#4056](https://github.com/KronicDeth/intellij-elixir/issues/4056).
+  - **A struct or exception in the Structure View is named after its module instead of part of the
+    file path.** Fixes [#4069](https://github.com/KronicDeth/intellij-elixir/issues/4069).
+
 - [#4039](https://github.com/KronicDeth/intellij-elixir/pull/4039) [@sh41](https://github.com/sh41)
   - **Go To Declaration, autocomplete and Quick Documentation now work for functions declared with
     `defdelegate`, including delegations into compiled modules such as `Map.values/1`.** Fixes

--- a/src/org/elixir_lang/navigation/ChooseByNameContributor.kt
+++ b/src/org/elixir_lang/navigation/ChooseByNameContributor.kt
@@ -126,8 +126,10 @@ open class ChooseByNameContributor(private val stubIndexKey: StubIndexKey<String
         enclosingModularByCall: EnclosingModularByCall,
         call: Call
     ) {
-        // A callback outside any module has nowhere to be listed
-        enclosingModularByCall.putNew(call)?.let { items.add(Callback(it, call)) }
+        Callback.Kind.of(call)?.let { kind ->
+            // A callback outside any module has nowhere to be listed.
+            enclosingModularByCall.putNew(call)?.let { items.add(Callback(it, call, kind)) }
+        }
     }
 
     private fun getItemsFromCallDefinitionClause(

--- a/src/org/elixir_lang/navigation/item_presentation/Implementation.java
+++ b/src/org/elixir_lang/navigation/item_presentation/Implementation.java
@@ -46,61 +46,23 @@ public class Implementation implements ItemPresentation, Parent {
      * an {@link ItemPresentation} and needs to act as the
      * {@link ItemPresentation#getLocationString()}.
      *
-     * @return {@link #getLocationString()} + "." + {@link #getPresentableText()} if {@link #getLocationString()} is not
-     * {@code null}; otherwise, {@link #getPresentableText()}.
+     * @return {@link #getLocationString()} + "." + {@link #getPresentableText()}
      */
     @NotNull
     @Override
     public String getLocatedPresentableText() {
-        String locatedPresentableText;
-        String locationString = getLocationString();
-
-        if (locationString != null) {
-            locatedPresentableText = locationString + "." + getPresentableText();
-        } else {
-            locatedPresentableText = getPresentableText();
-        }
-
-        return locatedPresentableText;
+        return getLocationString() + "." + getPresentableText();
     }
 
-    /**
-     * Returns the qualifier for the module created by the `defimpl` call.
-     *
-     * @return {@link #protocolName}.{@link #forName} without the last alias in {@link #forName}.
-     */
-    @Nullable
+    @NotNull
     @Override
     public String getLocationString() {
-        String[] aliases = forName.split(".");
-        StringBuilder locationStringBuilder = new StringBuilder(protocolName);
-
-        // length - 1 to exclude the final element of aliases
-        for (int i = 0; i < aliases.length - 1; i++) {
-            locationStringBuilder.append('.');
-            locationStringBuilder.append(aliases[i]);
-        }
-
-        return locationStringBuilder.toString();
+        return protocolName;
     }
 
-    /**
-     * Return the unqualified alias name of the module created by the `defimpl` call.
-     *
-     * @return final alias in {@link #forName}
-     */
-    @Nullable
+    @NotNull
     @Override
     public String getPresentableText() {
-        String[] aliases = forName.split(".");
-        String presentableText;
-
-        if (aliases.length == 0) {
-            presentableText = forName;
-        } else {
-            presentableText = aliases[aliases.length - 1];
-        }
-
-        return  presentableText;
+        return forName;
     }
 }

--- a/src/org/elixir_lang/navigation/item_presentation/ex_unit/case/Describe.kt
+++ b/src/org/elixir_lang/navigation/item_presentation/ex_unit/case/Describe.kt
@@ -2,13 +2,24 @@ package org.elixir_lang.navigation.item_presentation.ex_unit.case
 
 import com.intellij.navigation.ItemPresentation
 import org.elixir_lang.Icons.DESCRIBE
+import org.elixir_lang.navigation.item_presentation.Parent
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.psi.impl.stripAccessExpressions
 import javax.swing.Icon
 
-class Describe(val call: Call): ItemPresentation {
+/**
+ * [Parent] as well as [ItemPresentation]: the element classes nested inside a `describe` cast their
+ * parent's presentation to [Parent] unguarded, so one that is not throws while the tree renders.
+ */
+class Describe(private val location: String?, val call: Call): ItemPresentation, Parent {
     override fun getPresentableText(): String =
             "describe ${call.finalArguments()?.stripAccessExpressions()?.firstOrNull()?.text}"
+
+    override fun getLocationString(): String? = location
+
+    override fun getLocatedPresentableText(): String =
+            locationString?.let { location -> "$location $presentableText" } ?: presentableText
+
     override fun getIcon(unused: Boolean): Icon = DESCRIBE
 }

--- a/src/org/elixir_lang/navigation/item_presentation/ex_unit/case/Test.kt
+++ b/src/org/elixir_lang/navigation/item_presentation/ex_unit/case/Test.kt
@@ -2,13 +2,27 @@ package org.elixir_lang.navigation.item_presentation.ex_unit.case
 
 import com.intellij.navigation.ItemPresentation
 import org.elixir_lang.Icons.TEST
+import org.elixir_lang.navigation.item_presentation.Parent
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.call.finalArguments
 import org.elixir_lang.psi.impl.stripAccessExpressions
 import javax.swing.Icon
 
-class Test(val call: Call): ItemPresentation {
+/**
+ * [Parent] as well as [ItemPresentation]: the element classes nested inside a `test` cast their
+ * parent's presentation to [Parent] unguarded, so one that is not throws while the tree renders.
+ */
+class Test(private val location: String?, val call: Call): ItemPresentation, Parent {
+    // `test` is arity 1..3, so a message-less one has no final arguments to interpolate.
     override fun getPresentableText(): String =
-            "test ${call.finalArguments()?.stripAccessExpressions()?.firstOrNull()?.text}"
+            call.finalArguments()?.stripAccessExpressions()?.firstOrNull()?.text
+                    ?.let { message -> "test $message" }
+                    ?: "test"
+
+    override fun getLocationString(): String? = location
+
+    override fun getLocatedPresentableText(): String =
+            locationString?.let { location -> "$location $presentableText" } ?: presentableText
+
     override fun getIcon(unused: Boolean): Icon = TEST
 }

--- a/src/org/elixir_lang/psi/scope/Module.kt
+++ b/src/org/elixir_lang/psi/scope/Module.kt
@@ -223,7 +223,8 @@ abstract class Module : PsiScopeProcessor {
 
 
     private fun executeOnModular(match: Named, state: ResolveState): Boolean =
-            if (state.get(ENTRANCE).containingFile.context == match) {
+            // No entrance means no file to have been injected into, so `match` cannot be its host.
+            if (state.get(ENTRANCE)?.containingFile?.context == match) {
                 executeOnViewModular(match, state)
             } else {
                 val keepProcessing = match.name?.let {

--- a/src/org/elixir_lang/reference.kt
+++ b/src/org/elixir_lang/reference.kt
@@ -91,7 +91,11 @@ private fun isBeingResolved(call: Call, state: ResolveState): Boolean =
 
 private fun qualifierIsBeingResolved(call: Call, state: ResolveState): Boolean =
         if (call is Qualified) {
-            call.qualifier().isAncestor(state.get(ElixirPsiImplUtil.ENTRANCE), strict = false)
+            // `isAncestor` rejects a null second argument, and a caller with no entrance has nothing
+            // for the guard to compare against.
+            state.get(ElixirPsiImplUtil.ENTRANCE)?.let { entrance ->
+                call.qualifier().isAncestor(entrance, strict = false)
+            } ?: false
         } else {
             false
         }

--- a/src/org/elixir_lang/structure_view/ChildCall.kt
+++ b/src/org/elixir_lang/structure_view/ChildCall.kt
@@ -1,0 +1,210 @@
+package org.elixir_lang.structure_view
+
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.psi.ResolveState
+import com.intellij.util.concurrency.ThreadingAssertions
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.operation.Or
+import org.elixir_lang.structure_view.element.CallDefinitionHead
+import org.elixir_lang.structure_view.element.CallDefinitionSpecification
+import org.elixir_lang.structure_view.element.Callback
+import org.elixir_lang.structure_view.element.Delegation
+import org.elixir_lang.structure_view.element.EExFunctionFrom
+import org.elixir_lang.structure_view.element.Exception
+import org.elixir_lang.structure_view.element.Overridable
+import org.elixir_lang.structure_view.element.Quote
+import org.elixir_lang.structure_view.element.Type
+import org.elixir_lang.structure_view.element.Use
+import org.elixir_lang.structure_view.element.call_definition_by_name_arity.FunctionByNameArity
+import org.elixir_lang.structure_view.element.call_definition_by_name_arity.MacroByNameArity
+import org.elixir_lang.structure_view.element.ex_unit.case.Describe
+import org.elixir_lang.structure_view.element.ex_unit.case.Test
+import org.elixir_lang.structure_view.element.modular.Implementation
+import org.elixir_lang.structure_view.element.modular.Modular
+import org.elixir_lang.structure_view.element.modular.Module
+import org.elixir_lang.structure_view.element.modular.Protocol
+import org.elixir_lang.structure_view.element.modular.Unknown
+import org.elixir_lang.structure_view.element.structure.Structure
+
+/**
+ * Every kind of call the structure view models as a child of a modular, in one ordered list, which
+ * [Module.callChildren] and [Model.isSuitable] both derive from.
+ *
+ * Scope is this dispatch only. `File.getChildren` and [org.elixir_lang.structure_view.element.Body]
+ * build tree nodes from their own lists, so a call one of those misses can still be claimed by
+ * [Model.isSuitable] - a `use Foo` inside a `def`.
+ *
+ * Order decides which entry wins for a call several match. [Unknown] is last because `Unknown.is` is
+ * `hasDoBlockOrKeyword()`, which most entries above it also satisfy; it is not a catch-all, and a call
+ * matching no entry builds nothing.
+ */
+object ChildCall {
+    class Accumulator(
+        val modular: Modular,
+        val treeElementList: MutableList<TreeElement>,
+        val functionByNameArity: FunctionByNameArity,
+        val macroByNameArity: MacroByNameArity,
+        val overridableSet: MutableSet<Overridable>,
+        val useSet: MutableSet<Use>,
+        val childCallQueue: java.util.Queue<Call>
+    )
+
+    /**
+     * @param handle `null` for an entry [Model.isSuitable] claims but this dispatch never builds; such
+     *   an entry is skipped here rather than swallowing the call.
+     * @param suitable a non-inclusion, not an exclusion - [Model.isSuitable] asks whether *any*
+     *   suitable entry matches.
+     */
+    class Entry(
+        val name: String,
+        val matches: (Call, ResolveState) -> Boolean,
+        val handle: ((Accumulator, Call) -> Unit)?,
+        val suitable: Boolean = true
+    )
+
+    val ENTRIES: List<Entry> = listOf(
+        Entry(
+            "or",
+            matches = { call, _ -> call is Or },
+            suitable = false,
+            handle = { accumulator, call -> accumulator.childCallQueue.addAll(orOperandCalls(call as Or)) }
+        ),
+        Entry(
+            "callback",
+            matches = { call, _ -> Callback.`is`(call) },
+            handle = { accumulator, call ->
+                Callback.fromCall(accumulator.modular, call)?.let { accumulator.treeElementList.add(it) }
+            }
+        ),
+        Entry(
+            "delegation",
+            matches = { call, _ -> Delegation.`is`(call) },
+            handle = { accumulator, call -> accumulator.functionByNameArity.addDelegationToTreeElementList(call) }
+        ),
+        Entry(
+            "exception",
+            matches = { call, _ -> org.elixir_lang.psi.Exception.`is`(call) },
+            handle = { accumulator, call ->
+                accumulator.functionByNameArity.exception = Exception(call)
+            }
+        ),
+        Entry(
+            "function",
+            matches = { call, _ -> org.elixir_lang.psi.CallDefinitionClause.isFunction(call) },
+            handle = { accumulator, call -> accumulator.functionByNameArity.addClausesToCallDefinition(call) }
+        ),
+        Entry(
+            "specification",
+            matches = { call, _ -> CallDefinitionSpecification.`is`(call) },
+            handle = { accumulator, call -> accumulator.functionByNameArity.addSpecificationToCallDefinition(call) }
+        ),
+        Entry(
+            "eex function_from",
+            matches = { call, state -> org.elixir_lang.EEx.isFunctionFrom(call, state) },
+            handle = { accumulator, call ->
+                accumulator.treeElementList.add(EExFunctionFrom(accumulator.modular, call))
+            }
+        ),
+        Entry(
+            "implementation",
+            matches = { call, _ -> org.elixir_lang.psi.Implementation.`is`(call) },
+            handle = { accumulator, call ->
+                accumulator.treeElementList.add(Implementation(accumulator.modular, call))
+            }
+        ),
+        Entry(
+            "macro",
+            matches = { call, _ -> org.elixir_lang.psi.CallDefinitionClause.isMacro(call) },
+            handle = { accumulator, call -> accumulator.macroByNameArity.addClausesToCallDefinition(call) }
+        ),
+        Entry(
+            "module",
+            matches = { call, _ -> org.elixir_lang.psi.Module.`is`(call) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Module(accumulator.modular, call)) }
+        ),
+        Entry(
+            "overridable",
+            matches = { call, _ -> Overridable.`is`(call) },
+            handle = { accumulator, call ->
+                val overridable = Overridable(accumulator.modular, call)
+                accumulator.overridableSet.add(overridable)
+                accumulator.treeElementList.add(overridable)
+            }
+        ),
+        Entry(
+            "protocol",
+            matches = { call, _ -> org.elixir_lang.psi.Protocol.`is`(call) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Protocol(accumulator.modular, call)) }
+        ),
+        Entry(
+            "quote",
+            matches = { call, _ -> org.elixir_lang.psi.QuoteMacro.`is`(call) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Quote(accumulator.modular, call)) }
+        ),
+        Entry(
+            "structure",
+            matches = { call, _ -> Structure.`is`(call) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Structure(call)) }
+        ),
+        Entry(
+            "type",
+            matches = { call, _ -> Type.`is`(call) },
+            handle = { accumulator, call ->
+                Type.fromCall(accumulator.modular, call)?.let { accumulator.treeElementList.add(it) }
+            }
+        ),
+        Entry(
+            "use",
+            matches = { call, _ -> org.elixir_lang.psi.Use.`is`(call) },
+            handle = { accumulator, call ->
+                val use = Use(accumulator.modular, call)
+                accumulator.useSet.add(use)
+                accumulator.treeElementList.add(use)
+            }
+        ),
+        Entry(
+            "ex_unit describe",
+            matches = { call, _ -> org.elixir_lang.psi.ex_unit.Case.isDescribe(call, ResolveState.initial()) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Describe(accumulator.modular, call)) }
+        ),
+        Entry(
+            "ex_unit test",
+            matches = { call, _ -> org.elixir_lang.psi.ex_unit.Case.isTest(call, ResolveState.initial()) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Test(accumulator.modular, call)) }
+        ),
+        Entry(
+            "call definition head",
+            matches = { call, _ -> CallDefinitionHead.`is`(call) },
+            handle = null
+        ),
+        Entry(
+            "unknown",
+            matches = { call, _ -> Unknown.`is`(call) },
+            handle = { accumulator, call -> accumulator.treeElementList.add(Unknown(accumulator.modular, call)) }
+        )
+    )
+
+    /**
+     * Entries with no handler are invisible here, so a call one of them claims still falls through to
+     * a later entry that builds.
+     */
+    @RequiresReadLock
+    fun build(accumulator: Accumulator, call: Call, resolveState: ResolveState) {
+        ThreadingAssertions.assertReadAccess()
+
+        ENTRIES
+            .firstOrNull { entry -> entry.handle != null && entry.matches(call, resolveState) }
+            ?.let { entry -> entry.handle!!(accumulator, call) }
+    }
+
+    @RequiresReadLock
+    fun isSuitable(call: Call, resolveState: ResolveState): Boolean {
+        ThreadingAssertions.assertReadAccess()
+
+        return ENTRIES.any { entry -> entry.suitable && entry.matches(call, resolveState) }
+    }
+
+    private fun orOperandCalls(or: Or): List<Call> =
+        listOfNotNull(or.leftOperand() as? Call, or.rightOperand() as? Call)
+}

--- a/src/org/elixir_lang/structure_view/Model.kt
+++ b/src/org/elixir_lang/structure_view/Model.kt
@@ -10,17 +10,10 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveState
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.psi.*
-import org.elixir_lang.psi.CallDefinitionClause.isFunction
-import org.elixir_lang.psi.CallDefinitionClause.isMacro
-import org.elixir_lang.psi.Exception
-import org.elixir_lang.psi.Use
 import org.elixir_lang.psi.call.Call
-import org.elixir_lang.psi.ex_unit.Case
 import org.elixir_lang.structure_view.element.*
-import org.elixir_lang.structure_view.element.modular.Unknown
 import org.elixir_lang.structure_view.element.structure.Field
 import org.elixir_lang.structure_view.element.structure.FieldWithDefaultValue
-import org.elixir_lang.structure_view.element.structure.Structure
 import org.elixir_lang.structure_view.node_provider.Used
 import org.elixir_lang.structure_view.sorter.Time
 import org.elixir_lang.structure_view.sorter.Visibility
@@ -76,25 +69,7 @@ class Model(elixirFile: ElixirFile, editor: Editor?) : TextEditorBasedStructureV
         private val NODE_PROVIDERS: Collection<NodeProvider<*>> = Arrays.asList<NodeProvider<*>>(Used())
 
         @RequiresReadLock
-        fun isSuitable(call: Call?): Boolean {
-            // everything in {@link Module#childCallTreeElements}
-            return isFunction(call!!) ||
-                    isMacro(call) ||
-                    CallDefinitionHead.`is`(call) ||
-                    CallDefinitionSpecification.`is`(call) ||
-                    Callback.`is`(call) ||
-                    Delegation.`is`(call) ||
-                    Exception.`is`(call) ||
-                    Implementation.`is`(call) ||
-                    Module.`is`(call) ||
-                    Overridable.`is`(call) ||
-                    Protocol.`is`(call) ||
-                    QuoteMacro.`is`(call) ||
-                    Structure.`is`(call) ||
-                    Type.`is`(call) ||
-                    Use.`is`(call) ||
-                    Case.isChild(call, ResolveState.initial()) ||
-                    Unknown.`is`(call)
-        }
+        fun isSuitable(call: Call?): Boolean =
+                ChildCall.isSuitable(call!!, ResolveState.initial())
     }
 }

--- a/src/org/elixir_lang/structure_view/element/Body.kt
+++ b/src/org/elixir_lang/structure_view/element/Body.kt
@@ -1,0 +1,31 @@
+package org.elixir_lang.structure_view.element
+
+import com.intellij.ide.util.treeView.smartTree.TreeElement
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.psi.QuoteMacro
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.call.macroChildCalls
+import org.elixir_lang.structure_view.element.modular.Implementation
+import org.elixir_lang.structure_view.element.modular.Modular
+import org.elixir_lang.structure_view.element.modular.Module
+
+/**
+ * What a body shows: the modules it declares, not how it branches.
+ */
+object Body {
+    /** @param quote a `quote` takes its parent as a [Presentable], and a `def` clause is not a [Modular]. */
+    @RequiresReadLock
+    fun treeElements(modular: Modular, quote: (Call) -> Quote, call: Call): Array<TreeElement> =
+        call
+            .macroChildCalls()
+            .mapNotNull { childCall -> treeElement(modular, quote, childCall) }
+            .toTypedArray()
+
+    private fun treeElement(modular: Modular, quote: (Call) -> Quote, childCall: Call): TreeElement? =
+        when {
+            org.elixir_lang.psi.Implementation.`is`(childCall) -> Implementation(modular, childCall)
+            org.elixir_lang.psi.Module.`is`(childCall) -> Module(modular, childCall)
+            QuoteMacro.`is`(childCall) -> quote(childCall)
+            else -> null
+        }
+}

--- a/src/org/elixir_lang/structure_view/element/CallDefinitionClause.kt
+++ b/src/org/elixir_lang/structure_view/element/CallDefinitionClause.kt
@@ -19,7 +19,6 @@ import org.elixir_lang.psi.CallDefinitionClause.isPublicGuard
 import org.elixir_lang.psi.CallDefinitionClause.isPublicMacro
 import org.elixir_lang.psi.QuoteMacro
 import org.elixir_lang.psi.call.Call
-import org.elixir_lang.psi.impl.call.macroChildCalls
 import org.elixir_lang.psi.impl.enclosingMacroCall
 import org.elixir_lang.structure_view.element.modular.*
 import org.jetbrains.annotations.Contract
@@ -39,9 +38,7 @@ class CallDefinitionClause(val callDefinition: CallDefinition, call: Call) :
      */
 
     override fun getChildren(): Array<TreeElement> =
-        navigationItem.macroChildCalls().let {
-            childCallTreeElements(it)
-        } ?: emptyArray()
+        Body.treeElements(callDefinition.modular, { Quote(this, it) }, navigationItem)
 
     /**
      * Returns the presentation of the tree element.
@@ -62,29 +59,6 @@ class CallDefinitionClause(val callDefinition: CallDefinition, call: Call) :
      * `Visible.Visibility.PRIVATE` for private call definitions (`defp` and `defmacrop`).
      */
     override fun visibility(): Visibility = visibility
-
-    private fun addChildCall(treeElementList: MutableList<TreeElement>, childCall: Call) {
-        when {
-            org.elixir_lang.psi.Implementation.`is`(childCall) -> Implementation(callDefinition.modular, childCall)
-            org.elixir_lang.psi.Module.`is`(childCall) -> Module(callDefinition.modular, childCall)
-            QuoteMacro.`is`(childCall) -> Quote(this, childCall)
-            else -> null
-        }?.run {
-            treeElementList.add(this)
-        }
-    }
-
-    @Contract(pure = true)
-    private fun childCallTreeElements(childCalls: Array<Call>?): Array<TreeElement>? =
-        childCalls?.let {
-            val treeElementList = ArrayList<TreeElement>(it.size)
-
-            for (childCall in it) {
-                addChildCall(treeElementList, childCall)
-            }
-
-            treeElementList.toTypedArray()
-        }
 
     companion object {
         /**

--- a/src/org/elixir_lang/structure_view/element/Callback.kt
+++ b/src/org/elixir_lang/structure_view/element/Callback.kt
@@ -21,8 +21,32 @@ import org.elixir_lang.structure_view.element.Timed.Time
 import org.elixir_lang.structure_view.element.modular.Modular
 import org.jetbrains.annotations.Contract
 
-class Callback(private val modular: Modular, navigationItem: Call) :
+class Callback(private val modular: Modular, navigationItem: Call, private val kind: Kind) :
     Element<AtUnqualifiedNoParenthesesCall<*>>(navigationItem as AtUnqualifiedNoParenthesesCall<*>), Timed {
+    /** The module attributes a callback node can be built from. */
+    enum class Kind {
+        CALLBACK,
+        MACROCALLBACK;
+
+        val time: Time
+            get() = when (this) {
+                CALLBACK -> Time.RUN
+                MACROCALLBACK -> Time.COMPILE
+            }
+
+        companion object {
+            fun of(moduleAttributeName: String): Kind? =
+                when (moduleAttributeName) {
+                    "@callback" -> CALLBACK
+                    "@macrocallback" -> MACROCALLBACK
+                    else -> null
+                }
+
+            fun of(call: Call): Kind? =
+                (call as? AtUnqualifiedNoParenthesesCall<*>)?.let { of(ElixirPsiImplUtil.moduleAttributeName(it)) }
+        }
+    }
+
     /**
      * A callback's [.getPresentation] is a [NameArity] like a [CallDefinition], so like a call
      * definition, it's children are the specifications and clauses, since the callback has no clauses, the only child
@@ -70,20 +94,7 @@ class Callback(private val modular: Modular, navigationItem: Call) :
         )
     }
 
-    /**
-     * When the defined call is usable
-     *
-     * @return [Time.COMPILE] for compile time (`defmacro`, `defmacrop`);
-     * [Time.RUN] for run time `def`, `defp`)
-     */
-    override fun time(): Time =
-        ElixirPsiImplUtil.moduleAttributeName(navigationItem).let { moduleAttributeName ->
-            when (moduleAttributeName) {
-                "@callback" -> Time.RUN
-                "@macrocallback" -> Time.COMPILE
-                else -> TODO("Unknown callback $moduleAttributeName")
-            }
-        }
+    override fun time(): Time = kind.time
 
     companion object {
         @JvmStatic
@@ -106,12 +117,10 @@ class Callback(private val modular: Modular, navigationItem: Call) :
                 ?.let { specificationHeadCall(it) }
 
         @Contract(pure = true)
-        fun `is`(call: Call): Boolean =
-            (call as? AtUnqualifiedNoParenthesesCall<*>)?.let {
-                val moduleAttributeName = ElixirPsiImplUtil.moduleAttributeName(it)
+        fun `is`(call: Call): Boolean = Kind.of(call) != null
 
-                moduleAttributeName == "@callback" || moduleAttributeName == "@macrocallback"
-            } ?: false
+        fun fromCall(modular: Modular, call: Call): Callback? =
+            Kind.of(call)?.let { kind -> Callback(modular, call, kind) }
 
         /**
          * `true` if [element] is (within) the name/head of an enclosing `@callback`/`@macrocallback`,
@@ -132,8 +141,8 @@ class Callback(private val modular: Modular, navigationItem: Call) :
 
         @RequiresReadLock
         fun fromCall(call: Call): Callback? =
-            enclosingModular(call)?.let { modular ->
-                Callback(modular, call)
+            Kind.of(call)?.let { kind ->
+                enclosingModular(call)?.let { modular -> Callback(modular, call, kind) }
             }
 
         @Contract(pure = true)

--- a/src/org/elixir_lang/structure_view/element/Exception.java
+++ b/src/org/elixir_lang/structure_view/element/Exception.java
@@ -6,13 +6,11 @@ import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.PsiElement;
 import com.intellij.usageView.UsageViewTypeLocation;
 import com.intellij.util.concurrency.annotations.RequiresReadLock;
-import org.elixir_lang.navigation.item_presentation.Parent;
 import org.elixir_lang.psi.ElixirAccessExpression;
 import org.elixir_lang.psi.ElixirList;
 import org.elixir_lang.psi.QuotableKeywordList;
 import org.elixir_lang.psi.QuotableKeywordPair;
 import org.elixir_lang.psi.call.Call;
-import org.elixir_lang.structure_view.element.modular.Modular;
 import org.elixir_lang.structure_view.element.structure.Structure;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -36,8 +34,6 @@ public class Exception extends Element<Call> {
 
     @Nullable
     private List<CallDefinition> callbacks = null;
-    @NotNull
-    private final Modular modular;
 
     /*
      * Static Methods
@@ -58,9 +54,8 @@ public class Exception extends Element<Call> {
      * Constructors
      */
 
-    public Exception(@NotNull Modular modular, @NotNull Call call) {
+    public Exception(@NotNull Call call) {
         super(call);
-        this.modular = modular;
     }
 
     /*
@@ -150,7 +145,7 @@ public class Exception extends Element<Call> {
         List<TreeElement> childList = new ArrayList<TreeElement>();
 
         childList.add(
-                new Structure(modular, navigationItem)
+                new Structure(navigationItem)
         );
 
         if (callbacks != null) {
@@ -168,23 +163,11 @@ public class Exception extends Element<Call> {
     @NotNull
     @Override
     public ItemPresentation getPresentation() {
-        Parent parentPresentation = (Parent) modular.getPresentation();
-        String location = parentPresentation.getLocatedPresentableText();
-        int lastIndex = location.lastIndexOf('.');
-        String parentLocation;
-        String name;
-
-        if (lastIndex != -1) {
-            parentLocation = location.substring(0, lastIndex);
-            name = location.substring(lastIndex + 1, location.length());
-        } else {
-            parentLocation = null;
-            name = location;
-        }
+        ModuleQualifiedName qualifiedName = ModuleQualifiedName.of(navigationItem, "exception");
 
         return new org.elixir_lang.navigation.item_presentation.Exception(
-                parentLocation,
-                name
+                qualifiedName.getLocation(),
+                qualifiedName.getName()
         );
     }
 

--- a/src/org/elixir_lang/structure_view/element/ModuleQualifiedName.kt
+++ b/src/org/elixir_lang/structure_view/element/ModuleQualifiedName.kt
@@ -1,0 +1,66 @@
+package org.elixir_lang.structure_view.element
+
+import com.intellij.util.concurrency.annotations.RequiresReadLock
+import org.elixir_lang.psi.Implementation
+import org.elixir_lang.psi.Module
+import org.elixir_lang.psi.Protocol
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.impl.enclosingMacroCall
+
+/**
+ * The qualifier and final segment of the module a node is compiled onto, which is how
+ * `item_presentation` renders a struct or an exception.
+ */
+data class ModuleQualifiedName(val location: String?, val name: String) {
+    private val full: String get() = location?.let { location -> "$location.$name" } ?: name
+
+    companion object {
+        /** @param fallbackName for a call that is in no module, and so has no name to take. */
+        @JvmStatic
+        @RequiresReadLock
+        fun of(call: Call, fallbackName: String): ModuleQualifiedName =
+            call.enclosingMacroCall()?.qualifiedName() ?: ModuleQualifiedName(null, fallbackName)
+
+        private fun Call.qualifiedName(): ModuleQualifiedName? {
+            if (Implementation.`is`(this)) {
+                implementationQualifiedName()?.let { qualifiedName -> return qualifiedName }
+            }
+
+            // `defprotocol` defines a module the same way, and takes its name in the same argument.
+            if (Module.`is`(this) || Protocol.`is`(this)) {
+                val name = Module.name(this)
+
+                return split(enclosingMacroCall()?.qualifiedName()?.let { outer -> "${outer.full}.$name" } ?: name)
+            }
+
+            return enclosingMacroCall()?.qualifiedName()
+        }
+
+        /** `defimpl P, for: T` compiles onto `P.T`, whatever module it is written in. */
+        private fun Call.implementationQualifiedName(): ModuleQualifiedName? {
+            val protocolName = Implementation.protocolName(this) ?: return null
+            val forNames = Implementation.forNameCollection(null, this)
+
+            // A `for:` list compiles to one module per entry and the tree builds a single node for all
+            // of them, so it is named after the whole list.
+            if (forNames != null && forNames.size != 1) {
+                return ModuleQualifiedName(protocolName, forNames.joinToString(", ", "[", "]"))
+            }
+
+            // `defimpl P do` with no `for:` means the module it is written in.
+            val forName = forNames?.singleOrNull() ?: enclosingMacroCall()?.qualifiedName()?.full ?: return null
+
+            return split("$protocolName.$forName")
+        }
+
+        private fun split(moduleName: String): ModuleQualifiedName {
+            val lastIndex = moduleName.lastIndexOf('.')
+
+            return if (lastIndex != -1) {
+                ModuleQualifiedName(moduleName.substring(0, lastIndex), moduleName.substring(lastIndex + 1))
+            } else {
+                ModuleQualifiedName(null, moduleName)
+            }
+        }
+    }
+}

--- a/src/org/elixir_lang/structure_view/element/Type.kt
+++ b/src/org/elixir_lang/structure_view/element/Type.kt
@@ -17,8 +17,7 @@ import org.elixir_lang.structure_view.element.modular.Modular
 class Type(
     private val modular: Modular,
     moduleAttributeDefinition: AtUnqualifiedNoParenthesesCall<*>,
-    private val opaque: Boolean,
-    private val visibility: Visibility
+    private val kind: Kind
 ) : Element<AtUnqualifiedNoParenthesesCall<*>?>(moduleAttributeDefinition), Visible {
 
     /**
@@ -40,18 +39,40 @@ class Type(
         return org.elixir_lang.navigation.item_presentation.Type(
             location,
             type(navigationItem!!),
-            opaque,
-            visibility
+            kind.isOpaque,
+            kind.visibility
         )
     }
 
-    /**
-     * The visibility of the element.
-     *
-     * @return [Visibility.PUBLIC] for `@type` and `@opaque`; [Visibility.PRIVATE] for
-     * `@typep`
-     */
-    override fun visibility(): Visibility = visibility
+    override fun visibility(): Visibility = kind.visibility
+
+    /** The module attributes a type node can be built from. */
+    enum class Kind {
+        OPAQUE,
+        TYPE,
+        TYPEP;
+
+        val isOpaque: Boolean get() = this == OPAQUE
+
+        val visibility: Visibility
+            get() = when (this) {
+                OPAQUE, TYPE -> Visibility.PUBLIC
+                TYPEP -> Visibility.PRIVATE
+            }
+
+        companion object {
+            fun of(moduleAttributeName: String): Kind? =
+                when (moduleAttributeName) {
+                    "@opaque" -> OPAQUE
+                    "@type" -> TYPE
+                    "@typep" -> TYPEP
+                    else -> null
+                }
+
+            fun of(call: Call): Kind? =
+                (call as? AtUnqualifiedNoParenthesesCall<*>)?.let { of(ElixirPsiImplUtil.moduleAttributeName(it)) }
+        }
+    }
 
     companion object {
         fun elementDescription(location: ElementDescriptionLocation): String? =
@@ -61,26 +82,13 @@ class Type(
                 null
             }
 
-        fun fromCall(modular: Modular, call: Call): Type =
-            fromAtUnqualifiedNoParenthesesCall(modular, call as AtUnqualifiedNoParenthesesCall<*>)
-
-        fun fromAtUnqualifiedNoParenthesesCall(
-            modular: Modular,
-            moduleAttributeDefinition: AtUnqualifiedNoParenthesesCall<*>
-        ): Type {
-            val moduleAttributeName = ElixirPsiImplUtil.moduleAttributeName(moduleAttributeDefinition)
-            val opaque = isOpaque(moduleAttributeName)
-            val visibility = visibility(moduleAttributeName)
-            return Type(modular, moduleAttributeDefinition, opaque, visibility)
-        }
+        fun fromCall(modular: Modular, call: Call): Type? =
+            Kind.of(call)?.let { kind ->
+                Type(modular, call as AtUnqualifiedNoParenthesesCall<*>, kind)
+            }
 
         @JvmStatic
-        fun `is`(call: Call): Boolean = if (call is AtUnqualifiedNoParenthesesCall<*>) {
-            val moduleAttributeName = ElixirPsiImplUtil.moduleAttributeName(call)
-            moduleAttributeName == "@opaque" || moduleAttributeName == "@type" || moduleAttributeName == "@typep"
-        } else {
-            false
-        }
+        fun `is`(call: Call): Boolean = Kind.of(call) != null
 
         fun isHead(element: PsiElement): Boolean {
             val attribute = PsiTreeUtil.getParentOfType(element, AtUnqualifiedNoParenthesesCall::class.java, false)
@@ -91,8 +99,6 @@ class Type(
 
             return PsiTreeUtil.isAncestor(head, element, false) || PsiTreeUtil.isAncestor(element, head, false)
         }
-
-        private fun isOpaque(moduleAttributeName: String): Boolean = moduleAttributeName == "@opaque"
 
         fun nameIdentifier(atUnqualifiedNoParenthesesCall: AtUnqualifiedNoParenthesesCall<*>): PsiElement? =
             specification(atUnqualifiedNoParenthesesCall)?.let { specificationType(it) }?.let { typeNameIdentifier(it) }
@@ -114,12 +120,5 @@ class Type(
             atUnqualifiedNoParenthesesCall.noParenthesesOneArgument.arguments().singleOrNull()?.let { it as? Call }
 
         private fun typeNameIdentifier(type: Call): PsiElement? = type.functionNameElement()
-
-        fun visibility(moduleAttributeName: String): Visibility =
-            when (moduleAttributeName) {
-                "@opaque", "@type" -> Visibility.PUBLIC
-                "@typep" -> Visibility.PRIVATE
-                else -> TODO()
-            }
     }
 }

--- a/src/org/elixir_lang/structure_view/element/ex_unit/case/Describe.kt
+++ b/src/org/elixir_lang/structure_view/element/ex_unit/case/Describe.kt
@@ -1,25 +1,15 @@
 package org.elixir_lang.structure_view.element.ex_unit.case
 
-import com.intellij.ide.util.treeView.smartTree.TreeElement
 import com.intellij.navigation.ItemPresentation
-import com.intellij.psi.ResolveState
 import org.elixir_lang.psi.call.Call
-import org.elixir_lang.structure_view.element.Element
-import org.elixir_lang.navigation.item_presentation.ex_unit.case.Describe
-import org.elixir_lang.psi.impl.call.stabBodyChildExpressions
+import org.elixir_lang.structure_view.element.modular.Modular
+import org.elixir_lang.structure_view.element.modular.Module
+import org.elixir_lang.navigation.item_presentation.ex_unit.case.Describe as DescribePresentation
 
-class Describe(call: Call) : Element<Call>(call) {
-    override fun getPresentation(): ItemPresentation = Describe(navigationItem)
-
-    override fun getChildren(): Array<TreeElement> =
-        navigationItem
-                .stabBodyChildExpressions()
-                .orEmpty()
-                .filterIsInstance<Call>()
-                .filter { org.elixir_lang.psi.ex_unit.Case.isTest(it, ResolveState.initial()) }
-                .map { call ->
-                    Test(call)
-                }
-                .toList()
-                .toTypedArray()
+/**
+ * `ExUnit.Case.describe/2` evaluates its block in the module body, so what a `describe` declares -
+ * a `defdelegate`, a `setup` - is compiled onto the case module. It shows what a `defmodule` shows.
+ */
+class Describe(parent: Modular, call: Call) : Module(parent, call) {
+    override fun getPresentation(): ItemPresentation = DescribePresentation(location(), navigationItem)
 }

--- a/src/org/elixir_lang/structure_view/element/ex_unit/case/Test.kt
+++ b/src/org/elixir_lang/structure_view/element/ex_unit/case/Test.kt
@@ -3,11 +3,19 @@ package org.elixir_lang.structure_view.element.ex_unit.case
 import com.intellij.ide.util.treeView.smartTree.TreeElement
 import com.intellij.navigation.ItemPresentation
 import org.elixir_lang.psi.call.Call
-import org.elixir_lang.structure_view.element.Element
-import org.elixir_lang.navigation.item_presentation.ex_unit.case.Test
+import org.elixir_lang.structure_view.element.Body
+import org.elixir_lang.structure_view.element.Quote
+import org.elixir_lang.structure_view.element.modular.Modular
+import org.elixir_lang.structure_view.element.modular.Module
+import org.elixir_lang.navigation.item_presentation.ex_unit.case.Test as TestPresentation
 
-class Test(call: Call) : Element<Call>(call) {
-    override fun getPresentation(): ItemPresentation = Test(navigationItem)
+/**
+ * `ExUnit.Case.test/3` expands to a `def` whose body is the test's block, so a `test` shows what a
+ * `def` clause shows. A [Modular] so the modules it declares can be built and qualified beneath it.
+ */
+class Test(parent: Modular, call: Call) : Module(parent, call) {
+    override fun getPresentation(): ItemPresentation = TestPresentation(location(), navigationItem)
 
-    override fun getChildren(): Array<TreeElement> = emptyArray()
+    override fun getChildren(): Array<TreeElement> =
+        Body.treeElements(this, { Quote(this, it) }, navigationItem)
 }

--- a/src/org/elixir_lang/structure_view/element/modular/Module.kt
+++ b/src/org/elixir_lang/structure_view/element/modular/Module.kt
@@ -14,21 +14,17 @@ import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.elixir_lang.NameArity
 import org.elixir_lang.navigation.item_presentation.Parent
 import org.elixir_lang.psi.ArityInterval
-import org.elixir_lang.psi.QuoteMacro
 import org.elixir_lang.psi.call.Call
 import org.elixir_lang.psi.impl.ElixirPsiImplUtil.ENTRANCE
 import org.elixir_lang.psi.impl.call.macroChildCalls
 import org.elixir_lang.psi.impl.enclosingMacroCall
 import org.elixir_lang.psi.impl.locationString
 import org.elixir_lang.psi.impl.stripAccessExpression
-import org.elixir_lang.psi.operation.Or
 import org.elixir_lang.psi.putInitialVisitedElement
+import org.elixir_lang.structure_view.ChildCall
 import org.elixir_lang.structure_view.element.*
-import org.elixir_lang.structure_view.element.Quote
 import org.elixir_lang.structure_view.element.call_definition_by_name_arity.FunctionByNameArity
 import org.elixir_lang.structure_view.element.call_definition_by_name_arity.MacroByNameArity
-import org.elixir_lang.structure_view.element.ex_unit.case.Describe
-import org.elixir_lang.structure_view.element.structure.Structure
 import org.elixir_lang.structure_view.node_provider.Used
 import org.jetbrains.annotations.Contract
 import java.util.*
@@ -129,39 +125,18 @@ open class Module(protected val parent: Modular?, call: Call) : Element<Call>(ca
                 val overridableSet = HashSet<Overridable>()
                 val useSet = HashSet<org.elixir_lang.structure_view.element.Use>()
 
-                while (!childCallQueue.isEmpty()) {
-                    val childCall = childCallQueue.remove()
+                val accumulator = ChildCall.Accumulator(
+                        modular,
+                        treeElementList,
+                        functionByNameArity,
+                        macroByNameArity,
+                        overridableSet,
+                        useSet,
+                        childCallQueue
+                )
 
-                    when {
-                        childCall is Or -> childCallQueue.addAll(orChildCallList(childCall as Or))
-                        Callback.`is`(childCall) -> treeElementList.add(Callback(modular, childCall))
-                        Delegation.`is`(childCall) -> functionByNameArity.addDelegationToTreeElementList(childCall)
-                        org.elixir_lang.psi.Exception.`is`(childCall) -> functionByNameArity.exception = Exception(modular, childCall)
-                        org.elixir_lang.psi.CallDefinitionClause.isFunction(childCall) -> functionByNameArity.addClausesToCallDefinition(childCall)
-                        CallDefinitionSpecification.`is`(childCall) -> functionByNameArity.addSpecificationToCallDefinition(childCall)
-                        org.elixir_lang.EEx.isFunctionFrom(childCall, resolveState) -> treeElementList.add(EExFunctionFrom(modular, childCall))
-                        org.elixir_lang.psi.Implementation.`is`(childCall) -> treeElementList.add(Implementation(modular, childCall))
-                        org.elixir_lang.psi.CallDefinitionClause.isMacro(childCall) -> macroByNameArity.addClausesToCallDefinition(childCall)
-                        org.elixir_lang.psi.Module.`is`(childCall) -> treeElementList.add(Module(modular, childCall))
-                        Overridable.`is`(childCall) -> {
-                            val overridable = Overridable(modular, childCall)
-                            overridableSet.add(overridable)
-                            treeElementList.add(overridable)
-                        }
-                        org.elixir_lang.psi.Protocol.`is`(childCall) -> treeElementList.add(Protocol(modular, childCall))
-                        QuoteMacro.`is`(childCall) -> treeElementList.add(Quote(modular, childCall))
-                        Structure.`is`(childCall) -> treeElementList.add(Structure(modular, childCall))
-                        Type.`is`(childCall) -> treeElementList.add(Type.fromCall(modular, childCall))
-                        org.elixir_lang.psi.Use.`is`(childCall) -> {
-                            val use = org.elixir_lang.structure_view.element.Use(modular, childCall)
-                            useSet.add(use)
-                            treeElementList.add(use)
-                        }
-                        org.elixir_lang.psi.ex_unit.Case.isDescribe(childCall, ResolveState.initial()) ->
-                            treeElementList.add(Describe(childCall))
-                        Unknown.`is`(childCall) -> // Should always be last since it will match all macro calls
-                            treeElementList.add(Unknown(modular, childCall))
-                    }
+                while (!childCallQueue.isEmpty()) {
+                    ChildCall.build(accumulator, childCallQueue.remove(), resolveState)
                 }
 
                 for (overridable in overridableSet) {
@@ -198,19 +173,6 @@ open class Module(protected val parent: Modular?, call: Call) : Element<Call>(ca
             return treeElements ?: emptyArray()
         }
 
-        private fun orChildCallList(or: Or): List<Call> {
-            val childCallList = ArrayList<Call>()
-
-            (or.leftOperand() as? Call)?.run {
-                childCallList.add(this)
-            }
-
-            (or.rightOperand() as? Call)?.run {
-                childCallList.add(this)
-            }
-
-            return childCallList
-        }
     }
 
 }

--- a/src/org/elixir_lang/structure_view/element/structure/Structure.java
+++ b/src/org/elixir_lang/structure_view/element/structure/Structure.java
@@ -5,11 +5,10 @@ import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.ElementDescriptionLocation;
 import com.intellij.psi.PsiElement;
 import com.intellij.usageView.UsageViewTypeLocation;
-import org.elixir_lang.navigation.item_presentation.Parent;
 import org.elixir_lang.psi.*;
 import org.elixir_lang.psi.call.Call;
 import org.elixir_lang.structure_view.element.Element;
-import org.elixir_lang.structure_view.element.modular.Modular;
+import org.elixir_lang.structure_view.element.ModuleQualifiedName;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -25,9 +24,6 @@ public class Structure extends Element<Call> {
     /*
      * Fields
      */
-
-    @NotNull
-    private final Modular modular;
 
     /*
      * Static Methods
@@ -52,9 +48,8 @@ public class Structure extends Element<Call> {
      * Constructors
      */
 
-    public Structure(@NotNull Modular modular, @NotNull Call call) {
+    public Structure(@NotNull Call call) {
         super(call);
-        this.modular = modular;
     }
 
     /*
@@ -115,21 +110,12 @@ public class Structure extends Element<Call> {
     @NotNull
     @Override
     public ItemPresentation getPresentation() {
-        Parent parentPresentation = (Parent) modular.getPresentation();
-        String location = parentPresentation.getLocatedPresentableText();
-        int lastIndex = location.lastIndexOf('.');
-        String parentLocation;
-        String name;
+        ModuleQualifiedName qualifiedName = ModuleQualifiedName.of(navigationItem, "struct");
 
-        if (lastIndex != -1) {
-            parentLocation = location.substring(0, lastIndex);
-            name = location.substring(lastIndex + 1, location.length());
-        } else {
-            parentLocation = null;
-            name = location;
-        }
-
-        return new org.elixir_lang.navigation.item_presentation.structure.Structure(parentLocation, name);
+        return new org.elixir_lang.navigation.item_presentation.structure.Structure(
+                qualifiedName.getLocation(),
+                qualifiedName.getName()
+        );
     }
 
     /*

--- a/testData/org/elixir_lang/structure_view/ex_unit/case_test.exs
+++ b/testData/org/elixir_lang/structure_view/ex_unit/case_test.exs
@@ -1,0 +1,51 @@
+defmodule CaseTest do
+  use ExUnit.Case
+
+  describe "a describe block" do
+    # `describe` evaluates its block in the module body, so these are the case module's own
+    # declarations. Each builds an element that casts its parent's presentation to `Parent` unguarded.
+    defstruct [:a]
+    @type t :: any()
+    @callback a_callback() :: :ok
+    @spec a_spec() :: :ok
+    defdelegate values(map), to: Map
+
+    setup do
+      :ok
+    end
+
+    test "nested inside the describe" do
+      assert true
+    end
+  end
+
+  test "at the top level, outside any describe" do
+    defmodule DefinedInsideATest do
+      def helper, do: :ok
+    end
+
+    # A test's implementation, not its declarations: these must build no node.
+    for n <- 1..3, do: n
+
+    case :ok do
+      :ok -> :fine
+    end
+
+    assert true
+  end
+
+  # No `do` block, so `Unknown.is` is false and nothing else matches it either.
+  test "not implemented yet"
+
+  # The one entry whose `suitable = false` flag has an observable consequence.
+  true or false
+
+  # `CallDefinitionHead.is` claims it and builds nothing; `Unknown.is` claims it and builds a node.
+  unrecognised_macro() do
+    :ok
+  end
+
+  test do
+    assert true
+  end
+end

--- a/testData/org/elixir_lang/structure_view/ex_unit/eex.ex
+++ b/testData/org/elixir_lang/structure_view/ex_unit/eex.ex
@@ -1,0 +1,21 @@
+defmodule EEx do
+  defmacro function_from_file(kind, name, file, args \\ [], options \\ []) do
+    quote do
+      unquote(kind)
+      unquote(name)
+      unquote(file)
+      unquote(args)
+      unquote(options)
+    end
+  end
+
+  defmacro function_from_string(kind, name, source, args \\ [], options \\ []) do
+    quote do
+      unquote(kind)
+      unquote(name)
+      unquote(source)
+      unquote(args)
+      unquote(options)
+    end
+  end
+end

--- a/testData/org/elixir_lang/structure_view/ex_unit/eex_host.ex
+++ b/testData/org/elixir_lang/structure_view/ex_unit/eex_host.ex
@@ -1,0 +1,7 @@
+defmodule EExHost do
+  require EEx
+
+  EEx.function_from_file(:def, :render_from_file, "greeting.eex", [:assigns])
+
+  EEx.function_from_string(:def, :render_from_string, "<%= @name %>", [:assigns])
+end

--- a/testData/org/elixir_lang/structure_view/ex_unit/ex_unit_case.ex
+++ b/testData/org/elixir_lang/structure_view/ex_unit/ex_unit_case.ex
@@ -1,0 +1,27 @@
+defmodule ExUnit.Case do
+  defmacro __using__(_opts) do
+    quote do
+      import ExUnit.Case
+    end
+  end
+
+  defmacro describe(message, do: block) do
+    quote do
+      unquote(message)
+      unquote(block)
+    end
+  end
+
+  defmacro test(message, do: block) do
+    quote do
+      unquote(message)
+      unquote(block)
+    end
+  end
+
+  defmacro test(message) do
+    quote do
+      unquote(message)
+    end
+  end
+end

--- a/tests/org/elixir_lang/structure_view/ChildCallTest.kt
+++ b/tests/org/elixir_lang/structure_view/ChildCallTest.kt
@@ -1,0 +1,94 @@
+package org.elixir_lang.structure_view
+
+import junit.framework.TestCase
+
+/**
+ * The table's invariants. Pure assertions over [ChildCall.ENTRIES] - no fixture, no IDE.
+ */
+class ChildCallTest : TestCase() {
+    private fun names(entries: List<ChildCall.Entry>) = entries.map { it.name }.sorted()
+
+    private val nonEmpty = "the table must not be empty or this assertion is vacuous"
+
+    /**
+     * Membership and order in full. Order is behaviour - it decides which entry wins for a call several
+     * match - and the assertions below are relational, so a deleted or reordered entry satisfies them.
+     */
+    fun testTheTableIsExactlyThisInThisOrder() {
+        assertEquals(
+            listOf(
+                "or",
+                "callback",
+                "delegation",
+                "exception",
+                "function",
+                "specification",
+                "eex function_from",
+                "implementation",
+                "macro",
+                "module",
+                "overridable",
+                "protocol",
+                "quote",
+                "structure",
+                "type",
+                "use",
+                "ex_unit describe",
+                "ex_unit test",
+                "call definition head",
+                "unknown"
+            ),
+            ChildCall.ENTRIES.map { it.name }
+        )
+    }
+
+    /**
+     * Not covered by the order test: adding the new entry's name to that list repairs it while leaving
+     * `build` reaching `unknown` first for anything with a `do` block.
+     */
+    fun testCatchAllStaysLast() {
+        assertEquals(
+            "the catch-all must be the last entry or the entries after it never build anything",
+            "unknown",
+            ChildCall.ENTRIES.last().name
+        )
+    }
+
+    fun testEntryNamesAreUnique() {
+        assertFalse(nonEmpty, ChildCall.ENTRIES.isEmpty())
+
+        val duplicates = ChildCall.ENTRIES.groupBy { it.name }.filterValues { it.size > 1 }.keys
+
+        assertEquals(emptySet<String>(), duplicates)
+    }
+
+    fun testEveryEntryDoesSomething() {
+        assertFalse(nonEmpty, ChildCall.ENTRIES.isEmpty())
+
+        val inert = ChildCall.ENTRIES.filter { it.handle == null && !it.suitable }.map { it.name }
+
+        assertEquals("an entry must build a node, be claimed by isSuitable, or both", emptyList<String>(), inert)
+    }
+
+    /**
+     * Building a node and being a caret-sync target are the same answer except for two entries, each
+     * for a structural reason. A third means the two have drifted apart again.
+     */
+    fun testOnlyTheTwoDocumentedEntriesDifferBetweenConsumers() {
+        val builtButNotClaimed = ChildCall.ENTRIES.filter { it.handle != null && !it.suitable }
+        val claimedButNotBuilt = ChildCall.ENTRIES.filter { it.handle == null && it.suitable }
+
+        assertEquals(
+            "only `or` may be dispatched without contributing to isSuitable - it is the container the " +
+                "dispatch unwraps",
+            listOf("or"),
+            names(builtButNotClaimed)
+        )
+        assertEquals(
+            "only `call definition head` may be a caret target this dispatch does not build - " +
+                "those elements are built as children of a CallDefinition",
+            listOf("call definition head"),
+            names(claimedButNotBuilt)
+        )
+    }
+}

--- a/tests/org/elixir_lang/structure_view/EExFunctionFromNodeTest.kt
+++ b/tests/org/elixir_lang/structure_view/EExFunctionFromNodeTest.kt
@@ -1,0 +1,71 @@
+package org.elixir_lang.structure_view
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.structure_view.element.EExFunctionFrom
+
+/**
+ * `EEx.function_from_*` builds a node but was absent from [Model.isSuitable].
+ *
+ * The call is qualified and [Model.isSuitable] answers from a bare `ResolveState`, a combination
+ * `build` never produces - it threads an entrance of its own.
+ */
+class EExFunctionFromNodeTest : PlatformTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/structure_view/ex_unit"
+
+    private fun configure(): List<Call> {
+        myFixture.configureByFiles("eex_host.ex", "eex.ex")
+
+        return PsiTreeUtil
+            .findChildrenOfType(myFixture.file, Call::class.java)
+            .filter { call -> call.functionName()?.startsWith("function_from_") == true }
+    }
+
+    /**
+     * Calls [Model.isSuitable] per call because it is also the crash guard: a null `ENTRANCE` reaching
+     * `isAncestor` used to throw here.
+     */
+    fun testAFunctionFromCallIsACaretSyncTarget() {
+        val calls = configure()
+
+        assertFalse("the fixture must contain function_from_* calls", calls.isEmpty())
+
+        val unclaimed = calls.filterNot { call -> Model.isSuitable(call) }.map { it.text.lineSequence().first() }
+
+        assertEquals(
+            "Model.isSuitable must claim an EEx.function_from_* call, or its node cannot follow the caret",
+            emptyList<String>(),
+            unclaimed
+        )
+    }
+
+    fun testAFunctionFromCallIsBuiltAsItsOwnNode() {
+        val calls = configure()
+
+        assertFalse("the fixture must contain function_from_* calls", calls.isEmpty())
+
+        val built = mutableSetOf<PsiElement>()
+
+        fun walk(element: StructureViewTreeElement) {
+            if (element is EExFunctionFrom) {
+                (element.value as? PsiElement)?.let { built.add(it) }
+            }
+
+            for (child in element.children) {
+                if (child is StructureViewTreeElement) {
+                    walk(child)
+                }
+            }
+        }
+
+        walk(Model(myFixture.file as ElixirFile, null).root)
+
+        val missing = calls.filterNot { call -> call in built }.map { it.text.lineSequence().first() }
+
+        assertEquals("every function_from_* call must build an EExFunctionFrom node", emptyList<String>(), missing)
+    }
+}

--- a/tests/org/elixir_lang/structure_view/element/KindTest.kt
+++ b/tests/org/elixir_lang/structure_view/element/KindTest.kt
@@ -1,0 +1,34 @@
+package org.elixir_lang.structure_view.element
+
+import junit.framework.TestCase
+import org.elixir_lang.call.Visibility
+import org.elixir_lang.structure_view.element.Timed.Time
+
+/**
+ * The module-attribute mappings the sorters read, and the boundary that answers an unrecognised name.
+ */
+class KindTest : TestCase() {
+    fun testTypeKindVisibility() {
+        assertEquals(Visibility.PUBLIC, Type.Kind.of("@opaque")?.visibility)
+        assertEquals(Visibility.PUBLIC, Type.Kind.of("@type")?.visibility)
+        assertEquals(Visibility.PRIVATE, Type.Kind.of("@typep")?.visibility)
+    }
+
+    fun testOnlyOpaqueIsOpaque() {
+        assertEquals(true, Type.Kind.of("@opaque")?.isOpaque)
+        assertEquals(false, Type.Kind.of("@type")?.isOpaque)
+        assertEquals(false, Type.Kind.of("@typep")?.isOpaque)
+    }
+
+    fun testCallbackKindTime() {
+        assertEquals(Time.RUN, Callback.Kind.of("@callback")?.time)
+        assertEquals(Time.COMPILE, Callback.Kind.of("@macrocallback")?.time)
+    }
+
+    fun testAnUnrecognisedAttributeIsNull() {
+        assertNull(Type.Kind.of("@spec"))
+        assertNull(Type.Kind.of("@callback"))
+        assertNull(Callback.Kind.of("@type"))
+        assertNull(Callback.Kind.of("@spec"))
+    }
+}

--- a/tests/org/elixir_lang/structure_view/element/modular/ImplementationNodeTest.kt
+++ b/tests/org/elixir_lang/structure_view/element/modular/ImplementationNodeTest.kt
@@ -1,0 +1,51 @@
+package org.elixir_lang.structure_view.element.modular
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.structure_view.Model
+
+/**
+ * `defimpl P, for: T` compiles to a module named `P.T`, but the node presents the protocol and the
+ * type rather than that generated name's qualifier and final segment.
+ */
+class ImplementationNodeTest : PlatformTestCase() {
+    private fun implementation(code: String): StructureViewTreeElement {
+        myFixture.configureByText("demo.ex", code)
+
+        val found = mutableListOf<StructureViewTreeElement>()
+
+        fun walk(element: StructureViewTreeElement) {
+            if (element is Implementation) {
+                found.add(element)
+            }
+
+            for (child in element.children) {
+                if (child is StructureViewTreeElement) {
+                    walk(child)
+                }
+            }
+        }
+
+        walk(Model(myFixture.file as ElixirFile, null).root)
+        assertEquals("the fixture must build exactly one implementation node", 1, found.size)
+
+        return found.single()
+    }
+
+    fun testQualifiedFor() {
+        val presentation =
+            implementation("defimpl Enumerable, for: Foo.Bar do\n  def count(_), do: 0\nend\n").presentation
+
+        assertEquals("Foo.Bar", presentation.presentableText)
+        assertEquals("Enumerable", presentation.locationString)
+    }
+
+    fun testUnqualifiedFor() {
+        val presentation =
+            implementation("defimpl Enumerable, for: Bar do\n  def count(_), do: 0\nend\n").presentation
+
+        assertEquals("Bar", presentation.presentableText)
+        assertEquals("Enumerable", presentation.locationString)
+    }
+}

--- a/tests/org/elixir_lang/structure_view/element/structure/StructureNameTest.kt
+++ b/tests/org/elixir_lang/structure_view/element/structure/StructureNameTest.kt
@@ -1,0 +1,203 @@
+package org.elixir_lang.structure_view.element.structure
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.structure_view.Model
+import org.elixir_lang.structure_view.element.Exception as ExceptionElement
+
+/**
+ * A struct is named after the `defmodule` it is compiled onto, so the label must not vary with the
+ * file name or with what the enclosing node happens to present.
+ */
+class StructureNameTest : PlatformTestCase() {
+    private fun structure(code: String): StructureViewTreeElement {
+        myFixture.configureByText("a_file_whose_name_has_dots.ex", code)
+
+        val found = mutableListOf<StructureViewTreeElement>()
+
+        fun walk(element: StructureViewTreeElement) {
+            if (element is Structure) {
+                found.add(element)
+            }
+
+            for (child in element.children) {
+                if (child is StructureViewTreeElement) {
+                    walk(child)
+                }
+            }
+        }
+
+        walk(Model(myFixture.file as ElixirFile, null).root)
+        assertEquals("the fixture must build exactly one struct node", 1, found.size)
+
+        return found.single()
+    }
+
+    fun testUnqualifiedModule() {
+        val presentation = structure("defmodule Foo do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%Foo{}", presentation.presentableText)
+        assertNull("an unqualified module leaves the struct with no qualifier", presentation.locationString)
+    }
+
+    fun testQualifiedModule() {
+        val presentation = structure("defmodule Foo.Bar do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%Bar{}", presentation.presentableText)
+        assertEquals("Foo", presentation.locationString)
+    }
+
+    /** The name comes from the module, not from the `def` the `defstruct` is written in. */
+    fun testInsideACallDefinition() {
+        val presentation =
+            structure("defmodule Foo do\n  def f do\n    defmodule Inner do\n      defstruct [:a]\n    end\n  end\nend\n")
+                .presentation
+
+        assertEquals("%Inner{}", presentation.presentableText)
+        assertEquals("Foo", presentation.locationString)
+    }
+
+    /** A lexically nested `defmodule` defines `Foo.Bar`, so it must read as `defmodule Foo.Bar` does. */
+    fun testLexicallyNestedModule() {
+        val nested = structure("defmodule Foo do\n  defmodule Bar do\n    defstruct [:a]\n  end\nend\n").presentation
+        val dotted = structure("defmodule Foo.Bar do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%Bar{}", nested.presentableText)
+        assertEquals("Foo", nested.locationString)
+        assertEquals(dotted.presentableText, nested.presentableText)
+        assertEquals(dotted.locationString, nested.locationString)
+    }
+
+    /** `defexception` named itself the same broken way, and shares the fix. */
+    fun testAnExceptionIsNamedAfterItsModule() {
+        myFixture.configureByText(
+            "a_file_whose_name_has_dots.ex",
+            "defmodule Foo.Bar do\n  defexception [:message]\nend\n"
+        )
+
+        val found = mutableListOf<ExceptionElement>()
+
+        fun walk(element: StructureViewTreeElement) {
+            if (element is ExceptionElement) {
+                found.add(element)
+            }
+
+            for (child in element.children) {
+                if (child is StructureViewTreeElement) {
+                    walk(child)
+                }
+            }
+        }
+
+        walk(Model(myFixture.file as ElixirFile, null).root)
+        assertEquals("the fixture must build exactly one exception node", 1, found.size)
+
+        assertEquals("Bar", found.single().presentation.presentableText)
+        assertEquals("Foo", found.single().presentation.locationString)
+    }
+
+    /** `Module.is` accepts a parenthesised `defmodule`, so the tree builds a node and the struct in it
+     *  must be named rather than falling back. */
+    fun testParenthesisedModule() {
+        val presentation = structure("defmodule(Foo) do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%Foo{}", presentation.presentableText)
+    }
+
+    /** `for:` a list compiles to one module per entry, but the tree builds one node for all of them. */
+    fun testInsideAnImplementationForAList() {
+        val presentation = structure("defimpl Enumerable, for: [A, B] do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%[A, B]{}", presentation.presentableText)
+        assertEquals("Enumerable", presentation.locationString)
+    }
+
+    /** The list is assembled from the `for:` aliases, not read off the source, so a `.` in an entry
+     *  is not mistaken for the qualifier separator and newlines cannot reach the label. */
+    fun testInsideAnImplementationForAnAwkwardList() {
+        val dotted = structure("defimpl Enumerable, for: [A.B, C] do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%[A.B, C]{}", dotted.presentableText)
+        assertEquals("Enumerable", dotted.locationString)
+
+        val multiline = structure(
+            "defimpl Enumerable,\n  for: [\n    A,\n    B\n  ] do\n  defstruct [:a]\nend\n"
+        ).presentation
+
+        assertEquals("%[A, B]{}", multiline.presentableText)
+    }
+
+    /** `defprotocol` defines a module too, so the walk must stop at it rather than climb past. */
+    fun testInsideAProtocol() {
+        val presentation = structure("defmodule Foo do\n  defprotocol Bar do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Bar{}", presentation.presentableText)
+        assertEquals("Foo", presentation.locationString)
+    }
+
+    /** An empty `for:` list is still a list, not a missing `for:`. */
+    fun testInsideAnImplementationForAnEmptyList() {
+        val presentation = structure("defimpl Enumerable, for: [] do\n  defstruct [:a]\nend\n").presentation
+
+        assertEquals("%[]{}", presentation.presentableText)
+        assertEquals("Enumerable", presentation.locationString)
+    }
+
+    /** A qualified outer module exercises the rejoin the nested walk does before re-splitting. */
+    fun testANestedModuleUnderAQualifiedOuterModule() {
+        val presentation = structure("defmodule Foo.Bar do\n  defmodule Baz do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Baz{}", presentation.presentableText)
+        assertEquals("Foo.Bar", presentation.locationString)
+    }
+
+    /** The walk out of a nested module must not lose the list implementation above it. */
+    fun testAModuleInsideAnImplementationForAList() {
+        val presentation = structure("defimpl Enumerable, for: [A, B] do\n  defmodule Inner do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Inner{}", presentation.presentableText)
+        assertEquals("Enumerable.[A, B]", presentation.locationString)
+    }
+
+    /** `defimpl P` with no `for:` means the module it is written in, so the module is `P.That`. */
+    fun testInsideAnImplementationWithoutAFor() {
+        val presentation = structure("defmodule Foo do\n  defimpl Enumerable do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Foo{}", presentation.presentableText)
+        assertEquals("Enumerable", presentation.locationString)
+    }
+
+    /** The nearest modular wins: a `defmodule` inside a `defimpl` is not overridden by it. */
+    fun testAModuleInsideAnImplementation() {
+        val presentation = structure("defimpl Enumerable, for: Bar do\n  defmodule Baz do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Baz{}", presentation.presentableText)
+        assertEquals("Enumerable.Bar", presentation.locationString)
+    }
+
+    /** A parenthesised `defmodule` nested in a plain one must still be qualified by it. */
+    fun testParenthesisedModuleNestedInAPlainOne() {
+        val presentation = structure("defmodule Foo do\n  defmodule(Bar) do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Bar{}", presentation.presentableText)
+        assertEquals("Foo", presentation.locationString)
+    }
+
+    /** Both spellings nested, which neither `getModuleName` nor a single-step walk assembles. */
+    fun testParenthesisedModuleNestedInAParenthesisedOne() {
+        val presentation = structure("defmodule(Foo) do\n  defmodule(Bar) do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Bar{}", presentation.presentableText)
+        assertEquals("Foo", presentation.locationString)
+    }
+
+    /** `defimpl Proto, for: For` compiles onto `Proto.For`, not onto the module around it. */
+    fun testInsideAnImplementation() {
+        val presentation =
+            structure("defmodule Foo do\n  defimpl Enumerable, for: Bar do\n    defstruct [:a]\n  end\nend\n").presentation
+
+        assertEquals("%Bar{}", presentation.presentableText)
+        assertEquals("Enumerable", presentation.locationString)
+    }
+}

--- a/tests/org/elixir_lang/structure_view/ex_unit/CaseNodeTest.kt
+++ b/tests/org/elixir_lang/structure_view/ex_unit/CaseNodeTest.kt
@@ -1,0 +1,313 @@
+package org.elixir_lang.structure_view.ex_unit
+
+import com.intellij.ide.structureView.StructureViewTreeElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveState
+import com.intellij.psi.util.PsiTreeUtil
+import org.elixir_lang.PlatformTestCase
+import org.elixir_lang.psi.ElixirFile
+import org.elixir_lang.psi.call.Call
+import org.elixir_lang.psi.ex_unit.Case
+import org.elixir_lang.psi.operation.Or
+import org.elixir_lang.structure_view.ChildCall
+import org.elixir_lang.structure_view.Model
+import org.elixir_lang.structure_view.element.Callback
+import org.elixir_lang.structure_view.element.Delegation
+import org.elixir_lang.structure_view.element.Type
+import org.elixir_lang.structure_view.element.modular.Unknown
+import org.elixir_lang.structure_view.element.structure.Structure
+import org.elixir_lang.structure_view.element.ex_unit.case.Describe as DescribeElement
+import org.elixir_lang.structure_view.element.ex_unit.case.Test as TestElement
+
+/**
+ * `ExUnit.Case`'s two child forms, which [Model.isSuitable] and the tree dispatch decide separately.
+ */
+class CaseNodeTest : PlatformTestCase() {
+    override fun getTestDataPath(): String = "testData/org/elixir_lang/structure_view/ex_unit"
+
+    private class Tree(
+        val byLabel: Map<String, StructureViewTreeElement>,
+        val duplicatedLabels: Set<String>,
+        val elementByValue: Map<PsiElement, StructureViewTreeElement>
+    ) {
+        val values: Set<PsiElement> get() = elementByValue.keys
+    }
+
+    /** The tree repeats labels - a `defdelegate` builds two `values/1` nodes - so refuse an ambiguous one. */
+    private fun Tree.at(label: String): StructureViewTreeElement? {
+        assertFalse("more than one node is labelled \"$label\", so the lookup is ambiguous", label in duplicatedLabels)
+
+        return byLabel[label]
+    }
+
+    private fun build(): Tree {
+        myFixture.configureByFiles("case_test.exs", "ex_unit_case.ex")
+
+        val byLabel = mutableMapOf<String, StructureViewTreeElement>()
+        val duplicatedLabels = mutableSetOf<String>()
+        val elementByValue = mutableMapOf<PsiElement, StructureViewTreeElement>()
+
+        fun walk(element: StructureViewTreeElement) {
+            element.presentation.presentableText?.let { label ->
+                if (byLabel.putIfAbsent(label, element) != null) {
+                    duplicatedLabels.add(label)
+                }
+            }
+            // Outermost wins: a child can carry the same PSI as its parent, as `Callback.getChildren()`
+            // does over the same `@callback` call.
+            (element.value as? PsiElement)?.let { elementByValue.putIfAbsent(it, element) }
+
+            for (child in element.children) {
+                if (child is StructureViewTreeElement) {
+                    walk(child)
+                }
+            }
+        }
+
+        walk(Model(myFixture.file as ElixirFile, null).root)
+
+        return Tree(byLabel, duplicatedLabels, elementByValue)
+    }
+
+    fun testTopLevelTestGetsItsOwnNode() {
+        val tree = build()
+
+        val element = tree.at("test \"at the top level, outside any describe\"")
+
+        assertNotNull(
+            "a `test` outside a `describe` must get its own node; built nodes were ${tree.byLabel.keys}",
+            element
+        )
+        assertInstanceOf(element, TestElement::class.java)
+    }
+
+    fun testTestInsideDescribeGetsItsOwnNode() {
+        val tree = build()
+
+        val element = tree.at("test \"nested inside the describe\"")
+
+        assertNotNull(
+            "a `test` inside a `describe` must get its own node; built nodes were ${tree.byLabel.keys}",
+            element
+        )
+        assertInstanceOf(element, TestElement::class.java)
+
+        assertEquals(
+            "a `test` inside a `describe` is qualified by the describe, not the module or the file path",
+            "/src/case_test.exs defmodule CaseTest describe \"a describe block\"",
+            element!!.presentation.locationString
+        )
+    }
+
+    /** A `test` is a modular, so its body's declarations get nodes and stay qualified by the module. */
+    fun testATestBodyKeepsItsChildren() {
+        val tree = build()
+
+        assertNotNull(
+            "a module defined inside a top-level `test` must still get a node; built nodes were " +
+                "${tree.byLabel.keys}",
+            tree.at("defmodule DefinedInsideATest")
+        )
+        assertNotNull(
+            "and the walk must continue into that module; built nodes were ${tree.byLabel.keys}",
+            tree.at("helper/0")
+        )
+
+        assertEquals(
+            "a declaration inside a top-level `test` is qualified by both the module and the test",
+            "/src/case_test.exs defmodule CaseTest test \"at the top level, outside any describe\"",
+            tree.at("defmodule DefinedInsideATest")?.presentation?.locationString
+        )
+
+        assertEquals(
+            "and the `test` node itself is qualified by the module",
+            "/src/case_test.exs defmodule CaseTest",
+            tree.at("test \"at the top level, outside any describe\"")?.presentation?.locationString
+        )
+    }
+
+    /** `test` is arity 1..3, so a message-less one has no argument to put in the label. */
+    fun testAMessageLessTestIsLabelledWithoutANullMessage() {
+        val tree = build()
+
+        assertNotNull(
+            "a message-less `test` must still get a node; built nodes were ${tree.byLabel.keys}",
+            tree.at("test")
+        )
+        assertInstanceOf(tree.at("test"), TestElement::class.java)
+        assertTrue(
+            "no node may be labelled with an interpolated null; built nodes were ${tree.byLabel.keys}",
+            tree.byLabel.keys.none { it.contains("null") }
+        )
+    }
+
+    /** Each of these builds an element that casts its parent's presentation to `Parent` unguarded. */
+    fun testDeclarationsInsideADescribeBuildTheirOwnNodes() {
+        val tree = build()
+
+        // Scoped to the describe's subtree, not the file: a module-level `defstruct` added later for
+        // something else would otherwise keep this green.
+        val describe = tree.at("describe \"a describe block\"")
+        assertNotNull("the describe node must exist for this to assert anything", describe)
+
+        val built = mutableSetOf<Class<*>>()
+
+        fun collect(element: StructureViewTreeElement) {
+            built.add(element.javaClass)
+
+            for (child in element.children) {
+                if (child is StructureViewTreeElement) {
+                    collect(child)
+                }
+            }
+        }
+
+        for (child in describe!!.children) {
+            if (child is StructureViewTreeElement) {
+                collect(child)
+            }
+        }
+
+        for (element in listOf(Structure::class.java, Type::class.java, Callback::class.java, Delegation::class.java)) {
+            assertTrue(
+                "`${element.simpleName}` must be built inside a `describe`, or its unguarded `as Parent` " +
+                    "cast goes unreached; built element classes were ${built.map { it.simpleName }}",
+                element in built
+            )
+        }
+
+        // The struct is compiled onto the case module, so it is named after it and not after the
+        // `describe` it is written in.
+        assertEquals(
+            "%CaseTest{}",
+            describe.children.filterIsInstance<Structure>().single().presentation.presentableText
+        )
+
+        // By node, not class: `Callback.getChildren()` supplies the class regardless of the `@spec`.
+        assertNotNull(
+            "the `@spec` inside the `describe` must build its own node; built nodes were ${tree.byLabel.keys}",
+            tree.at("a_spec/0")
+        )
+    }
+
+    /**
+     * A `test` walks its body as a `def` clause does, so an unmodelled call builds nothing rather than
+     * an [Unknown]. Its `for` and `case` are claimed by `unknown` in the modular dispatch and never
+     * reach this walk.
+     */
+    fun testATestShowsNoNodeForItsControlFlow() {
+        val tree = build()
+
+        val test = tree.at("test \"at the top level, outside any describe\"")
+        assertNotNull("the top-level test node must exist for this to assert anything", test)
+
+        val unmodelled = test!!.children
+            .filterIsInstance<Unknown>()
+            .map { it.presentation.presentableText }
+
+        assertEquals("a test's control flow must build no node", emptyList<String?>(), unmodelled)
+
+        assertNotNull(
+            "but its declarations must survive; built nodes were ${tree.byLabel.keys}",
+            tree.at("defmodule DefinedInsideATest")
+        )
+    }
+
+    /** No `do` block, so `Unknown.is` is false and nothing else matches it either. */
+    fun testABodyLessTestIsStillBuilt() {
+        val tree = build()
+
+        val element = tree.at("test \"not implemented yet\"")
+
+        assertNotNull(
+            "a `test` with no do block must still get a node; built nodes were ${tree.byLabel.keys}",
+            element
+        )
+        assertInstanceOf(element, TestElement::class.java)
+    }
+
+    /**
+     * `CallDefinitionHead.is` is `call is UnqualifiedParenthesesCall<*>`, which this call satisfies, and
+     * its entry sits above `unknown` carrying no handler. Without the filter `build` selects it and
+     * throws on `entry.handle!!`.
+     */
+    fun testAHandlerLessEntryDoesNotSwallowACallAWiderEntryBuilds() {
+        val tree = build()
+
+        val call = PsiTreeUtil
+            .findChildrenOfType(myFixture.file, Call::class.java)
+            .firstOrNull { it.functionName() == "unrecognised_macro" }
+
+        assertNotNull("the fixture must contain the call or this test proves nothing", call)
+
+        // Control: without it this asserts only that some unremarkable call built an `Unknown`.
+        assertTrue(
+            "the handler-less entry's predicate must actually match the fixture call",
+            ChildCall.ENTRIES.single { it.name == "call definition head" }.matches(call!!, ResolveState.initial())
+        )
+
+        assertNotNull(
+            "an unqualified parenthesised call with a do block must still reach `unknown`; built nodes " +
+                "were ${tree.byLabel.keys}",
+            tree.at("unrecognised_macro")
+        )
+    }
+
+    /** [Model.isSuitable] consulting the flag, rather than `ChildCallTest` reading it off the table. */
+    fun testAnOrIsNotACaretSyncTarget() {
+        val tree = build()
+
+        val or = PsiTreeUtil
+            .findChildrenOfType(myFixture.file, Or::class.java)
+            .firstOrNull { it.parent is org.elixir_lang.psi.ElixirStabBody }
+            ?: PsiTreeUtil.findChildrenOfType(myFixture.file, Or::class.java).firstOrNull()
+
+        assertNotNull("the fixture must contain an `or` or this test proves nothing", or)
+
+        val call = or as Call
+
+        // Control: nothing else matches a bare `or`, so the negatives below would pass without it.
+        assertTrue(
+            "the `or` entry's predicate must actually match an `or`",
+            ChildCall.ENTRIES.single { it.name == "or" }.matches(call, ResolveState.initial())
+        )
+
+        assertFalse(
+            "an `or` is unwrapped by the dispatch, so the caret must not sync to it",
+            Model.isSuitable(call)
+        )
+        assertFalse("and it must build no node of its own", call in tree.values)
+    }
+
+    /**
+     * Both directions, and by node kind: drop the `ex_unit test` entry and a `test` is still claimed and
+     * still gets a node, because `unknown` matches it and carries the same call as its value.
+     */
+    fun testCaretSyncTargetsInACaseAreTheNodesTheTreeBuilt() {
+        val tree = build()
+
+        val caseChildren = PsiTreeUtil
+            .findChildrenOfType(myFixture.file, Call::class.java)
+            .filter { call -> Case.isChild(call, ResolveState.initial()) }
+
+        assertFalse(
+            "the fixture must contain ExUnit.Case children or this test proves nothing",
+            caseChildren.isEmpty()
+        )
+
+        val unclaimed = caseChildren.filterNot { call -> Model.isSuitable(call) }.map { it.text.lineSequence().first() }
+        assertEquals("Model.isSuitable must claim every ExUnit.Case child", emptyList<String>(), unclaimed)
+
+        val unbuilt = caseChildren.filterNot { call -> call in tree.values }.map { it.text.lineSequence().first() }
+        assertEquals("the tree must build a node for every call isSuitable claims", emptyList<String>(), unbuilt)
+
+        val wrongType = caseChildren
+            .filterNot { call -> tree.elementByValue[call].let { it is TestElement || it is DescribeElement } }
+            .map { it.text.lineSequence().first() }
+        assertEquals(
+            "an ExUnit.Case child must build its own node kind, not fall through to Unknown",
+            emptyList<String>(),
+            wrongType
+        )
+    }
+}


### PR DESCRIPTION
## Summary

The structure view kept the same list twice. `Module#childCallTreeElements` dispatched over 18 predicates to build a node; `Model.isSuitable` re-listed 16 of them as an `||` chain to decide what the caret can sync to, plus `CallDefinitionHead`, which was never a dispatch arm. The two agreed until `0996878b2` widened one side and not the other — it replaced `kase.Describe.is` with `Case.isChild`, which matches `describe` and `test`, in `Model` alone, while the dispatch's arm became `Case.isDescribe`. A `test` outside a `describe` has fallen to the `unknown` catch-all ever since — taking the message as its label and the wrong icon — and a body-less one has had no node at all, since `Unknown.is` is `hasDoBlockOrKeyword()`.

Both now derive from one ordered list, `structure_view/ChildCall`. An entry carries a handler rather than a constructor, because the dispatch is not a map from call to node: five entries fold a call into a `FunctionByNameArity`/`MacroByNameArity`, two also add to a set the caller post-processes afterwards, and `Or` adds no node at all and re-queues its operands. The two places the consumers genuinely differ are now flags on an entry rather than an invisible gap between two lists — `or` is dispatched but is not a caret target, and `call definition head` is a caret target built as a child of a `CallDefinition`.

## Fixed

- A `test` written outside a `describe` gets its own node, with the test name and icon, instead of falling to the `Unknown` catch-all.
- An `EEx.function_from_*` node follows the caret. It was in the dispatch and absent from `Model.isSuitable`, so it had a node caret sync would not select.
- Two crashes, both reachable and neither previously reported. Answering `isSuitable` from a bare `ResolveState` reached a null `ENTRANCE` in `qualifierIsBeingResolved`, which threw rather than answering — moving the caret into a qualified `EEx.function_from_file(...)` raised `NullPointerException: get(...) must not be null`. `psi/scope/Module.executeOnModular` dereferenced the same key unguarded. Both now treat a missing entrance as "nothing to compare against".
- The two crashing `TODO()` defaults named under "Related, and small" in #4056, in `structure_view/element/Type.kt` and `structure_view/element/Callback.kt`. Each dispatched over a module attribute name held as a `String`, so the `when` could never be exhaustive and had to end somewhere. Both sets are closed, so each gains a `Kind` enum: the attribute is classified once at recognition, and visibility, opaqueness and time are exhaustive `when`s over it. A fourth attribute is now a compile error — `'when' expression must be exhaustive` — rather than a crash reached at runtime, which is what #3985 asks for. `ChooseByNameContributor` built a `Callback` without classifying and re-read the attribute afterwards; it classifies once and passes the result.

- A struct's label. `Structure` named it by splitting its parent's *display* string on the last `.`, so the result depended on where that `.` fell — right for a dotted module name at module level, `%ex defmodule Foo{}` for an undotted one, and `%CaseTest describe "..."{}` once a `describe` walks its body like a module and a `defstruct` can be written in one. It now splits the enclosing `defmodule`'s own name, which is the module a `defstruct` is compiled onto however it is nested. Filed as #4069 while this was in review, and fixed here because this change adds the third case rather than merely exposing the first two.

## A `describe` is a module and a `test` is a function

Not by analogy — by expansion. `ExUnit.Case.test/3` builds `{:def, [], [{{:unquote, [], [name]}, [], [var]}, [do: contents]]}`, so the test's block is the body of a generated `def`. `describe/2` evaluates `unquote(block)` in the module body, so what a `describe` declares is compiled onto the case module: `defdelegate my_flatten(list), to: List` inside a `describe` really does define `my_flatten/1` on the test module.

So a `test` shows what a `def` clause shows, and a `describe` shows what a `defmodule` shows. The `def` list moves out of `CallDefinitionClause` into `Body` and both use it; `Describe` loses its bespoke walk entirely, because this dispatch's `ex_unit test` entry already builds the tests a describe contains. Neither gets a list of its own.

Two consequences fall out rather than being arranged: a `test` nested in a `describe` is qualified by the describe, and a `setup` gets an `Unknown` node where it had none.

## How a `defimpl` node is named

`defimpl P, for: T` compiles to a module named `P.T` — `Protocol.__concat__` in `lib/elixir/lib/protocol.ex`. The node could therefore present that generated name split the way every other node is, giving `Bar` under `Enumerable.Foo` for `for: Foo.Bar`. It presents the protocol and the type instead, so that both halves always name a module someone wrote: `P.Foo` is a prefix of a generated name that nobody defined.

Nothing chose that before this PR. `getLocationString()` and `getPresentableText()` split `forName` with `String.split(".")`, whose argument is a regex — `.` matches everything, the array was always empty, and both branches consuming it were unreachable. The rendering was what a broken split happened to produce; it is now what the code says.

## Scope

This is a modular's children reached from this dispatch. Two other chains build tree nodes and neither is driven from it: `File` for a file's top-level nodes, and `Body` for what a `def` clause or a `test` declares. So "one list" is a claim about this dispatch, not about the tree.

## Tests

`ChildCallTest` holds the table's invariants with no fixture: membership and order in full, the catch-all stays last, names unique, no inert entry, and — the one that matters — exactly two named entries may differ between the two consumers. A third means they have drifted apart again.

`CaseNodeTest` and `EExFunctionFromNodeTest` cover behaviour through the real `Model`: node identity and kind, that every call `isSuitable` claims is one the tree built, that a `test`'s control flow builds nothing while its declarations survive, and that the caret path does not throw. `KindTest` pins the attribute mappings.

`testDeclarationsInsideADescribeBuildTheirOwnNodes` and `testATestShowsNoNodeForItsControlFlow` were mutation-checked after the `Test`/`Describe` rewrite — the production line each names was broken, the failure message read, and the change reverted. The rest were mutation-checked before that rewrite and not re-run since.

## Verified in a real IDE — against a superseded implementation

An earlier revision was run against a real Phoenix project, not only fixtures: a top-level `test` rendered with the test icon where it previously fell to `Unknown`, a body-less `test` got a node where it previously got none, and a `test`'s declarations kept the enclosing module in their location.

That revision made `test` a modular and filtered `Unknown` out of its children. The current one walks a `test` as a `def` clause and a `describe` as a module, which changes what a nested test shows as its location and what a `describe` body renders. **The current implementation has not been re-checked in a running IDE**; the claims above hold for fixtures and the test suite, not for a fresh visual pass.

## Left open

- `HEEx.isFunctionFrom` exists but is referenced nowhere under `structure_view/`, so a HEEx `function_from_*` call gets no dedicated node and is not a caret target. Adding it needs a tree element that does not exist yet, so it is not an entry here — unlike `EEx`, which is.
- `Unknown` labels a node with the call's first argument, so `for n <- 1..3` reads `n <- 1..3`. Not ExUnit-specific and not introduced here — it happens in any module and at the top level of any script on `main` today.
- `setup` inside a `describe` now gets a node, but an `Unknown` one labelled `setup` rather than a dedicated node. Visible instead of absent; not fixed.

## What changes on screen

Both pairs are the Structure tool window, expanded, on the same file. Before is `main` (`bdff12642`); after is this branch.

**A struct and an exception are named after their module.** Look at the four node labels and the grey qualifier beside each - `%ex defmodule Wallet{}` and `ex defmodule InsufficientFunds` are the file extension leaking into the name.

Before (`main`):

<img width="715" height="559" alt="image" src="https://github.com/user-attachments/assets/4edeae57-40fd-49ff-b213-eda9c9f70ada" />

After (this PR):

<img width="568" height="538" alt="image" src="https://github.com/user-attachments/assets/173db600-bc3e-45ff-821f-30d5a68971c0" />

**ExUnit.** Look at four things: what the `describe` contains, whether the top-level `test` has a test icon, whether its body shows `n <- 1..3` and `:ok`, and whether the pending `test` has a node at all.

Before (`main`):

<img width="1368" height="374" alt="image" src="https://github.com/user-attachments/assets/eaeef60f-a3b5-41bb-808d-839021241d8d" />

After (this PR):

<img width="1419" height="565" alt="image" src="https://github.com/user-attachments/assets/585a5112-8312-4f11-9e95-ec928919c32d" />

Fixes #4056.
Fixes #4069.
Refs #4053, #3985.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
