### PR TITLE
build(quoter): build and call quoter v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,11 @@
 
 ### Build / CI
 
+- [#4083](https://github.com/KronicDeth/intellij-elixir/pull/4083) [@sh41](https://github.com/sh41)
+  - **The tests quote with quoter
+    [v3.0.0](https://github.com/intellij-elixir/intellij-elixir-quoter/tree/v3.0.0) from
+    [intellij-elixir/intellij-elixir-quoter](https://github.com/intellij-elixir/intellij-elixir-quoter).**
+
 - [#4006](https://github.com/KronicDeth/intellij-elixir/pull/4006) [@sh41](https://github.com/sh41)
   - **CI is faster: Gradle's build and configuration caches are kept, Elixir is no longer rebuilt from
     source on the Windows leg, and the runners no longer reclaim disk space they were not short of.**
@@ -406,9 +411,6 @@
   - **CI gets the quoter cache paths from the build** (a `quoterCachePaths` task) instead of
     re-deriving them in bash, so the workflow can no longer disagree with Gradle about where the
     cache lives.
-  - **The quoter is pinned to a commit of `sh41/intellij_elixir` which can be built without warnings
-    on all Elixir versions 1.13-1.20**, pending merge/tagging of the
-    [PR](https://github.com/KronicDeth/intellij_elixir/pull/11).
   - **The quoter builds with an explicit `MIX_ENV=prod`**, and only prod dependencies are fetched. An exported `MIX_ENV` still overrides it.
 
 - [#3914](https://github.com/KronicDeth/intellij-elixir/pull/3914) [@sh41](https://github.com/sh41)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -343,7 +343,7 @@ To stop at the quoter instead, which is what you want when debugging the quoter 
 ```
 
 The quoter is built with `MIX_ENV=prod`, so its release lands in
-`cache/<pair>-intellij_elixir-<ref>/_build/prod/rel/intellij_elixir`. The environment is set by the
+`cache/<pair>-quoter-<ref>/_build/prod/rel/quoter`. The environment is set by the
 build rather than left to `mix release`, which has no preferred environment and assembles under `:dev`
 when `MIX_ENV` is unset - compiling the quoter's dev/test-only dependencies, none of which the daemon
 needs at runtime. Exporting `MIX_ENV` overrides this, and the path the build looks in follows the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,8 +109,8 @@ val expectedVersionSource: String =
 // with instructions before anything writes to that path.
 val elixirVersion: String = versionWithoutBuildTag(expectedElixirVersion.getOrElse("unresolved"))
 
-val quoterRepo = providers.gradleProperty("quoterRepo").getOrElse("KronicDeth/intellij_elixir")
-val quoterRef = providers.gradleProperty("quoterRef").getOrElse("v2.1.0")
+val quoterRepo = providers.gradleProperty("quoterRepo").getOrElse("intellij-elixir/intellij-elixir-quoter")
+val quoterRef = providers.gradleProperty("quoterRef").getOrElse("v3.0.0")
 // Cache namespace for the quoter, derived from the ref ('/' is illegal in a path segment). Keeps
 // each repo/ref's downloaded zip, build dir, and daemon tmp dir separate, so switching source
 // never reuses another's artifacts.
@@ -168,12 +168,12 @@ val javaVersionStr: String = if (platformBuildNumber >= 262) "25" else libs.vers
 val cachePath: Directory = layout.projectDirectory.dir("cache")
 val elixirPath: Directory = cachePath.dir("elixir-$elixirVersion")
 // Keyed on the Elixir/OTP PAIR, via the same rule as MIX_HOME/MIX_ARCHIVES below. `_build` and `deps`
-// hold BEAM code and a distillery release, so the reason MIX_ARCHIVES is pair-keyed - the loader
+// hold BEAM code and a release, so the reason MIX_ARCHIVES is pair-keyed - the loader
 // rejects a chunk layout built by a different OTP - applies here unchanged. Keyed on Elixir alone,
 // 1.13.4/24.3.4.6 and 1.13.4/25.3.2.21 shared one tree and overwrote each other's build, while their
 // hex/rebar sat in correctly separated pair directories.
 val quoterUnzippedPath: Directory =
-    cachePath.dir("${pairToken(elixirVersion, expectedOtpVersion.getOrElse("unresolved"))}-intellij_elixir-$quoterRefSlug")
+    cachePath.dir("${pairToken(elixirVersion, expectedOtpVersion.getOrElse("unresolved"))}-quoter-$quoterRefSlug")
 // MIX_ENV for both quoter mix tasks AND the launcher path below - one value, so the directory the build
 // looks in is the one mix wrote. Read through `providers` rather than System.getenv so the
 // configuration cache treats it as an input and re-resolves when it changes. Defaults to prod; see
@@ -192,14 +192,13 @@ val quoterRequired: Boolean = providers.gradleProperty("quoterRequired").getOrEl
 val quoterTmpPath: Directory = cachePath.dir("quoter_tmp_$quoterRefSlug")
 // Distributed Erlang node names for the quoter daemon and for the test JVM that talks to it. Erlang
 // registers a node by name with the machine-wide epmd, and epmd allows exactly one node per name - so
-// with a fixed name a second checkout starting its own quoter gets "the name intellij_elixir@127.0.0.1
+// with a fixed name a second checkout starting its own quoter gets "the name quoter@127.0.0.1
 // seems to be in use by another Erlang node" and exits 0, which `startQuoter` reports as the daemon
 // dying immediately. Deriving both names from the checkout path lets worktrees run tests concurrently.
-// Unset (a plain `java -jar` of the plugin, or any non-test use) the plugin falls back to the original
-// literals, so nothing outside the build changes.
+// Unset (a plain `java -jar` of the plugin, or any non-test use) the plugin falls back to fixed names.
 val quoterNodeToken: String = rootDir.absolutePath.lowercase().hashCode().toUInt().toString(16)
-val quoterNodeName: String = "intellij_elixir_$quoterNodeToken@127.0.0.1"
-val quoterClientNodeName: String = "intellij_elixir_client_$quoterNodeToken@127.0.0.1"
+val quoterNodeName: String = "quoter_$quoterNodeToken@127.0.0.1"
+val quoterClientNodeName: String = "quoter_client_$quoterNodeToken@127.0.0.1"
 // hex/rebar + fetched deps are cached under the project (used by the quoter mix build).
 val mixHomePath: Directory = cachePath.dir("mix_home")
 val mixArchivesPath: Directory = cachePath.dir("mix_archives")
@@ -826,7 +825,7 @@ runIdePlatformsList.forEach { platform ->
 val getQuoter = tasks.register<Download>("getQuoter") {
     description = "Downloads the Quoter tool"
     src("https://github.com/$quoterRepo/archive/$quoterRef.zip")
-    dest(cachePath.file("intellij_elixir-$quoterRefSlug.zip"))
+    dest(cachePath.file("quoter-$quoterRefSlug.zip"))
     overwrite(false)
 }
 
@@ -890,7 +889,8 @@ val releaseQuoter = tasks.register<ReleaseQuoterTask>("releaseQuoter") {
         quoterUnzippedPath.file("mix.lock")
     ).withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir(quoterUnzippedPath.dir("lib")).withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.dir(quoterUnzippedPath.dir("config")).withPathSensitivity(PathSensitivity.RELATIVE)
+    // A file tree rather than inputs.dir, which fails validation when the quoter has no config/.
+    inputs.files(quoterUnzippedPath.dir("config").asFileTree).withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir(quoterUnzippedPath.dir("deps")).withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
@@ -926,8 +926,6 @@ tasks.register<QuoterCachePathsTask>("quoterCachePaths") {
                 .joinToString("/"),
             // Sockets, not build output - actions/cache cannot archive them.
             "!cache/**/tmp/pipe/**",
-            // Only present while quoterRef points at a Distillery-era quoter (v2.1.0 and earlier).
-            "!cache/**/distillery/priv",
         )
     )
 }

--- a/buildSrc/src/main/kotlin/platform/windows/WindowsQuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/platform/windows/WindowsQuoterPlatform.kt
@@ -32,7 +32,7 @@ class WindowsQuoterPlatform(private val startEpmd: Boolean = true) : QuoterPlatf
 
     /**
      * Cleans stdout by removing any lines that also appear in stderr.
-     * This handles Erlang/distillery releases writing warnings to both streams.
+     * This handles Erlang releases writing warnings to both streams.
      *
      * @param stdout The standard output stream content
      * @param stderr The standard error stream content

--- a/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
+++ b/buildSrc/src/main/kotlin/quoter/QuoterPlatform.kt
@@ -79,11 +79,8 @@ fun createQuoterPlatform(platform: Platform, startEpmd: Boolean = true): QuoterP
     }
 }
 
-/**
- * The node name used when no per-checkout name is supplied - the value this was hardcoded to before
- * the name became configurable, so a caller that does not pass one behaves exactly as before.
- */
-const val DEFAULT_QUOTER_NODE_NAME = "intellij_elixir@127.0.0.1"
+/** The node name used when no per-checkout name is supplied. */
+const val DEFAULT_QUOTER_NODE_NAME = "quoter@127.0.0.1"
 
 /** The only interface the quoter's distribution and epmd ever need; see [Epmd] and [getReleaseEnvironment]. */
 const val LOOPBACK_ADDRESS = "127.0.0.1"
@@ -108,7 +105,8 @@ fun getReleaseEnvironment(
     startEpmd: Boolean = true
 ): Map<String, String> {
     return buildMap {
-        put("RELEASE_COOKIE", "intellij_elixir")
+        // Must match the cookie in org.elixir_lang.IntellijElixir, the test JVM's side of the connection.
+        put("RELEASE_COOKIE", "intellij-elixir-quoter")
         put("RELEASE_DISTRIBUTION", "name")
         put("RELEASE_NAME", releaseName)
         releaseTmp?.let { put("RELEASE_TMP", it.absolutePath) }

--- a/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
+++ b/buildSrc/src/main/kotlin/sdk/MixEnvironment.kt
@@ -69,7 +69,7 @@ fun resolveMixEnv(ambient: String?): String =
  * environment segment - see that function.
  */
 fun quoterReleaseExecutablePath(mixEnv: String): String =
-    "_build/$mixEnv/rel/intellij_elixir/bin/intellij_elixir"
+    "_build/$mixEnv/rel/quoter/bin/quoter"
 
 /**
  * Full environment for `mix` commands: the Erlang runtime environment, MIX_HOME/MIX_ARCHIVES so

--- a/gradle.properties
+++ b/gradle.properties
@@ -78,24 +78,18 @@ pluginVerifierChannels=RELEASE,EAP,RC,PREVIEW
 # The Elixir/Erlang the build targets are NOT declared here - mise.toml is the pin, and the build asks
 # mise for the effective version. Override per-invocation with -PelixirVersion / -PotpVersion.
 
-# Quoter source (the intellij_elixir project compiled/run to produce reference ASTs).
-# quoterRepo: GitHub <owner>/<repo>. quoterRef: a commit SHA, a tag (e.g. v2.1.0) or a branch archive
+# Quoter source (https://github.com/intellij-elixir/intellij-elixir-quoter, compiled/run to produce
+# reference ASTs). The build expects a v3 quoter: the `quoter` release built by `mix release`.
+# quoterRepo: GitHub <owner>/<repo>. quoterRef: a commit SHA, a tag (e.g. v3.0.0) or a branch archive
 # ref (e.g. refs/heads/my-branch) - anything https://github.com/<repo>/archive/<ref>.zip serves.
 # Override to test a fork/branch, e.g.:
 #   -PquoterRepo=sh41/intellij_elixir -PquoterRef=refs/heads/my-branch
 # The download/build cache is namespaced by a slug of quoterRef (slashes -> dashes), so switching
 # repo/ref fetches and builds into its own cache dir automatically. Prefer a full SHA over a branch
 # ref: a moving branch keeps the same slug, so the cached zip is reused and new commits are never
-# fetched until cache/intellij_elixir-<slug>.zip is deleted by hand.
-#
-# Pinned to sh41's fork rather than a KronicDeth tag because v2.1.0 predates `mix release` - it carries
-# a Distillery rel/config.exs and no `releases:` in mix.exs - and still uses `use Mix.Config` and
-# Supervisor.Spec, so it warns on every Elixir the pipeline tests. This SHA is the same quoter with the
-# build modernised; the quoting behaviour it reports is unchanged.
-quoterRepo=sh41/intellij_elixir
-quoterRef=44b95390967b2b8db51322412b7dcbfc434d0a9b
-#quoterRepo=KronicDeth/intellij_elixir
-#quoterRef=v2.1.0
+# fetched until cache/quoter-<slug>.zip is deleted by hand.
+quoterRepo=intellij-elixir/intellij-elixir-quoter
+quoterRef=v3.0.0
 
 # Plugins which will run ONLY when running `runIde` tasks, not for testing/release.
 #

--- a/src/org/elixir_lang/IntellijElixir.java
+++ b/src/org/elixir_lang/IntellijElixir.java
@@ -15,17 +15,18 @@ public class IntellijElixir {
      * machine-wide epmd, which allows one node per name. With the names fixed, two checkouts running
      * tests at once collide: the second quoter exits with "the name ... seems to be in use by another
      * Erlang node", and so would the second test JVM's own node. The build sets these per checkout;
-     * unset, both fall back to the literals used before they were configurable.
+     * unset, both fall back to fixed names.
      */
     public static final String REMOTE_NODE =
-            System.getProperty("elixir.quoter.remoteNode", "intellij_elixir@127.0.0.1");
+            System.getProperty("elixir.quoter.remoteNode", "quoter@127.0.0.1");
 
     private static final String LOCAL_NODE =
-            System.getProperty("elixir.quoter.localNode", "intellij-elixir@127.0.0.1");
+            System.getProperty("elixir.quoter.localNode", "quoter_client@127.0.0.1");
 
+    // Must match RELEASE_COOKIE in buildSrc's QuoterPlatform.kt.
     public static OtpNode getLocalNode() throws IOException {
         if (localNode == null) {
-            localNode = new OtpNode(LOCAL_NODE, "intellij_elixir", LoopbackTransportFactory.INSTANCE);
+            localNode = new OtpNode(LOCAL_NODE, "intellij-elixir-quoter", LoopbackTransportFactory.INSTANCE);
         }
 
         return localNode;

--- a/testUI/kotlin/org/elixir_lang/ui/framework/core/ProjectOperations.kt
+++ b/testUI/kotlin/org/elixir_lang/ui/framework/core/ProjectOperations.kt
@@ -19,7 +19,7 @@ import com.intellij.driver.sdk.ui.components.elements.dialog
  *
  * This removes:
  * - .idea directory (contains project settings, workspace, etc.)
- * - intellij_elixir.iml (module file for the Elixir plugin)
+ * - quoter.iml (module file for the quoter project the tests open)
  * - deps directory (Mix dependencies)
  * - _build directory (Mix build artifacts)
  *
@@ -31,7 +31,7 @@ import com.intellij.driver.sdk.ui.components.elements.dialog
 private fun cleanIdeaFiles(projectPath: String) {
     step("Clean existing IntelliJ configuration and Mix build files") {
         val projectDir = java.io.File(projectPath)
-        val pathsToClean = listOf(".idea", "intellij_elixir.iml", "deps", "_build", "out")
+        val pathsToClean = listOf(".idea", "quoter.iml", "deps", "_build", "out")
 
         pathsToClean.forEach { path ->
             val file = java.io.File(projectDir, path)

--- a/tests/org/elixir_lang/intellij_elixir/Quoter.kt
+++ b/tests/org/elixir_lang/intellij_elixir/Quoter.kt
@@ -121,7 +121,7 @@ object Quoter {
                 val tokenBinary = error.elementAt(2) as OtpErlangBinary
                 val token = ElixirPsiImplUtil.javaString(tokenBinary)
                 throw AssertionError(
-                    "intellij_elixir returned \"$message\" $location due to $token, use assertQuotesAroundError if error is expect in Elixir natively, but not in intellij-elixir plugin"
+                    "quoter returned \"$message\" $location due to $token, use assertQuotesAroundError if error is expect in Elixir natively, but not in intellij-elixir plugin"
                 )
             }
         } catch (e: IOException) {

--- a/tests/org/elixir_lang/quoter/PipeLocationTest.kt
+++ b/tests/org/elixir_lang/quoter/PipeLocationTest.kt
@@ -17,7 +17,7 @@ class PipeLocationTest : PlatformTestCase() {
 
         // Find any _build directories in cache
         val buildDirs = cacheDir.listFiles { file ->
-            file.isDirectory && file.name.contains("intellij_elixir")
+            file.isDirectory && file.name.contains("-quoter-")
         }?.flatMap { quoterDir ->
             File(quoterDir, "_build").walkTopDown()
                 .filter { it.name == "pipe" && it.isDirectory }


### PR DESCRIPTION
The quoter moved to [intellij-elixir/intellij-elixir-quoter](https://github.com/intellij-elixir/intellij-elixir-quoter) and is now tagged [v3.0.0](https://github.com/intellij-elixir/intellij-elixir-quoter/tree/v3.0.0). v3 renames the application and release from `intellij_elixir` to `quoter` and removes `config/`, which breaks this build in two places.

- **Launcher path:** the build now looks for `_build/<env>/rel/quoter/bin/quoter`.
- **`releaseQuoter` input:** the declared `config/` input directory failed Gradle's validation, which failed the whole build rather than marking the quoter unavailable. It is now a file tree, which tolerates a missing directory.

The build's own names follow the rename:
- Cache tree `cache/<pair>-quoter-<ref>` and zip `cache/quoter-<ref>.zip`.
- Node names `quoter_<token>@127.0.0.1` and `quoter_client_<token>@127.0.0.1`.
- Cookie `intellij-elixir-quoter`, set in both `QuoterPlatform.kt` and `IntellijElixir.java`.
- The testUI cleanup now removes `quoter.iml`.

The pin in `gradle.properties` and the `build.gradle.kts` defaults are `intellij-elixir/intellij-elixir-quoter` / `v3.0.0`. The leftover Distillery references are gone too.

## Verification

- **Before the change:** with only the pin updated, `:releaseQuoter` failed with "Input file does not exist … `config` which doesn't exist".
- **Pre-release CI:** before the tag existed, this PR was pinned to the head of [intellij-elixir-quoter#12](https://github.com/intellij-elixir/intellij-elixir-quoter/pull/12) on the fork (`sh41/intellij_elixir@0b3fccc`). Every CI leg passed against it, including all Elixir/OTP pairs from 1.13.4 to 1.20.2 and the Windows leg. `v3.0.0` is #12's merge commit, and its tree is identical to `0b3fccc`.
- **Locally against the tag:** on Windows with Elixir 1.13.4 / OTP 24.3.4.6, the build downloads `v3.0.0`, the daemon starts from `rel\quoter\bin\quoter` as `quoter_<token>@127.0.0.1`, and `PipeLocationTest` plus `MatchedDotOperationParsingTestCase` pass (28 tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
